### PR TITLE
Add totalCents and subtotalCents

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -13,6 +13,8 @@ class Types::OrderType < Types::BaseObject
   field :tax_total_cents, Integer, null: true
   field :transaction_fee_cents, Integer, null: true
   field :commission_fee_cents, Integer, null: true
+  field :subtotal_cents, Integer, null: true
+  field :total_cents, Integer, null: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :state_updated_at, Types::DateTimeType, null: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -42,7 +42,15 @@ class Order < ApplicationRecord
   end
 
   def items_total_cents
-    line_items.pluck(:price_cents).sum
+    line_items.sum(:price_cents)
+  end
+
+  def subtotal_cents
+    items_total_cents + shipping_total_cents.to_i + tax_total_cents.to_i
+  end
+
+  def total_cents
+    subtotal_cents + commission_fee_cents.to_i + transaction_fee_cents.to_i
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -50,7 +50,7 @@ class Order < ApplicationRecord
   end
 
   def total_cents
-    subtotal_cents + commission_fee_cents.to_i + transaction_fee_cents.to_i
+    subtotal_cents - commission_fee_cents.to_i - transaction_fee_cents.to_i
   end
 
   private

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -7,7 +7,7 @@ describe Api::GraphqlController, type: :request do
     let(:second_partner_id) { 'partner-2' }
     let(:user_id) { jwt_user_id }
     let(:second_user) { 'user2' }
-    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago, shipping_total_cents: 100_00, commission_fee_cents: 200_00) }
+    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago, shipping_total_cents: 100_00, commission_fee_cents: 50_00) }
     let!(:user2_order1) { Fabricate(:order, partner_id: second_partner_id, user_id: second_user) }
 
     let(:query) do
@@ -49,7 +49,7 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.currency_code).to eq 'usd'
         expect(result.data.order.state).to eq 'PENDING'
         expect(result.data.order.items_total_cents).to eq 0
-        expect(result.data.order.total_cents).to eq 300_00
+        expect(result.data.order.total_cents).to eq 50_00
         expect(result.data.order.subtotal_cents).to eq 100_00
       end
     end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -7,7 +7,7 @@ describe Api::GraphqlController, type: :request do
     let(:second_partner_id) { 'partner-2' }
     let(:user_id) { jwt_user_id }
     let(:second_user) { 'user2' }
-    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago) }
+    let!(:user1_order1) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago, shipping_total_cents: 100_00, commission_fee_cents: 200_00) }
     let!(:user2_order1) { Fabricate(:order, partner_id: second_partner_id, user_id: second_user) }
 
     let(:query) do
@@ -21,6 +21,8 @@ describe Api::GraphqlController, type: :request do
             currencyCode
             itemsTotalCents
             shippingTotalCents
+            totalCents
+            subtotalCents
             lineItems{
               edges{
                 node{
@@ -47,6 +49,8 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.currency_code).to eq 'usd'
         expect(result.data.order.state).to eq 'PENDING'
         expect(result.data.order.items_total_cents).to eq 0
+        expect(result.data.order.total_cents).to eq 300_00
+        expect(result.data.order.subtotal_cents).to eq 100_00
       end
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -64,6 +64,25 @@ RSpec.describe Order, type: :model do
   end
 
   describe '#total_cents' do
+    before do
+      Fabricate.times 2, :line_item, order: order, price_cents: 100_00
+    end
+    it 'returns correct total_cents' do
+      order.update!(tax_total_cents: 50_00, shipping_total_cents: 50_00, commission_fee_cents: 20_00, transaction_fee_cents: 20_00)
+      expect(order.reload.total_cents).to eq 260_00
+    end
+    context 'without commission fee' do
+      it 'returns correct total cents' do
+        order.update!(tax_total_cents: 50_00, shipping_total_cents: 50_00, commission_fee_cents: nil, transaction_fee_cents: 20_00)
+        expect(order.reload.total_cents).to eq 280_00
+      end
+    end
+    context 'without transaction fee' do
+      it 'returns correct total cents' do
+        order.update!(tax_total_cents: 50_00, shipping_total_cents: 50_00, commission_fee_cents: 20_00, transaction_fee_cents: nil)
+        expect(order.reload.total_cents).to eq 280_00
+      end
+    end
   end
 
   describe '#subtotal_cents' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -62,4 +62,31 @@ RSpec.describe Order, type: :model do
       end
     end
   end
+
+  describe '#total_cents' do
+  end
+
+  describe '#subtotal_cents' do
+    context 'without shipping total cents' do
+      it 'returns tax + line items' do
+        Fabricate.times 2, :line_item, order: order, price_cents: 100_00
+        order.update!(tax_total_cents: 100_00)
+        expect(order.subtotal_cents).to eq 300_00
+      end
+    end
+    context 'without tax total cents' do
+      it 'returns tax + line items' do
+        Fabricate.times 2, :line_item, order: order, price_cents: 100_00
+        order.update!(shipping_total_cents: 100_00)
+        expect(order.subtotal_cents).to eq 300_00
+      end
+    end
+    context 'with shipping/tax and line items' do
+      it 'returns shipping + tax + line items' do
+        Fabricate.times 2, :line_item, order: order, price_cents: 100_00
+        order.update!(shipping_total_cents: 100_00, tax_total_cents: 50_00)
+        expect(order.subtotal_cents).to eq 350_00
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem
We were calculating total and subtotal in CMS. We want to have one source of truth for totals and subtotals and it makes sense for that to be Exchange since it's the place that will ultimately calculate these values and call Stripe with that for holding the charge.

# Solution
Add `totalCents` and `subtotalCents` to `Order` and `OrderType`.

# Follow up
Add these to MP.