### PR TITLE
Add `state_updated_at` and `state_expires_at`

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -15,5 +15,7 @@ class Types::OrderType < Types::BaseObject
   field :commission_fee_cents, Integer, null: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
+  field :state_updated_at, Types::DateTimeType, null: true
+  field :state_expires_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
 end

--- a/db/migrate/20180702162920_add_state_updated_expires_at_to_orders.rb
+++ b/db/migrate/20180702162920_add_state_updated_expires_at_to_orders.rb
@@ -1,0 +1,8 @@
+class AddStateUpdatedExpiresAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    change_table :orders, bulk: true do |t|
+      t.column :state_updated_at, :timestamp
+      t.column :state_expires_at, :timestamp
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_25_123034) do
+ActiveRecord::Schema.define(version: 2018_07_02_162920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 2018_06_25_123034) do
     t.datetime "updated_at", null: false
     t.string "state", null: false
     t.string "credit_card_id"
+    t.datetime "state_updated_at"
+    t.datetime "state_expires_at"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -60,6 +60,8 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.submit_order.errors).to match []
         expect(order.reload.credit_card_id).to eq credit_card_id
         expect(order.state).to eq Order::SUBMITTED
+        expect(order.state_updated_at).not_to be_nil
+        expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Order, type: :model do
       expect(order.state_updated_at).to eq current_timestamp
     end
 
-    it 'does not update timestamps if state changed to state with expiration' do
+    it 'updates timestamps if state changed to state with expiration' do
       current_timestamp = order.state_updated_at
       current_expiration = order.state_expires_at
       order.submit!

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  let(:order) { Fabricate(:order) }
+  describe 'update_state_timestamps' do
+    it 'sets state timestamps in create' do
+      expect(order.state_updated_at).not_to be_nil
+      expect(order.state_expires_at).to eq order.state_updated_at + 2.days
+    end
+
+    it 'does not update timestamps if state did not change' do
+      current_timestamp = order.state_updated_at
+      order.update!(currency_code: 'CAD')
+      expect(order.state_updated_at).to eq current_timestamp
+    end
+
+    it 'does not update timestamps if state changed to state with expiration' do
+      current_timestamp = order.state_updated_at
+      current_expiration = order.state_expires_at
+      order.submit!
+      order.save!
+      expect(order.state_updated_at).not_to eq current_timestamp
+      expect(order.state_expires_at).not_to eq current_expiration
+    end
+    it 'does not update expiration timestamp if state changed to state without expiration' do
+      order.submit!
+      order.save!
+      submitted_timestamp = order.state_updated_at
+      order.approve!
+      order.save!
+      expect(order.state_updated_at).not_to eq submitted_timestamp
+      expect(order.state_expires_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
# Problem
In CMS UI we want to be able to show when the current state (if) expires.

# Solution
Added `state_updated_at` and `state_expires_at` fields to reflect when order state was updated and whats the current expiry, knowing that not all states may expire, this field 

Keep in mind, currently we don't know exactly which states are going to expire and what is the threshold but for now setting two states with some basic thresholds.

cc: @sepans @jonallured 