### PR TITLE
Update README to reflect graphql schema changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ rails db:setup
 $ rails s
 ```
 
+## Did You Change GraphQL Schema?
+Metaphysics is the current consumer of Exchange GraphQL schema and keeps a copy of latest schema in https://github.com/artsy/metaphysics/tree/master/src/data, if you have changed Exchange GraphQL schema, make sure you also update the copy of this schema in Metaphysics. In order to do so follow these steps:
+1) In exchange run
+```shell
+rake graphql:schema:idl
+```
+2) rename `schema.graphql` file generated ☝🏼 to `exchange.graphql`
+```shell
+mv schema.graphql exchange.graphql
+```
+3) copy file above to your local update Metaphysics under `src/data` and make a PR to Metaphysics with this change
+
+
 ## Talking to Exchange 🤑
 In order to talk to Exchange GraphQL endpoint:
 - Copy `.env.example` to `.env`

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -3,5 +3,5 @@ import {danger, warn} from "danger"
 const addedOrModified = danger.git.modified_files.concat(danger.git.created_files)
 const fileInGraphQLFolder = addedOrModified.find(f => f.startsWith("/app/graphql"))
 if (fileInGraphQLFolder) {
-  warn("If you want these changes to be reflected in Metaphysics, you will need to [update the stored schema](https://github.com/artsy/exchange/blob/master/README.md).")
+  warn("If you want these changes to be reflected in Metaphysics, you will need to [update the stored schema](https://github.com/artsy/exchange#did-you-change-graphql-schema?).")
 }


### PR DESCRIPTION
# Problem
With https://github.com/artsy/metaphysics/pull/1120 in the works, we need to make sure everytime we update Exchange's GraphQL schema, we need to update the copy of it stored in Metaphysics.

# Solution
We [already added](#41 ) a danger rule to make sure it warns people if they've changed the schema, here we added some documentation about what needs to be done and updated danger file to point to this new doc.