### PR TITLE
Fix Sidekiq restart issue

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,2 +1,3 @@
 ---
 project-name: exchange
+pre-deploy: 'bundle exec rake db:migrate'

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -64,14 +64,6 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:production
           imagePullPolicy: Always
           command: ["bundle", "exec", "sidekiq"]
-          livenessProbe:
-            exec:
-              command:
-              - pgrep
-              - -f
-              - sidekiq
-            initialDelaySeconds: 5
-            periodSeconds: 5
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -64,14 +64,6 @@ spec:
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:staging
           imagePullPolicy: Always
           command: ["bundle", "exec", "sidekiq"]
-          livenessProbe:
-            exec:
-              command:
-              - pgrep
-              - -f
-              - sidekiq
-            initialDelaySeconds: 5
-            periodSeconds: 5
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
# Problem
We noticed Sidekiq on k8s was in crashloop and wasn't starting with following error:
```
2018-06-21T10:28:45.976Z 1 TID-gov2ckjxt INFO: Running in ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
2018-06-21T10:28:45.976Z 1 TID-gov2ckjxt INFO: See LICENSE and the LGPL-3.0 for licensing details.
2018-06-21T10:28:45.976Z 1 TID-gov2ckjxt INFO: Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org
2018-06-21T10:28:45.977Z 1 TID-gov2ckjxt INFO: Booting Sidekiq 5.1.3 with redis options {:id=>"Sidekiq-server-PID-1", :url=>"redis://staging-shared.uvuuuk.0001.use1.cache.amazonaws.com/7"}
2018-06-21T10:28:45.981Z 1 TID-gov2ckjxt INFO: Starting processing, hit Ctrl-C to stop
2018-06-21T10:28:50.934Z 1 TID-gov2ckjxt INFO: Shutting down
2018-06-21T10:28:50.934Z 1 TID-gov2ckjxt INFO: Terminating quiet workers
2018-06-21T10:28:50.934Z 1 TID-gov2sdqal INFO: Scheduler exiting...
2018-06-21T10:28:51.434Z 1 TID-gov2ckjxt INFO: Pausing to allow workers to finish...
2018-06-21T10:28:52.936Z 1 TID-gov2ckjxt INFO: Bye!
```

# Solution(?)
I noticed sidekiq is being restarted since `livenessProbe` was failing. Noticed trying `pgrep` on pods fails:
```
✘  ~/src/exchange   master ●  hokusai staging run "pgrep" --tty
failed to open log file "/var/log/pods/cefb4bf3-755d-11e8-a680-12cd48ef0104/exchange-hokusai-run-ashkinas-wnool_0.log": open /var/log/pods/cefb4bf3-755d-11e8-a680-12cd48ef0104/exchange-hokusai-run-ashkinas-wnool_0.log: no such file or directoryerror: pod default/exchange-hokusai-run-ashkinas-wnool failed with unknown exit code
ERROR: Command 'kubectl --context staging run exchange-hokusai-run-ashkinas-wnool -t -i --image=585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:staging --restart=Never --overrides='{"spec": {"containers": [{"tty": true, "stdin": true, "name": "exchange-hokusai-run-ashkinas-wnool", "envFrom": [{"configMapRef": {"name": "exchange-environment"}}], "image": "585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:staging", "args": ["pgrep"], "stdinOnce": true, "imagePullPolicy": "Always"}]}, "apiVersion": "v1"}' --rm' returned non-zero exit status 1
```

For now I removed `livenessProbe` which has fixed the issue.