### PR TITLE
Add `external_charge_id` to Order model and save on order submit

### DIFF
--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -20,6 +20,7 @@ module OrderSubmitService
     Order.transaction do
       order.submit!
       charge = PaymentService.authorize_charge(charge_params)
+      order.external_charge_id = charge[:id]
       TransactionService.create_success!(order, charge)
       order.save!
     end

--- a/db/migrate/20180719184045_add_external_charge_id_to_orders.rb
+++ b/db/migrate/20180719184045_add_external_charge_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddExternalChargeIdToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :external_charge_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_18_174508) do
+ActiveRecord::Schema.define(version: 2018_07_19_184045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2018_07_18_174508) do
     t.string "shipping_postal_code"
     t.string "fulfillment_type"
     t.string "shipping_region"
+    t.string "external_charge_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -8,6 +8,7 @@ describe Api::GraphqlController, type: :request do
     let(:credit_card_id) { 'cc-1' }
     let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'ma-1' } } }
     let(:merchant_account) { { external_id: 'ma-1' } }
+    let(:charge_success) { { id: 'ch-1' } }
     let(:order) do
       Fabricate(
         :order,
@@ -88,7 +89,7 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'submits the order' do
-        allow(PaymentService).to receive(:authorize_charge)
+        allow(PaymentService).to receive(:authorize_charge).and_return(charge_success)
         allow(TransactionService).to receive(:create_success!)
         allow(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
         allow(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -45,6 +45,10 @@ describe OrderSubmitService, type: :services do
           expect(order.state).to eq Order::SUBMITTED
           expect(order.state_updated_at).not_to be_nil
         end
+
+        it 'updates external_charge_id with the id of the charge' do
+          expect(order.external_charge_id).to eq(charge_success[:id])
+        end
       end
 
       context 'with an unsuccessful transaction' do


### PR DESCRIPTION
### Before
We would authorize a charge and save the transaction on order submit but not store the charge id on the order model itself. Since an order may have multiple charges, we would have to decide which transaction ought to be captured in order to complete the order.

### With these changes
The order model now contains an `external_charge_id` field that stores the Stripe charge id of the charge created on submitting an order. This allows us to easily retrieve it later when we want to capture the charge.

### What changed
- Adds `external_charge_id` string field to `orders` table
- Saves Stripe charge id to `external_charge_id` on successful submission of an order.