### PR TITLE
Force ssl on staging and prod, also add sidekiq service

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -36,6 +36,53 @@ spec:
         ports:
         - containerPort: 8080
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: exchange-sidekiq
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: exchange
+        layer: application
+        component: sidekiq
+      name: exchange-sidekiq
+      namespace: default
+    spec:
+      containers:
+        - name: exchange-sidekiq
+          envFrom:
+          - configMapRef:
+              name: exchange-environment
+          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:production
+          imagePullPolicy: Always
+          command: ["bundle", "exec", "sidekiq"]
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - -f
+              - sidekiq
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - background
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,10 +92,22 @@ metadata:
     layer: application
   name: exchange-web
   namespace: default
+  service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard"
+  service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+  service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+  service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+  service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+  service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
 spec:
   ports:
+  ports:
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 8080
   - port: 80
     protocol: TCP
+    name: http
     targetPort: 8080
   selector:
     app: exchange

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -36,6 +36,53 @@ spec:
         ports:
         - containerPort: 8080
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: exchange-sidekiq
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: exchange
+        layer: application
+        component: sidekiq
+      name: exchange-sidekiq
+      namespace: default
+    spec:
+      containers:
+        - name: exchange-sidekiq
+          envFrom:
+          - configMapRef:
+              name: exchange-environment
+          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:staging
+          imagePullPolicy: Always
+          command: ["bundle", "exec", "sidekiq"]
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - -f
+              - sidekiq
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - background
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,10 +92,22 @@ metadata:
     layer: application
   name: exchange-web
   namespace: default
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
 spec:
   ports:
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 8080
   - port: 80
     protocol: TCP
+    name: http
     targetPort: 8080
   selector:
     app: exchange


### PR DESCRIPTION
# Changes
- `force_ssl` on staging and production.
- Add SSL support to k8s setting.
- Add sidekiq service

https://artsyproduct.atlassian.net/browse/CP-58
