### PR TITLE
WIP: Track order history using RecordHistoryService

### DIFF
--- a/app/graphql/mutations/approve_order.rb
+++ b/app/graphql/mutations/approve_order.rb
@@ -10,7 +10,7 @@ class Mutations::ApproveOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.approve!(order),
+      order: OrderService.approve!(order, context[:current_user]['id']),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/finalize_order.rb
+++ b/app/graphql/mutations/finalize_order.rb
@@ -10,7 +10,7 @@ class Mutations::FinalizeOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.finalize!(order),
+      order: OrderService.finalize!(order, context[:current_user]['id']),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/reject_order.rb
+++ b/app/graphql/mutations/reject_order.rb
@@ -10,7 +10,7 @@ class Mutations::RejectOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.reject!(order),
+      order: OrderService.reject!(order, context[:current_user]['id']),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -11,7 +11,7 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.submit!(order, credit_card_id: credit_card_id),
+      order: OrderService.submit!(order, context[:current_user]['id'], credit_card_id: credit_card_id),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,6 +18,7 @@ class Order < ApplicationRecord
   ACTIONS = %i[abandon submit approve reject finalize].freeze
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'
+  has_many :history, dependent: :destroy, class_name: 'OrderHistory'
 
   validates :state, presence: true, inclusion: STATES
 

--- a/app/models/order_history.rb
+++ b/app/models/order_history.rb
@@ -1,0 +1,3 @@
+class OrderHistory < ApplicationRecord
+  belongs_to :order
+end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -4,47 +4,50 @@ module OrderService
     Order.transaction do
       abandon_pending_orders!(user_id) if pending_order?(user_id)
       order = Order.create!(user_id: user_id, partner_id: partner_id, currency_code: currency_code, state: Order::PENDING)
+      RecordHistoryService.create!(order, user_id, order.attributes)
       line_items.each { |li| LineItemService.create!(order, li) }
       # queue a job for few days from now to abandon the order
       order
     end
   end
 
-  # rubocop:disable Lint/UnusedMethodArgument
-  def self.submit!(order, credit_card_id:, shipping_info: '')
+  def self.submit!(order, user_id, credit_card_id:)
     Order.transaction do
       # verify price change?
       order.credit_card_id = credit_card_id
       # TODO: hold the charge for this price on credit card
       order.submit!
       order.save!
+      RecordHistoryService.create!(order, user_id, state: order.state, credit_card_id: order.credit_card_id)
     end
     order
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 
-  def self.approve!(order)
+  def self.approve!(order, user_id)
     Order.transaction do
       order.approve!
       order.save!
+      RecordHistoryService.create!(order, user_id, state: order.state)
       # TODO: process the charge by calling gravity with current credit_card_id and price
     end
     order
   end
 
-  def self.finalize!(order)
+  def self.finalize!(order, user_id)
     Order.transaction do
       order.finalize!
       order.save!
+      RecordHistoryService.create!(order, user_id, state: order.state)
       # TODO: process the charge by calling gravity with current credit_card_id and price
     end
     order
   end
 
-  def self.reject!(order)
+  def self.reject!(order, user_id)
     Order.transaction do
       order.reject!
       order.save!
+      RecordHistoryService.create!(order, user_id, state: order.state)
       # TODO: release the charge
     end
     order

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -57,6 +57,7 @@ module OrderService
     Order.transaction do
       order.abandon!
       order.save!
+      RecordHistoryService.create!(order, user_id, state: order.state)
     end
   end
 

--- a/app/services/record_history_service.rb
+++ b/app/services/record_history_service.rb
@@ -1,0 +1,8 @@
+module RecordHistoryService
+  def self.create!(record, modifier_id, args)
+    record.history.create!(
+      changed_fields: args,
+      modifier_id: modifier_id
+    )
+  end
+end

--- a/db/migrate/20180626201815_create_order_histories.rb
+++ b/db/migrate/20180626201815_create_order_histories.rb
@@ -1,0 +1,10 @@
+class CreateOrderHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :order_histories do |t|
+      t.references :order, foreign_key: true
+      t.string :modifier_id, null: false
+      t.jsonb :changed_fields, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_25_123034) do
+ActiveRecord::Schema.define(version: 2018_06_26_201815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2018_06_25_123034) do
     t.jsonb "artwork_snapshot"
     t.integer "quantity", default: 1, null: false
     t.index ["order_id"], name: "index_line_items_on_order_id"
+  end
+
+  create_table "order_histories", force: :cascade do |t|
+    t.bigint "order_id"
+    t.string "modifier_id", null: false
+    t.jsonb "changed_fields", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_histories_on_order_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -47,4 +56,5 @@ ActiveRecord::Schema.define(version: 2018_06_25_123034) do
   end
 
   add_foreign_key "line_items", "orders"
+  add_foreign_key "order_histories", "orders"
 end


### PR DESCRIPTION
- Adds `RecordHistoryService` which creates a history object with changes for any given record configured to do so.
- Adds `history` child object to Order and creates `order_histories` table
- Tracks changes to orders following mutations in `OrderService`

Will take off WIP label once I write some tests.

### Next
- Expose history to GraphQL