### PR TITLE
Fix approved state expiration timestamp issue

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,7 +18,8 @@ class Order < ApplicationRecord
 
   STATE_EXPIRATIONS = {
     'pending' => 2.days,
-    'submitted' => 2.days
+    'submitted' => 2.days,
+    'approved' => 5.days
   }.freeze
 
   FULFILLMENT_TYPES = [

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -56,11 +56,13 @@ describe Api::GraphqlController, type: :request do
         order.update_attributes! state: Order::SUBMITTED
       end
       it 'approves the order' do
-        response = client.execute(mutation, approve_order_input)
-        expect(response.data.approve_order.order.id).to eq order.id.to_s
-        expect(response.data.approve_order.order.state).to eq 'APPROVED'
-        expect(response.data.approve_order.errors).to match []
-        expect(order.reload.state).to eq Order::APPROVED
+        expect do
+          response = client.execute(mutation, approve_order_input)
+          expect(response.data.approve_order.order.id).to eq order.id.to_s
+          expect(response.data.approve_order.order.state).to eq 'APPROVED'
+          expect(response.data.approve_order.errors).to match []
+          expect(order.reload.state).to eq Order::APPROVED
+        end.to change(order, :state_expires_at)
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Order, type: :model do
       order.submit!
       order.save!
       submitted_timestamp = order.state_updated_at
-      order.approve!
+      order.reject!
       order.save!
       expect(order.state_updated_at).not_to eq submitted_timestamp
       expect(order.state_expires_at).to be_nil


### PR DESCRIPTION
# Problem
After approving an order, `state_expires_at` timestamp doesn't get updated properly and it becomes nil.
fixes #69 

# Cause
In the state expiry setting we didn't have approved since we didn't know whats the expiration rule.

# Solution
Set expiry for 5 days for _approved_.