### PR TITLE
Add quantity to line items

### DIFF
--- a/app/graphql/types/line_item_attributes.rb
+++ b/app/graphql/types/line_item_attributes.rb
@@ -4,4 +4,5 @@ class Types::LineItemAttributes < Types::BaseInputObject
   argument :price_cents, Integer, "Item's price in cents", required: true
   argument :artwork_id, String, 'Artwork Id', required: true
   argument :edition_set_id, String, 'EditionSet Id', required: false
+  argument :quantity, Integer, 'Number of items in the line item', required: true
 end

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -6,4 +6,5 @@ class Types::LineItemType < Types::BaseObject
   field :price_cents, Integer, null: false
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true
+  field :quantity, Integer, null: false
 end

--- a/app/services/line_item_service.rb
+++ b/app/services/line_item_service.rb
@@ -4,7 +4,8 @@ module LineItemService
       artwork_id: line_item_param[:artwork_id],
       edition_set_id: line_item_param[:edition_set_id],
       price_cents: line_item_param[:price_cents],
-      order_id: order.id
+      order_id: order.id,
+      quantity: line_item_param[:quantity]
     )
     # queue fetching gravity artwork
     SetLineItemArtworkJob.perform_later(line_item.id)

--- a/db/migrate/20180621193842_add_quantity_to_line_items.rb
+++ b/db/migrate/20180621193842_add_quantity_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddQuantityToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :quantity, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_12_185116) do
+ActiveRecord::Schema.define(version: 2018_06_21_193842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_185116) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "artwork_snapshot"
+    t.integer "quantity", default: 1, null: false
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/spec/controllers/api/requests/create_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_mutation_request_spec.rb
@@ -6,7 +6,8 @@ describe Api::GraphqlController, type: :request do
     let(:partner_id) { 'partner-id' }
     let(:artwork_id) { 'artwork-1' }
     let(:edition_set_id) { 'ed-1' }
-    let(:line_item1) { { artworkId: artwork_id, editionSetId: edition_set_id, priceCents: 420_00 } }
+    let(:quantity) { 1 }
+    let(:line_item1) { { artworkId: artwork_id, editionSetId: edition_set_id, priceCents: 420_00, quantity: quantity } }
     let(:line_items) { [line_item1] }
     let(:currency_code) { 'usd' }
     let(:order_input_with_line_item) do
@@ -67,6 +68,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.line_items.first.price_cents).to eq 420_00
         expect(order.line_items.first.artwork_id).to eq 'artwork-1'
         expect(order.line_items.first.edition_set_id).to eq 'ed-1'
+        expect(order.line_items.first.quantity).to eq 1
       end
 
       context 'with unsupported currency code' do

--- a/spec/fabricators/line_item_fabricator.rb
+++ b/spec/fabricators/line_item_fabricator.rb
@@ -1,5 +1,6 @@
 Fabricator(:line_item) do
   price_cents { 100_00 }
   artwork_id { sequence(:artwork_id) { |i| "artwork-id-#{i}" } }
+  quantity { 1 }
   order { Fabricate(:order) }
 end

--- a/spec/services/line_item_service_spec.rb
+++ b/spec/services/line_item_service_spec.rb
@@ -5,7 +5,7 @@ describe LineItemService, type: :services do
   include ActiveJob::TestHelper
   let(:order) { Fabricate(:order) }
   describe '#create!' do
-    let(:line_item_params) { { artwork_id: 'test-id', edition_set_id: 'ed-1', price_cents: 420_00 } }
+    let(:line_item_params) { { artwork_id: 'test-id', edition_set_id: 'ed-1', price_cents: 420_00, quantity: 1 } }
     it 'queues a job to set line item artwork snapshot' do
       expect do
         LineItemService.create!(order, line_item_params)
@@ -18,6 +18,7 @@ describe LineItemService, type: :services do
         expect(li.reload.artwork_id).to eq 'test-id'
         expect(li.edition_set_id).to eq 'ed-1'
         expect(li.price_cents).to eq 420_00
+        expect(li.quantity).to eq 1
         artwork_snapshot = li.artwork_snapshot.with_indifferent_access
         expect(artwork_snapshot[:title]).to eq 'Cat'
         expect(artwork_snapshot[:images].first[:image_urls][:cats]).to eq '/path/to/cats.jpg'


### PR DESCRIPTION
[CP-59](https://artsyproduct.atlassian.net/browse/CP-59)

Adds `quantity` to line items as a non-null field that defaults to 1 in the database. Required field for `LineItemAttributes`. We might change this later to be non-required for attributes and default to 1.