### PR TITLE
Create new order all the time

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -2,10 +2,8 @@ module OrderService
   def self.create!(user_id:, partner_id:, currency_code:, line_items: [])
     raise Errors::OrderError, 'Currency not supported' unless valid_currency_code?(currency_code)
     Order.transaction do
-      abandon_pending_orders!(user_id) if pending_order?(user_id)
       order = Order.create!(user_id: user_id, partner_id: partner_id, currency_code: currency_code, state: Order::PENDING)
       line_items.each { |li| LineItemService.create!(order, li) }
-      # queue a job for few days from now to abandon the order
       order
     end
   end
@@ -82,20 +80,6 @@ module OrderService
     Order.transaction do
       order.abandon!
       order.save!
-    end
-  end
-
-  def self.user_pending_artwork_order(user_id, artwork_id, edition_set_id = nil)
-    Order.pending.joins(:line_items).find_by(user_id: user_id, line_items: { artwork_id: artwork_id, edition_set_id: edition_set_id })
-  end
-
-  def self.pending_order?(user_id)
-    Order.pending.where(user_id: user_id).exists?
-  end
-
-  def self.abandon_pending_orders!(user_id)
-    Order.pending.where(user_id: user_id).each do |o|
-      abandon!(o)
     end
   end
 

--- a/spec/controllers/api/requests/create_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_mutation_request_spec.rb
@@ -83,13 +83,13 @@ describe Api::GraphqlController, type: :request do
 
       context 'with existing pending order for artwork' do
         let!(:order) { Fabricate(:order, user_id: jwt_user_id, state: Order::PENDING) }
-        it 'returns error' do
+        it 'creates a new order' do
           expect do
             response = client.execute(mutation, order_input_with_line_item)
             expect(response.data.create_order.order.id).not_to be_nil
             expect(response.data.create_order.errors).to match []
-            expect(order.reload.state).to eq Order::ABANDONED
-          end.to change(Order, :count).by(1).and change(Order.where(state: Order::ABANDONED), :count).by(1)
+            expect(order.reload.state).to eq Order::PENDING
+          end.to change(Order, :count).by(1)
         end
       end
     end


### PR DESCRIPTION
# Problem
Current pending order validation is expensive and doesn't really provide much, After some discussions, it seems the easiest solution for now would be to always create new order regardless of existing pending orders. This is fine since all subsequent mutations work with `order` id and they should be fine. 

# Solution
Always create new orders and don't even check for existing orders.

We will be creating pending charges but they can be cleaned up in many ways by queuing jobs or daily task that cleans up old pending orders.
 