### PR TITLE
Require 'net/http' in application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 # require "sprockets/railtie"
 require 'rails/test_unit/railtie'
+require 'net/http'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
`net/http` is available in dev but not in production, possibly due to how rails loads files in each environment. Adds `net/http` to application config to fix this difference.