### PR TITLE
Fix typo in update_at and add updated_at and created_at to line items

### DIFF
--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -7,4 +7,6 @@ class Types::LineItemType < Types::BaseObject
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true
   field :quantity, Integer, null: false
+  field :created_at, Types::DateTimeType, null: false
+  field :updated_at, Types::DateTimeType, null: false
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -9,6 +9,6 @@ class Types::OrderType < Types::BaseObject
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
   field :created_at, Types::DateTimeType, null: false
-  field :update_at, Types::DateTimeType, null: false
+  field :updated_at, Types::DateTimeType, null: false
   field :line_items, Types::LineItemType.connection_type, null: true
 end


### PR DESCRIPTION
`updated_at` was called `update_at` and added `updated_at` and `created_at` 