### PR TITLE
Remove itemsTotalCents from schema, add as a field on order

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -8,7 +8,7 @@ class Types::OrderType < Types::BaseObject
   field :partner_id, String, null: false
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
-  field :items_total_cents, Integer, null: true
+  field :items_total_cents, Integer, null: false
   field :shipping_total_cents, Integer, null: true
   field :tax_total_cents, Integer, null: true
   field :transaction_fee_cents, Integer, null: true

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -8,6 +8,11 @@ class Types::OrderType < Types::BaseObject
   field :partner_id, String, null: false
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
+  field :items_total_cents, Integer, null: true
+  field :shipping_total_cents, Integer, null: true
+  field :tax_total_cents, Integer, null: true
+  field :transaction_fee_cents, Integer, null: true
+  field :commission_fee_cents, Integer, null: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :line_items, Types::LineItemType.connection_type, null: true

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,7 +2,7 @@ class Types::QueryType < Types::BaseObject
   # Add root-level fields here.
   # They will be entry points for queries on your schema.
 
-  field :order, Types::OrderType, null: false do
+  field :order, Types::OrderType, null: true do
     description 'Find an order by ID'
     argument :id, ID, required: true
   end
@@ -17,12 +17,12 @@ class Types::QueryType < Types::BaseObject
 
   def order(id:)
     order = Order.find(id)
-    raise GraphQL::ExecutionError, 'permission error' unless order.user_id == context[:current_user][:id] || context[:current_user][:partner_ids].include?(order.partner_id)
+    raise GraphQL::ExecutionError, 'Not permitted' unless order.user_id == context[:current_user][:id] || context[:current_user][:partner_ids].include?(order.partner_id)
     order
   end
 
   def orders(params)
-    validate_params!(params)
+    validate_orders_params!(params)
     sort = params.delete(:sort)
     query = Order.where(params)
 
@@ -38,7 +38,7 @@ class Types::QueryType < Types::BaseObject
 
   private
 
-  def validate_params!(params)
+  def validate_orders_params!(params)
     raise GraphQL::ExecutionError, 'requires one of userId or partnerId' unless params[:user_id].present? || params[:partner_id].present?
     raise GraphQL::ExecutionError, 'Not permitted' if params[:user_id] && params[:user_id] != context[:current_user][:id]
     raise GraphQL::ExecutionError, 'Not permitted' if params[:partner_id] && !context[:current_user][:partner_ids].include?(params[:partner_id])

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,6 +34,10 @@ class Order < ApplicationRecord
     end
   end
 
+  def items_total_cents
+    (line_items.present? && line_items.map(&:price_cents).reduce(0, :+)) || 0
+  end
+
   private
 
   def set_code

--- a/db/migrate/20180625123034_remove_item_total_cents_from_orders.rb
+++ b/db/migrate/20180625123034_remove_item_total_cents_from_orders.rb
@@ -1,0 +1,5 @@
+class RemoveItemTotalCentsFromOrders < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :orders, :item_total_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_21_193842) do
+ActiveRecord::Schema.define(version: 2018_06_25_123034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,6 @@ ActiveRecord::Schema.define(version: 2018_06_21_193842) do
 
   create_table "orders", force: :cascade do |t|
     t.string "code"
-    t.integer "item_total_cents"
     t.integer "shipping_total_cents"
     t.integer "tax_total_cents"
     t.integer "transaction_fee_cents"

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'order query' do
+    include_context 'GraphQL Client'
+    let(:partner_id) { jwt_partner_ids.first }
+    let(:second_partner_id) { 'partner-2' }
+    let(:user_id) { jwt_user_id }
+    let(:second_user) { 'user2' }
+    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago) }
+    let!(:user2_order1) { Fabricate(:order, partner_id: second_partner_id, user_id: second_user) }
+
+    let(:query) do
+      <<-GRAPHQL
+        query($id: ID!) {
+          order(id: $id) {
+            id
+            userId
+            partnerId
+            state
+            currencyCode
+            itemsTotalCents
+            shippingTotalCents
+            lineItems{
+              edges{
+                node{
+                  priceCents
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'user accessing their order' do
+      it 'returns permission error when query for orders by user not in jwt' do
+        expect do
+          client.execute(query, id: user2_order1.id)
+        end.to raise_error(Graphlient::Errors::ExecutionError, 'order: Not permitted')
+      end
+
+      it 'returns order when accessing correct order' do
+        result = client.execute(query, id: user1_order1.id)
+        expect(result.data.order.user_id).to eq user_id
+        expect(result.data.order.partner_id).to eq partner_id
+        expect(result.data.order.currency_code).to eq 'usd'
+        expect(result.data.order.state).to eq 'PENDING'
+        expect(result.data.order.items_total_cents).to eq 0
+      end
+    end
+
+    context 'partner accessing order' do
+    end
+  end
+end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -51,6 +51,15 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'partner accessing order' do
+      it 'returns order when accessing correct order' do
+        another_user_order = Fabricate(:order, partner_id: partner_id, user_id: 'someone-else-id')
+        result = client.execute(query, id: another_user_order.id)
+        expect(result.data.order.user_id).to eq 'someone-else-id'
+        expect(result.data.order.partner_id).to eq partner_id
+        expect(result.data.order.currency_code).to eq 'usd'
+        expect(result.data.order.state).to eq 'PENDING'
+        expect(result.data.order.items_total_cents).to eq 0
+      end
     end
   end
 end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -21,6 +21,15 @@ describe Api::GraphqlController, type: :request do
                 userId
                 partnerId
                 state
+                currencyCode
+                itemsTotalCents
+                lineItems{
+                  edges{
+                    node{
+                      priceCents
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
# Changes
- Remove `item_total_cents` from `Order` and instead calculate it based on the Order's line items.
- Expose `items_total_cents`, `shippint_total_cents`, `tax_total_cents`, `comission_total_cents`  and `transaction_fee_cents` in the schema.
- added spec for `order(id: ID!)` query

