### PR TITLE
Remove required userId in createOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ For input set following variables:
 ```json
 {
   "input": {
-    "userId": "<your user id>",
     "partnerId": "<partner id>",
     "currencyCode": "usd",
     "lineItems": [
@@ -100,6 +99,61 @@ For input set following variables:
         "editionSetId": "<optional>"
       }
     ]
+  }
+}
+```
+
+#### Set Shipping on an order
+```graphql
+# set shipping order
+mutation($input: SetShippingInput!) {
+  setShipping(input: $input) {
+    order {
+      id
+      userId
+      partnerId
+      state
+    }
+    errors
+  }
+}
+```
+For input:
+```json
+{
+  "input": {
+    "id": "<order id>",
+    "fulfillmentType": "SHIP/PICKUP",
+    "shippingAddresLine1": "",
+    "shippingAddressLine2": "",
+    "shippingCity": "",
+    "shippingCountry": "",
+    "shippingPostalCode": ""
+  }
+}
+```
+
+#### Set Payment on an order
+```graphql
+# set payment order
+mutation($input: SetShippingInput!) {
+  setPayment(input: $input) {
+    order {
+      id
+      userId
+      partnerId
+      state
+    }
+    errors
+  }
+}
+```
+For input:
+```json
+{
+  "input": {
+    "id": "<order id>",
+    "creditCardId": "<gravity credit card id>"
   }
 }
 ```

--- a/app/graphql/mutations/create_order.rb
+++ b/app/graphql/mutations/create_order.rb
@@ -1,7 +1,6 @@
 class Mutations::CreateOrder < Mutations::BaseMutation
   null true
 
-  argument :user_id, String, required: true
   argument :partner_id, String, required: true
   argument :currency_code, String, required: true
 
@@ -10,17 +9,12 @@ class Mutations::CreateOrder < Mutations::BaseMutation
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false
 
-  def resolve(user_id:, partner_id:, currency_code:, line_items: [])
-    validate_user!(user_id)
+  def resolve(partner_id:, currency_code:, line_items: [])
     {
-      order: OrderService.create!(user_id: user_id, partner_id: partner_id, currency_code: currency_code, line_items: line_items),
+      order: OrderService.create!(user_id: context[:current_user][:id], partner_id: partner_id, currency_code: currency_code, line_items: line_items),
       errors: []
     }
   rescue Errors::ApplicationError => e
     { order: nil, errors: [e.message] }
-  end
-
-  def validate_user!(user_id)
-    raise Errors::AuthError, 'Not permitted' if context[:current_user][:id] != user_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,6 @@ ActiveRecord::Schema.define(version: 2018_07_16_171451) do
     t.string "credit_card_id"
     t.datetime "state_updated_at"
     t.datetime "state_expires_at"
-    t.string "merchant_account_id"
     t.string "shipping_address_line1"
     t.string "shipping_address_line2"
     t.string "shipping_city"

--- a/spec/controllers/api/requests/create_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_mutation_request_spec.rb
@@ -13,7 +13,6 @@ describe Api::GraphqlController, type: :request do
     let(:order_input_with_line_item) do
       {
         input: {
-          userId: jwt_user_id,
           partnerId: partner_id,
           lineItems: line_items,
           currencyCode: currency_code
@@ -23,7 +22,6 @@ describe Api::GraphqlController, type: :request do
     let(:order_input_wrong_user) do
       {
         input: {
-          userId: 'random-dude',
           partnerId: partner_id,
           lineItems: line_items,
           currencyCode: currency_code
@@ -44,16 +42,8 @@ describe Api::GraphqlController, type: :request do
         }
       GRAPHQL
     end
-    context 'with user id not matching jwt user id' do
-      it 'returns error when users dont match' do
-        expect do
-          response = client.execute(mutation, order_input_wrong_user)
-          expect(response.data.create_order.errors).to include 'Not permitted'
-        end.to change(Order, :count).by(0)
-      end
-    end
 
-    context 'with user id matching jwt user id' do
+    context 'with proper token' do
       it 'creates order with proper defaults' do
         expect do
           response = client.execute(mutation, order_input_with_line_item)


### PR DESCRIPTION
# Change
Use user id in JWT for creating the order. This makes things easier on client side and follows existing patterns used for other mutations.