### PR TITLE
Use GraphQL enum for order states

### DIFF
--- a/app/graphql/types/order_state_enum.rb
+++ b/app/graphql/types/order_state_enum.rb
@@ -1,0 +1,7 @@
+class Types::OrderStateEnum < Types::BaseEnum
+  value 'PENDING', 'order is still pending submission by collector', value: 'pending'
+  value 'SUBMITTED', 'order is submitted by collector', value: 'submitted'
+  value 'APPROVED', 'order is approved by partner', value: 'approved'
+  value 'REJECTED', 'order is rejected by partner', value: 'rejected'
+  value 'FINALIZED', 'order is finalized by partner', value: 'finalized'
+end

--- a/app/graphql/types/order_state_enum.rb
+++ b/app/graphql/types/order_state_enum.rb
@@ -1,7 +1,7 @@
 class Types::OrderStateEnum < Types::BaseEnum
-  value 'PENDING', 'order is still pending submission by collector', value: 'pending'
-  value 'SUBMITTED', 'order is submitted by collector', value: 'submitted'
-  value 'APPROVED', 'order is approved by partner', value: 'approved'
-  value 'REJECTED', 'order is rejected by partner', value: 'rejected'
-  value 'FINALIZED', 'order is finalized by partner', value: 'finalized'
+  value 'PENDING', 'order is still pending submission by collector', value: Order::PENDING
+  value 'SUBMITTED', 'order is submitted by collector', value: Order::SUBMITTED
+  value 'APPROVED', 'order is approved by partner', value: Order::APPROVED
+  value 'REJECTED', 'order is rejected by partner', value: Order::REJECTED
+  value 'FINALIZED', 'order is finalized by partner', value: Order::FINALIZED
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -6,7 +6,7 @@ class Types::OrderType < Types::BaseObject
   field :code, String, null: false
   field :user_id, String, null: false
   field :partner_id, String, null: false
-  field :state, String, null: false
+  field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
   field :created_at, Types::DateTimeType, null: false
   field :update_at, Types::DateTimeType, null: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,7 @@ class Types::QueryType < Types::BaseObject
     description 'Find list of orders'
     argument :user_id, String, required: false
     argument :partner_id, String, required: false
-    argument :state, String, required: false
+    argument :state, Types::OrderStateEnum, required: false
   end
 
   def order(id:)

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -58,7 +58,7 @@ describe Api::GraphqlController, type: :request do
       it 'approves the order' do
         response = client.execute(mutation, approve_order_input)
         expect(response.data.approve_order.order.id).to eq order.id.to_s
-        expect(response.data.approve_order.order.state).to eq Order::APPROVED
+        expect(response.data.approve_order.order.state).to eq 'APPROVED'
         expect(response.data.approve_order.errors).to match []
         expect(order.reload.state).to eq Order::APPROVED
       end

--- a/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
@@ -58,7 +58,7 @@ describe Api::GraphqlController, type: :request do
       it 'finalizes the order' do
         response = client.execute(mutation, finalize_order_input)
         expect(response.data.finalize_order.order.id).to eq order.id.to_s
-        expect(response.data.finalize_order.order.state).to eq Order::FINALIZED
+        expect(response.data.finalize_order.order.state).to eq 'FINALIZED'
         expect(response.data.finalize_order.errors).to match []
         expect(order.reload.state).to eq Order::FINALIZED
       end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -13,7 +13,7 @@ describe Api::GraphqlController, type: :request do
 
     let(:query) do
       <<-GRAPHQL
-        query($userId: String, $partnerId: String, $state: String) {
+        query($userId: String, $partnerId: String, $state: OrderStateEnum) {
           orders(userId: $userId, partnerId: $partnerId, state: $state) {
             edges{
               node{
@@ -30,7 +30,7 @@ describe Api::GraphqlController, type: :request do
 
     it 'returns error when missing both userId and partnerId' do
       expect do
-        client.execute(query, state: 'pending')
+        client.execute(query, state: 'PENDING')
       end.to raise_error(Graphlient::Errors::ExecutionError, 'orders: requires one of userId or partnerId')
     end
 

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -58,7 +58,7 @@ describe Api::GraphqlController, type: :request do
       it 'rejects the order' do
         response = client.execute(mutation, reject_order_input)
         expect(response.data.reject_order.order.id).to eq order.id.to_s
-        expect(response.data.reject_order.order.state).to eq Order::REJECTED
+        expect(response.data.reject_order.order.state).to eq 'REJECTED'
         expect(response.data.reject_order.errors).to match []
         expect(order.reload.state).to eq Order::REJECTED
       end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -56,7 +56,7 @@ describe Api::GraphqlController, type: :request do
       it 'submits the order' do
         response = client.execute(mutation, submit_order_input)
         expect(response.data.submit_order.order.id).to eq order.id.to_s
-        expect(response.data.submit_order.order.state).to eq Order::SUBMITTED
+        expect(response.data.submit_order.order.state).to eq 'SUBMITTED'
         expect(response.data.submit_order.errors).to match []
         expect(order.reload.credit_card_id).to eq credit_card_id
         expect(order.state).to eq Order::SUBMITTED


### PR DESCRIPTION
# Problem
Currently `state` in our GraphLQ schema is just a good old `String` and doesn't have any validation.

# Solution
Switch to use [GraphQL Enum](http://graphql-ruby.org/type_definitions/enums) for order states.