### PR TITLE
Capture charge on order approval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'graphlient'
   gem 'rspec-rails'
   gem 'rubocop'
+  gem 'stripe-ruby-mock', '~> 2.5.4', :require => 'stripe_mock'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :development, :test do
   gem 'graphlient'
   gem 'rspec-rails'
   gem 'rubocop'
-  gem 'stripe-ruby-mock', '~> 2.5.4', require: 'stripe_mock'
 end
 
 group :development do
@@ -28,4 +27,5 @@ end
 
 group :test do
   gem 'fabrication'
+  gem 'stripe-ruby-mock', '~> 2.5.4', require: 'stripe_mock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'graphlient'
   gem 'rspec-rails'
   gem 'rubocop'
-  gem 'stripe-ruby-mock', '~> 2.5.4', :require => 'stripe_mock'
+  gem 'stripe-ruby-mock', '~> 2.5.4', require: 'stripe_mock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crass (1.0.4)
+    dante (0.2.0)
     diff-lcs (1.3)
     erubi (1.7.1)
     fabrication (2.20.1)
@@ -88,6 +89,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.8.3)
@@ -181,6 +183,10 @@ GEM
       sprockets (>= 3.0.0)
     stripe (3.17.0)
       faraday (~> 0.10)
+    stripe-ruby-mock (2.5.4)
+      dante (>= 0.2.0)
+      multi_json (~> 1.0)
+      stripe (>= 2.0.3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -209,6 +215,7 @@ DEPENDENCIES
   rubocop
   sidekiq
   stripe
+  stripe-ruby-mock (~> 2.5.4)
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,3 +1,8 @@
 class Transaction < ApplicationRecord
   belongs_to :order
+
+  TYPES = [
+    HOLD = 'hold'.freeze,
+    CAPTURE = 'capture'.freeze
+  ].freeze
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -35,6 +35,7 @@ module OrderService
     order
   rescue Errors::PaymentError => e
     TransactionService.create_failure!(order, e.body)
+    Rails.logger.error("Could not approve order #{order.id}: #{e.message}")
     raise e
   end
 

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -28,17 +28,20 @@ module OrderService
   def self.approve!(order)
     Order.transaction do
       order.approve!
+      charge = PaymentService.capture_charge(order.external_charge_id)
+      TransactionService.create_success!(order, charge)
       order.save!
-      # TODO: process the charge by calling gravity with current credit_card_id and price
     end
     order
+  rescue Errors::PaymentError => e
+    TransactionService.create_failure!(order, e.body)
+    raise e
   end
 
   def self.finalize!(order)
     Order.transaction do
       order.finalize!
       order.save!
-      # TODO: process the charge by calling gravity with current credit_card_id and price
     end
     order
   end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -27,6 +27,7 @@ module OrderSubmitService
     order
   rescue Errors::PaymentError => e
     TransactionService.create_failure!(order, e.body)
+    Rails.logger.error("Could not submit order #{order.id}: #{e.message}")
     raise e
   end
 

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -9,7 +9,7 @@ module PaymentService
       destination: destination_id,
       capture: false
     )
-    charge.transaction_type = 'hold'
+    charge.transaction_type = Transaction::HOLD
     charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
@@ -20,7 +20,7 @@ module PaymentService
       destination_id: destination_id,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: 'hold'
+      transaction_type: Transaction::HOLD
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
@@ -28,7 +28,7 @@ module PaymentService
   def self.capture_charge(charge_id)
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
-    charge.transaction_type = 'capture'
+    charge.transaction_type = Transaction::CAPTURE
     charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
@@ -36,7 +36,7 @@ module PaymentService
       id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: 'capture'
+      transaction_type: Transaction::CAPTURE
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,6 +1,6 @@
 module PaymentService
   def self.authorize_charge(source_id:, customer_id:, destination_id:, amount:, currency_code:)
-    Stripe::Charge.create(
+    charge = Stripe::Charge.create(
       amount: amount,
       currency: currency_code,
       description: 'Artsy',
@@ -9,6 +9,8 @@ module PaymentService
       destination: destination_id,
       capture: false
     )
+    charge.transaction_type = 'hold'
+    return charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {
@@ -17,7 +19,8 @@ module PaymentService
       source_id: source_id,
       destination_id: destination_id,
       failure_code: body[:code],
-      failure_message: body[:message]
+      failure_message: body[:message],
+      transaction_type: 'hold'
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
@@ -25,12 +28,15 @@ module PaymentService
   def self.capture_charge(charge_id)
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
+    charge.transaction_type = 'capture'
+    return charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {
       id: charge_id,
       failure_code: body[:code],
-      failure_message: body[:message]
+      failure_message: body[:message],
+      transaction_type: 'capture'
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -28,10 +28,7 @@ module PaymentService
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {
-      amount: nil,
-      id: nil,
-      source_id: nil,
-      destination_id: nil,
+      id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message]
     }

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -10,7 +10,7 @@ module PaymentService
       capture: false
     )
     charge.transaction_type = 'hold'
-    return charge
+    charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {
@@ -29,7 +29,7 @@ module PaymentService
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
     charge.transaction_type = 'capture'
-    return charge
+    charge
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -21,4 +21,20 @@ module PaymentService
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
+
+  def self.capture_charge(charge_id)
+    charge = Stripe::Charge.retrieve(charge_id)
+    charge.capture
+  rescue Stripe::StripeError => e
+    body = e.json_body[:error]
+    failed_charge = {
+      amount: nil,
+      id: nil,
+      source_id: nil,
+      destination_id: nil,
+      failure_code: body[:code],
+      failure_message: body[:message]
+    }
+    raise Errors::PaymentError.new(e.message, failed_charge)
+  end
 end

--- a/app/services/transaction_service.rb
+++ b/app/services/transaction_service.rb
@@ -7,7 +7,7 @@ module TransactionService
       amount_cents: error[:amount],
       failure_code: error[:failure_code],
       failure_message: error[:failure_message],
-      captured: false,
+      transaction_type: error[:transaction_type],
       status: 'failure'
     )
   end
@@ -20,7 +20,7 @@ module TransactionService
       amount_cents: charge.amount,
       failure_code: charge.failure_code,
       failure_message: charge.failure_message,
-      captured: charge.captured,
+      transaction_type: charge.transaction_type,
       status: 'success'
     )
   end

--- a/app/services/transaction_service.rb
+++ b/app/services/transaction_service.rb
@@ -7,6 +7,7 @@ module TransactionService
       amount_cents: error[:amount],
       failure_code: error[:failure_code],
       failure_message: error[:failure_message],
+      captured: false,
       status: 'failure'
     )
   end
@@ -19,6 +20,7 @@ module TransactionService
       amount_cents: charge.amount,
       failure_code: charge.failure_code,
       failure_message: charge.failure_message,
+      captured: charge.captured,
       status: 'success'
     )
   end

--- a/db/migrate/20180719203953_add_captured_to_transactions.rb
+++ b/db/migrate/20180719203953_add_captured_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddCapturedToTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transactions, :captured, :boolean
+  end
+end

--- a/db/migrate/20180719203953_add_captured_to_transactions.rb
+++ b/db/migrate/20180719203953_add_captured_to_transactions.rb
@@ -1,5 +1,0 @@
-class AddCapturedToTransactions < ActiveRecord::Migration[5.2]
-  def change
-    add_column :transactions, :captured, :boolean
-  end
-end

--- a/db/migrate/20180723192428_add_transaction_type_to_transactions.rb
+++ b/db/migrate/20180723192428_add_transaction_type_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddTransactionTypeToTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transactions, :transaction_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_20_205337) do
+ActiveRecord::Schema.define(version: 2018_07_23_192428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2018_07_20_205337) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "transaction_type"
     t.index ["order_id"], name: "index_transactions_on_order_id"
   end
 

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -57,15 +57,15 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      let(:uncaptured_charge) {
+      let(:uncaptured_charge) do
         Stripe::Charge.create(
-          amount: 22222,
+          amount: 22_222,
           currency: 'usd',
           source: stripe_helper.generate_card_token,
           destination: 'ma-1',
           capture: false
         )
-      }
+      end
       before do
         order.update_attributes! state: Order::SUBMITTED
         order.update_attributes! external_charge_id: uncaptured_charge.id

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -67,7 +67,7 @@ describe Api::GraphqlController, type: :request do
           expect(response.data.approve_order.errors).to match []
           expect(order.reload.state).to eq Order::APPROVED
           expect(order.reload.transactions.last.external_id).to eq uncaptured_charge.id
-          expect(order.reload.transactions.last.transaction_type).to eq 'capture'
+          expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
         end.to change(order, :state_expires_at)
       end
     end

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -78,7 +78,7 @@ describe Api::GraphqlController, type: :request do
           expect(response.data.approve_order.errors).to match []
           expect(order.reload.state).to eq Order::APPROVED
           expect(order.reload.transactions.last.external_id).to eq uncaptured_charge.id
-          expect(order.reload.transactions.last.captured).to eq(true)
+          expect(order.reload.transactions.last.transaction_type).to eq 'capture'
         end.to change(order, :state_expires_at)
       end
     end

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
-require 'stripe_mock'
+require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
-  let(:stripe_helper) { StripeMock.create_test_helper }
-  before { StripeMock.start }
-  after { StripeMock.stop }
+  include_context 'use stripe mock'
 
   describe 'approve_order mutation' do
     include_context 'GraphQL Client'
@@ -57,15 +55,6 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      let(:uncaptured_charge) do
-        Stripe::Charge.create(
-          amount: 22_222,
-          currency: 'usd',
-          source: stripe_helper.generate_card_token,
-          destination: 'ma-1',
-          capture: false
-        )
-      end
       before do
         order.update_attributes! state: Order::SUBMITTED
         order.update_attributes! external_charge_id: uncaptured_charge.id

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -108,7 +108,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.state_updated_at).not_to be_nil
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
         expect(order.reload.transactions.last.external_id).not_to be_nil
-        expect(order.reload.transactions.last.transaction_type).to eq('hold')
+        expect(order.reload.transactions.last.transaction_type).to eq Transaction::HOLD
       end
     end
   end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
+require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
   describe 'submit_order mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'ma-1' } } }
     let(:merchant_account) { { external_id: 'ma-1' } }
-    let(:charge_success) { { id: 'ch-1' } }
+    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
     let(:order) do
       Fabricate(
         :order,
@@ -22,6 +23,9 @@ describe Api::GraphqlController, type: :request do
         shipping_country: 'IR',
         fulfillment_type: Order::SHIP
       )
+    end
+    let(:line_item) do
+      Fabricate(:line_item, order: order)
     end
 
     let(:mutation) do
@@ -47,6 +51,11 @@ describe Api::GraphqlController, type: :request do
         }
       }
     end
+
+    before do
+      order.line_items << line_item
+    end
+
     context 'with user without permission to this order' do
       let(:user_id) { 'random-user-id-on-another-order' }
       it 'returns permission error' do
@@ -89,8 +98,6 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'submits the order' do
-        allow(PaymentService).to receive(:authorize_charge).and_return(charge_success)
-        allow(TransactionService).to receive(:create_success!)
         allow(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
         allow(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)
         response = client.execute(mutation, submit_order_input)
@@ -100,6 +107,8 @@ describe Api::GraphqlController, type: :request do
         expect(order.reload.state).to eq Order::SUBMITTED
         expect(order.state_updated_at).not_to be_nil
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+        expect(order.reload.transactions.last.external_id).not_to be_nil
+        expect(order.reload.transactions.last.transaction_type).to eq('hold')
       end
     end
   end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -12,10 +12,12 @@ describe PaymentService, type: :services do
   let(:charge_amount) { 2222 }
 
   describe '#authorize_charge' do
-    let(:stripe_customer) { Stripe::Customer.create({
-      email: 'someuser@email.com',
-      source: stripe_helper.generate_card_token
-    }) }
+    let(:stripe_customer) do
+      Stripe::Customer.create(
+        email: 'someuser@email.com',
+        source: stripe_helper.generate_card_token
+      )
+    end
 
     it "authorizes a charge on the user's credit card" do
       params = {
@@ -43,7 +45,7 @@ describe PaymentService, type: :services do
         currency_code: currency_code,
         amount: charge_amount
       }
-      expect { PaymentService.authorize_charge(params) }.to raise_error {|e| 
+      expect { PaymentService.authorize_charge(params) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
         expect(e.body[:amount]).to eq charge_amount
@@ -51,12 +53,12 @@ describe PaymentService, type: :services do
         expect(e.body[:destination_id]).to eq destination_id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
-      }
+      end)
     end
   end
 
   describe '#capture_charge' do
-    let(:uncaptured_charge) {
+    let(:uncaptured_charge) do
       Stripe::Charge.create(
         amount: charge_amount,
         currency: currency_code,
@@ -65,20 +67,20 @@ describe PaymentService, type: :services do
         description: 'Artsy',
         capture: false
       )
-    }
+    end
     it 'captures a charge' do
       captured_charge = PaymentService.capture_charge(uncaptured_charge.id)
       expect(captured_charge.captured).to eq(true)
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :capture_charge)
-      expect { PaymentService.capture_charge(uncaptured_charge.id) }.to raise_error {|e| 
+      expect { PaymentService.capture_charge(uncaptured_charge.id) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
         expect(e.body[:id]).to eq uncaptured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
-      }
+      end)
     end
   end
 end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -26,7 +26,7 @@ describe PaymentService, type: :services do
       expect(charge.currency).to eq(currency_code)
       expect(charge.description).to eq('Artsy')
       expect(charge.captured).to eq(false)
-      expect(charge.transaction_type).to eq('hold')
+      expect(charge.transaction_type).to eq Transaction::HOLD
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
@@ -45,7 +45,7 @@ describe PaymentService, type: :services do
         expect(e.body[:destination_id]).to eq destination_id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq 'hold'
+        expect(e.body[:transaction_type]).to eq Transaction::HOLD
       end)
     end
   end
@@ -54,7 +54,7 @@ describe PaymentService, type: :services do
     it 'captures a charge' do
       captured_charge = PaymentService.capture_charge(uncaptured_charge.id)
       expect(captured_charge.captured).to eq(true)
-      expect(captured_charge.transaction_type).to eq('capture')
+      expect(captured_charge.transaction_type).to eq Transaction::CAPTURE
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :capture_charge)
@@ -64,7 +64,7 @@ describe PaymentService, type: :services do
         expect(e.body[:id]).to eq uncaptured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq 'capture'
+        expect(e.body[:transaction_type]).to eq Transaction::CAPTURE
       end)
     end
   end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -35,6 +35,7 @@ describe PaymentService, type: :services do
       expect(charge.currency).to eq(currency_code)
       expect(charge.description).to eq('Artsy')
       expect(charge.captured).to eq(false)
+      expect(charge.transaction_type).to eq('hold')
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
@@ -53,6 +54,7 @@ describe PaymentService, type: :services do
         expect(e.body[:destination_id]).to eq destination_id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
+        expect(e.body[:transaction_type]).to eq 'hold'
       end)
     end
   end
@@ -71,6 +73,7 @@ describe PaymentService, type: :services do
     it 'captures a charge' do
       captured_charge = PaymentService.capture_charge(uncaptured_charge.id)
       expect(captured_charge.captured).to eq(true)
+      expect(captured_charge.transaction_type).to eq('capture')
     end
     it 'catches Stripe errors and raises a PaymentError in its place' do
       StripeMock.prepare_card_error(:card_declined, :capture_charge)
@@ -80,6 +83,7 @@ describe PaymentService, type: :services do
         expect(e.body[:id]).to eq uncaptured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
+        expect(e.body[:transaction_type]).to eq 'capture'
       end)
     end
   end

--- a/spec/support/use_stripe_mock.rb
+++ b/spec/support/use_stripe_mock.rb
@@ -19,7 +19,6 @@ RSpec.shared_context 'use stripe mock' do
       capture: false
     )
   end
-
 end
 
 RSpec.configure do |rspec|

--- a/spec/support/use_stripe_mock.rb
+++ b/spec/support/use_stripe_mock.rb
@@ -1,0 +1,27 @@
+require 'stripe_mock'
+
+RSpec.shared_context 'use stripe mock' do
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  before { StripeMock.start }
+  after { StripeMock.stop }
+  let(:stripe_customer) do
+    Stripe::Customer.create(
+      email: 'someuser@email.com',
+      source: stripe_helper.generate_card_token
+    )
+  end
+  let(:uncaptured_charge) do
+    Stripe::Charge.create(
+      amount: 22_222,
+      currency: 'usd',
+      source: stripe_helper.generate_card_token,
+      destination: 'ma-1',
+      capture: false
+    )
+  end
+
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context 'use stripe mock', include_shared: true
+end


### PR DESCRIPTION
- Adds `PaymentService.capture_charge`, which retrieves a Stripe charge by id and captures it.
- Captures charge on order approval and records the successful (or failed) transaction.
- Adds Boolean `captured` column to `orders` to differentiate between captured and uncaptured charges.
- Adds `stripe-ruby-mock` to dependencies and refactors some tests to use mocked Stripe calls.

### Code Review Changes

- [x] Change `captured` Boolean to `type` to describe what kind of transaction it is
- [x] Create shared context for Stripe tests
- [x] Add logging statements for failed charges