### PR TITLE
Fetch Stripe credit card ID from Gravity on order submit

### DIFF
--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -4,9 +4,21 @@ module OrderSubmitService
     Order.transaction do
       # verify price change?
       order.submit!
+
       merchant_account = get_merchant_account(order)
       raise Errors::OrderError, 'Partner does not have merchant account' if merchant_account.nil?
-      charge = PaymentService.authorize_charge(order.credit_card_id, merchant_account[:external_id], order.buyer_total_cents, order.currency_code)
+
+      credit_card = get_credit_card(order)
+      raise Errors::OrderError, 'User does not have stored credit card' if credit_card.blank?
+
+      charge_params = {
+        source_id: credit_card[:external_id],
+        customer_id: credit_card[:customer_account][:external_id],
+        destination_id: merchant_account[:external_id],
+        amount: order.buyer_total_cents,
+        currency_code: order.currency_code
+      }
+      charge = PaymentService.authorize_charge(charge_params)
       TransactionService.create_success!(order, charge)
       order.save!
     end
@@ -18,6 +30,10 @@ module OrderSubmitService
 
   def self.get_merchant_account(order)
     Adapters::GravityV1.request("/merchant_accounts?partner_id=#{order.partner_id}").first
+  end
+
+  def self.get_credit_card(order)
+    Adapters::GravityV1.request("/credit_card/#{order.credit_card_id}")
   end
 
   def self.can_submit?(order)

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,10 +1,11 @@
 module PaymentService
-  def self.authorize_charge(source_id, destination_id, amount, currency_code)
+  def self.authorize_charge(source_id:, customer_id:, destination_id:, amount:, currency_code:)
     Stripe::Charge.create(
       amount: amount,
       currency: currency_code,
       description: 'Artsy',
       source: source_id,
+      customer: customer_id,
       destination: destination_id,
       capture: false
     )

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -79,6 +79,8 @@ describe Api::GraphqlController, type: :request do
           order.update_attributes! state: Order::APPROVED
         end
         it 'returns error' do
+          allow(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
+          allow(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.errors).to include 'Invalid action on this approved order'
           expect(order.reload.state).to eq Order::APPROVED

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -6,6 +6,7 @@ describe Api::GraphqlController, type: :request do
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
+    let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'ma-1' } } }
     let(:merchant_account) { { external_id: 'ma-1' } }
     let(:order) do
       Fabricate(
@@ -88,6 +89,7 @@ describe Api::GraphqlController, type: :request do
         allow(PaymentService).to receive(:authorize_charge)
         allow(TransactionService).to receive(:create_success!)
         allow(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
+        allow(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)
         response = client.execute(mutation, submit_order_input)
         expect(response.data.submit_order.order.id).to eq order.id.to_s
         expect(response.data.submit_order.order.state).to eq 'SUBMITTED'

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -3,24 +3,34 @@ require 'support/gravity_helper'
 
 describe OrderSubmitService, type: :services do
   let(:order) { Fabricate(:order, credit_card_id: 'cc-1', fulfillment_type: Order::PICKUP) }
-  let(:credit_card_id) { 'cc-1' }
+  let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' } } }
   let(:merchant_account_id) { 'ma-1' }
   let(:charge_success) { { id: 'ch-1' } }
   let(:charge_failure) { { failure_message: 'some_error' } }
   let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
+  let(:authorize_charge_params) do
+    {
+      source_id: credit_card[:external_id],
+      destination_id: merchant_account_id,
+      customer_id: credit_card[:customer_account][:external_id],
+      amount: order.buyer_total_cents,
+      currency_code: order.currency_code
+    }
+  end
 
   describe '#submit!' do
     context 'with a partner with a merchant account' do
       context 'with a successful transaction' do
         before(:each) do
           allow(OrderSubmitService).to receive(:get_merchant_account).with(order).and_return(partner_merchant_accounts.first)
-          allow(PaymentService).to receive(:authorize_charge).with(credit_card_id, merchant_account_id, order.buyer_total_cents, order.currency_code).and_return(charge_success)
+          allow(OrderSubmitService).to receive(:get_credit_card).with(order).and_return(credit_card)
+          allow(PaymentService).to receive(:authorize_charge).with(authorize_charge_params).and_return(charge_success)
           allow(TransactionService).to receive(:create_success!).with(order, charge_success)
           OrderSubmitService.submit!(order)
         end
 
         it 'authorizes a charge for the full amount of the order' do
-          expect(PaymentService).to have_received(:authorize_charge).with(credit_card_id, merchant_account_id, order.buyer_total_cents, order.currency_code)
+          expect(PaymentService).to have_received(:authorize_charge).with(authorize_charge_params)
         end
 
         it 'creates a record of the transaction' do
@@ -40,7 +50,8 @@ describe OrderSubmitService, type: :services do
       context 'with an unsuccessful transaction' do
         it 'creates a record of the transaction' do
           allow(OrderSubmitService).to receive(:get_merchant_account).with(order).and_return(partner_merchant_accounts.first)
-          allow(PaymentService).to receive(:authorize_charge).with(credit_card_id, merchant_account_id, order.buyer_total_cents, order.currency_code).and_raise(Errors::PaymentError.new('some_error', charge_failure))
+          allow(OrderSubmitService).to receive(:get_credit_card).with(order).and_return(credit_card)
+          allow(PaymentService).to receive(:authorize_charge).with(authorize_charge_params).and_raise(Errors::PaymentError.new('some_error', charge_failure))
           allow(TransactionService).to receive(:create_failure!).with(order, charge_failure)
           expect { OrderSubmitService.submit!(order) }.to raise_error(Errors::PaymentError)
           expect(TransactionService).to have_received(:create_failure!).with(order, charge_failure)
@@ -74,6 +85,14 @@ describe OrderSubmitService, type: :services do
       allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return([])
       result = OrderSubmitService.get_merchant_account(order)
       expect(result).to be(nil)
+    end
+  end
+
+  describe '#get_credit_card' do
+    it 'calls the /credit_card Gravity endpoint' do
+      allow(Adapters::GravityV1).to receive(:request).with("/credit_card/#{order.credit_card_id}")
+      OrderSubmitService.get_credit_card(order)
+      expect(Adapters::GravityV1).to have_received(:request).with("/credit_card/#{order.credit_card_id}")
     end
   end
 end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -2,17 +2,25 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe PaymentService, type: :services do
-  let(:credit_card_id) { 'cc-1' }
-  let(:merchant_account_id) { 'ma-1' }
+  let(:source_id) { 'cc-1' }
+  let(:destination_id) { 'ma-1' }
+  let(:customer_id) { 'cust-1' }
   let(:currency_code) { 'usd' }
   let(:charge_amount) { 2222 }
-  let(:authorize_charge_params) { { amount: charge_amount, currency: currency_code, description: 'Artsy', source: credit_card_id, destination: merchant_account_id, capture: false } }
+  let(:authorize_charge_params) { { amount: charge_amount, currency: currency_code, description: 'Artsy', source: source_id, customer: customer_id, destination: destination_id, capture: false } }
   let(:charge) { { id: 'ch_22' } }
 
   describe '#authorize_charge' do
     it "authorizes a charge on the user's credit card" do
       allow(Stripe::Charge).to receive(:create).with(authorize_charge_params).and_return(charge)
-      PaymentService.authorize_charge(credit_card_id, merchant_account_id, charge_amount, currency_code)
+      params = {
+        source_id: source_id,
+        customer_id: customer_id,
+        destination_id: destination_id,
+        currency_code: currency_code,
+        amount: charge_amount
+      }
+      PaymentService.authorize_charge(params)
       expect(Stripe::Charge).to have_received(:create).with(authorize_charge_params)
     end
   end


### PR DESCRIPTION
**Before**: The supplied `credit_card_id` from `setPayment` mutation was passed directly to the Stripe charge object as the `source`.

**With these changes**: The supplied `credit_card_id` is used to look up the user's Stripe credit card ID in Gravity, which is then passed to the charge object as the `source`.

**What changed**:
- Fetches buyer's Stripe credit card ID from Gravity using supplied `credit_card_id` on order submit and uses in transaction
- Adds `customer_id` to Stripe charge object since we need to use it for saved credit cards
- Refactors `PaymentService.authorize_charge` to use keyword arguments as parameters