### PR TITLE
Add shipping region

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For input:
     "shippingAddresLine1": "",
     "shippingAddressLine2": "",
     "shippingCity": "",
+    "shippingRegion": "",
     "shippingCountry": "",
     "shippingPostalCode": ""
   }

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -5,6 +5,7 @@ class Mutations::SetShipping < Mutations::BaseMutation
   argument :shipping_address_line1, String, required: false
   argument :shipping_address_line2, String, required: false
   argument :shipping_city, String, required: false
+  argument :shipping_region, String, required: false
   argument :shipping_country, String, required: false
   argument :shipping_postal_code, String, required: false
   argument :fulfillment_type, Types::OrderFulfillmentTypeEnum, required: false

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -24,6 +24,7 @@ module OrderService
           :shipping_address_line1,
           :shipping_address_line2,
           :shipping_city,
+          :shipping_region,
           :shipping_country,
           :shipping_postal_code,
           :fulfillment_type

--- a/db/migrate/20180718174508_add_shipping_region_to_orders.rb
+++ b/db/migrate/20180718174508_add_shipping_region_to_orders.rb
@@ -1,0 +1,5 @@
+class AddShippingRegionToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :shipping_region, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_16_171451) do
+ActiveRecord::Schema.define(version: 2018_07_18_174508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2018_07_16_171451) do
     t.string "shipping_country"
     t.string "shipping_postal_code"
     t.string "fulfillment_type"
+    t.string "shipping_region"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -31,6 +31,7 @@ describe Api::GraphqlController, type: :request do
           fulfillmentType: 'SHIP',
           shippingCountry: 'IR',
           shippingCity: 'Tehran',
+          shippingRegion: 'Tehran',
           shippingPostalCode: '02198912',
           shippingAddressLine1: 'Vanak',
           shippingAddressLine2: 'P 80'
@@ -67,6 +68,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.state).to eq Order::PENDING
         expect(order.shipping_country).to eq 'IR'
         expect(order.shipping_city).to eq 'Tehran'
+        expect(order.shipping_region).to eq 'Tehran'
         expect(order.shipping_postal_code).to eq '02198912'
         expect(order.shipping_address_line1).to eq 'Vanak'
         expect(order.shipping_address_line2).to eq 'P 80'


### PR DESCRIPTION
This came up during mock-pilot, we were missing `shipping_region` on Order. Adding it in this PR.