### PR TITLE
Fetch merchant_account_id directly from Gravity

### DIFF
--- a/app/graphql/mutations/set_payment.rb
+++ b/app/graphql/mutations/set_payment.rb
@@ -3,7 +3,6 @@ class Mutations::SetPayment < Mutations::BaseMutation
 
   argument :id, ID, required: true
   argument :credit_card_id, String, required: false
-  argument :merchant_account_id, String, required: false
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false
@@ -20,7 +19,7 @@ class Mutations::SetPayment < Mutations::BaseMutation
   end
 
   def assert_order_can_set_payment!(order, args)
-    raise Errors::ApplicationError, 'Missing required arguments' unless args[:merchant_account_id].present? || args[:credit_card_id].present?
+    raise Errors::ApplicationError, 'Missing required arguments' if args[:credit_card_id].blank?
     raise Errors::AuthError, 'Not permitted' unless context[:current_user]['id'] == order.user_id
   end
 end

--- a/app/graphql/mutations/set_payment.rb
+++ b/app/graphql/mutations/set_payment.rb
@@ -2,7 +2,7 @@ class Mutations::SetPayment < Mutations::BaseMutation
   null true
 
   argument :id, ID, required: true
-  argument :credit_card_id, String, required: false
+  argument :credit_card_id, String, required: true
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false
@@ -19,7 +19,6 @@ class Mutations::SetPayment < Mutations::BaseMutation
   end
 
   def assert_order_can_set_payment!(order, args)
-    raise Errors::ApplicationError, 'Missing required arguments' if args[:credit_card_id].blank?
     raise Errors::AuthError, 'Not permitted' unless context[:current_user]['id'] == order.user_id
   end
 end

--- a/app/graphql/mutations/set_payment.rb
+++ b/app/graphql/mutations/set_payment.rb
@@ -9,7 +9,7 @@ class Mutations::SetPayment < Mutations::BaseMutation
 
   def resolve(args)
     order = Order.find(args[:id])
-    assert_order_can_set_payment!(order, args)
+    assert_order_can_set_payment!(order)
     {
       order: OrderService.set_payment!(order, args.except(:id)),
       errors: []
@@ -18,7 +18,7 @@ class Mutations::SetPayment < Mutations::BaseMutation
     { order: nil, errors: [e.message] }
   end
 
-  def assert_order_can_set_payment!(order, args)
+  def assert_order_can_set_payment!(order)
     raise Errors::AuthError, 'Not permitted' unless context[:current_user]['id'] == order.user_id
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -65,7 +65,7 @@ class Order < ApplicationRecord
   end
 
   def payment_info?
-    credit_card_id.present? && merchant_account_id.present?
+    credit_card_id.present?
   end
 
   private

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -10,10 +10,10 @@ module OrderService
     end
   end
 
-  def self.set_payment!(order, credit_card_id:, merchant_account_id:)
+  def self.set_payment!(order, credit_card_id:)
     raise Errors::OrderError, 'Cannot set payment info on non-pending orders' unless order.state == Order::PENDING
     Order.transaction do
-      order.update!(credit_card_id: credit_card_id, merchant_account_id: merchant_account_id)
+      order.update!(credit_card_id: credit_card_id)
     end
     order
   end

--- a/app/services/transaction_service.rb
+++ b/app/services/transaction_service.rb
@@ -3,7 +3,7 @@ module TransactionService
     order.transactions.create!(
       external_id: error[:id],
       source_id: order.credit_card_id,
-      destination_id: order.merchant_account_id,
+      destination_id: error[:destination_id],
       amount_cents: error[:amount],
       failure_code: error[:failure_code],
       failure_message: error[:failure_message],
@@ -15,7 +15,7 @@ module TransactionService
     order.transactions.create!(
       external_id: charge.id,
       source_id: order.credit_card_id,
-      destination_id: order.merchant_account_id,
+      destination_id: charge.destination,
       amount_cents: charge.amount,
       failure_code: charge.failure_code,
       failure_message: charge.failure_message,

--- a/db/migrate/20180716171451_remove_merchant_account_id_from_orders.rb
+++ b/db/migrate/20180716171451_remove_merchant_account_id_from_orders.rb
@@ -1,0 +1,5 @@
+class RemoveMerchantAccountIdFromOrders < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :orders, :merchant_account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_13_200558) do
+ActiveRecord::Schema.define(version: 2018_07_16_171451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,6 @@ ActiveRecord::Schema.define(version: 2018_07_13_200558) do
     t.string "shipping_country"
     t.string "shipping_postal_code"
     t.string "fulfillment_type"
-    t.string "merchant_account_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
@@ -53,14 +53,6 @@ describe Api::GraphqlController, type: :request do
         end
       end
 
-      context 'without required args' do
-        let(:credit_card_id) { nil }
-        it 'returns error for missing required params' do
-          response = client.execute(mutation, set_payment_input)
-          expect(response.data.set_payment.errors).to include 'Missing required arguments'
-        end
-      end
-
       it 'sets payments on the order' do
         response = client.execute(mutation, set_payment_input)
         expect(response.data.set_payment.order.id).to eq order.id.to_s

--- a/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
@@ -6,7 +6,6 @@ describe Api::GraphqlController, type: :request do
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:merchant_account_id) { 'ma1' }
     let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
 
     let(:mutation) do
@@ -29,8 +28,7 @@ describe Api::GraphqlController, type: :request do
       {
         input: {
           id: order.id.to_s,
-          creditCardId: credit_card_id,
-          merchantAccountId: merchant_account_id
+          creditCardId: credit_card_id
         }
       }
     end
@@ -56,7 +54,6 @@ describe Api::GraphqlController, type: :request do
       end
 
       context 'without required args' do
-        let(:merchant_account_id) { nil }
         let(:credit_card_id) { nil }
         it 'returns error for missing required params' do
           response = client.execute(mutation, set_payment_input)
@@ -70,7 +67,6 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.set_payment.order.state).to eq 'PENDING'
         expect(response.data.set_payment.errors).to match []
         expect(order.reload.credit_card_id).to eq credit_card_id
-        expect(order.merchant_account_id).to eq merchant_account_id
         expect(order.state).to eq Order::PENDING
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
       end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -6,14 +6,12 @@ describe Api::GraphqlController, type: :request do
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:merchant_account_id) { 'ma1' }
     let(:order) do
       Fabricate(
         :order,
         partner_id: partner_id,
         user_id: user_id,
         credit_card_id: credit_card_id,
-        merchant_account_id: merchant_account_id,
         shipping_address_line1: '12 Vanak St',
         shipping_address_line2: 'P 80',
         shipping_city: 'Tehran',
@@ -68,14 +66,6 @@ describe Api::GraphqlController, type: :request do
       end
       context 'with order without credit card id' do
         let(:credit_card_id) { nil }
-        it 'returns error' do
-          response = client.execute(mutation, submit_order_input)
-          expect(response.data.submit_order.errors).to include "Missing info for submitting order(#{order.id})"
-          expect(order.reload.state).to eq Order::PENDING
-        end
-      end
-      context 'with order without merchant account id' do
-        let(:merchant_account_id) { nil }
         it 'returns error' do
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.errors).to include "Missing info for submitting order(#{order.id})"

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe OrderService, type: :services do
-  let(:order) { Fabricate(:order, credit_card_id: 'cc1', merchant_account_id: 'ma1', fulfillment_type: Order::PICKUP) }
+  let(:order) { Fabricate(:order, credit_card_id: 'cc1', fulfillment_type: Order::PICKUP) }
   let(:credit_card_id) { 'cc-1' }
   let(:charge_success) { { id: 'ch-1' } }
   let(:charge_failure) { { failure_message: 'some_error' } }

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -5,55 +5,45 @@ describe PaymentService, type: :services do
   let(:credit_card_id) { 'cc-1' }
   let(:merchant_account_id) { 'destination_account' }
   let(:charge_amount) { 2222 }
-  let(:order) { Fabricate(:order, credit_card_id: credit_card_id, merchant_account_id: merchant_account_id) }
-  let(:invalid_order) { Fabricate(:order) }
-  let(:authorize_charge_params) { { amount: charge_amount, currency: order.currency_code, description: 'Artsy', source: order.credit_card_id, destination: order.merchant_account_id, capture: false } }
+  let(:order) { Fabricate(:order, credit_card_id: credit_card_id) }
+  let(:authorize_charge_params) { { amount: charge_amount, currency: order.currency_code, description: 'Artsy', source: order.credit_card_id, destination: merchant_account_id, capture: false } }
   let(:charge) { { id: 'ch_22' } }
-  let(:matching_partner_merchant_accounts) { [{ external_id: merchant_account_id }, { external_id: 'some_account' }] }
-  let(:nonmatching_partner_merchant_accounts) { [{ external_id: 'some_account' }] }
+  let(:partner_merchant_accounts) { [{ external_id: merchant_account_id }, { external_id: 'some_account' }] }
 
   describe '#authorize_charge' do
-    context 'with order with valid payment info' do
-      it "authorizes a charge on the user's credit card" do
-        allow(Stripe::Charge).to receive(:create).with(authorize_charge_params).and_return(charge)
-        allow(PaymentService).to receive(:valid_destination_account?).and_return(true)
+    it "authorizes a charge on the user's credit card" do
+      allow(Stripe::Charge).to receive(:create).with(authorize_charge_params).and_return(charge)
+      allow(PaymentService).to receive(:get_merchant_account_id).and_return(merchant_account_id)
 
-        PaymentService.authorize_charge(order, charge_amount)
-        expect(Stripe::Charge).to have_received(:create).with(authorize_charge_params)
-      end
+      PaymentService.authorize_charge(order, charge_amount)
+      expect(Stripe::Charge).to have_received(:create).with(authorize_charge_params)
     end
 
-    context 'with order with invalid destination account' do
+    context 'with a partner that does not have a merchant account ID' do
       it 'raises a PaymentError and does not authorize a charge' do
-        allow(PaymentService).to receive(:valid_destination_account?).and_return(false)
-        expect { PaymentService.authorize_charge(invalid_order, charge_amount) }.to raise_error(Errors::PaymentError)
+        allow(PaymentService).to receive(:get_merchant_account_id).and_return(nil)
+        expect { PaymentService.authorize_charge(order, charge_amount) }.to raise_error(Errors::PaymentError)
       end
     end
   end
 
-  describe '#valid_destination_account?' do
+  describe '#get_merchant_account_id' do
     it 'calls the /merchant_accounts Gravity endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(matching_partner_merchant_accounts)
-      PaymentService.valid_destination_account?(order)
+      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(partner_merchant_accounts)
+      PaymentService.get_merchant_account_id(order.partner_id)
       expect(Adapters::GravityV1).to have_received(:request).with("/merchant_accounts?partner_id=#{order.partner_id}")
     end
 
-    it "returns true if the destination account matches one of the partner's merchant accounts" do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(matching_partner_merchant_accounts)
-      result = PaymentService.valid_destination_account?(order)
-      expect(result).to be(true)
+    it "returns the first merchant account of the partner's merchant accounts" do
+      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(partner_merchant_accounts)
+      result = PaymentService.get_merchant_account_id(order.partner_id)
+      expect(result).to be(merchant_account_id)
     end
 
-    it "returns false if the destination account does not match the partner's account" do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(nonmatching_partner_merchant_accounts)
-      result = PaymentService.valid_destination_account?(order)
-      expect(result).to be(false)
-    end
-
-    it 'returns false if the partner does not have any merchant accounts' do
+    it 'returns nil if the partner does not have a merchant account' do
       allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return([])
-      result = PaymentService.valid_destination_account?(order)
-      expect(result).to be(false)
+      result = PaymentService.get_merchant_account_id(order.partner_id)
+      expect(result).to be(nil)
     end
   end
 end


### PR DESCRIPTION
- Removes `merchant_account_id` from `order` model and `submitOrder` mutation
- Fetches `merchant_account_id` directly from Gravity