### PR TITLE
Add more careful error handling for fetching credit card and merchant account

### DIFF
--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -33,8 +33,9 @@ module OrderSubmitService
     merchant_account = Adapters::GravityV1.request("/merchant_accounts?partner_id=#{order.partner_id}").first
     raise Errors::OrderError, 'Partner does not have merchant account' if merchant_account.nil?
     merchant_account
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Unable to find partner or merchant account'
   rescue Adapters::GravityError => e
-    raise Errors::OrderError, 'Unable to find partner or merchant account' if e.status == 404
     raise Errors::OrderError, e.message
   end
 
@@ -42,8 +43,9 @@ module OrderSubmitService
     credit_card = Adapters::GravityV1.request("/credit_card/#{order.credit_card_id}")
     validate_credit_card(credit_card)
     credit_card
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Credit card not found'
   rescue Adapters::GravityError => e
-    raise Errors::OrderError, 'Credit card not found' if e.status == 404
     raise Errors::OrderError, e.message
   end
 

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -1,18 +1,14 @@
 module Adapters
-  class GravityError < StandardError
-    attr_reader :message, :status
-    def initialize(message, status = nil)
-      @message = message
-      @status = status
-    end
-  end
+  class GravityError < StandardError; end
+  class GravityNotFoundError < GravityError; end
   class GravityV1
     def self.request(url)
       url = "#{Rails.application.config_for(:gravity)['api_v1_root']}#{url}"
       response = Faraday.get(url, {}, headers)
-      raise GravityError.new("couldn't perform request! Response was #{response.status}.", response.status) unless response.success?
+      raise GravityNotFoundError if response.status == 404
+      raise GravityError, "couldn't perform request! Response was #{response.status}." unless response.success?
       JSON.parse(response.body, symbolize_names: true)
-    rescue GravityError => e
+    rescue GravityNotFoundError => e
       raise e
     rescue StandardError => e
       raise GravityError, e.message

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -1,12 +1,19 @@
 module Adapters
   class GravityError < StandardError
+    attr_reader :message, :status
+    def initialize(message, status = nil)
+      @message = message
+      @status = status
+    end
   end
   class GravityV1
     def self.request(url)
       url = "#{Rails.application.config_for(:gravity)['api_v1_root']}#{url}"
       response = Faraday.get(url, {}, headers)
-      raise GravityError, "couldn't perform request! Response was #{response.status}." unless response.success?
+      raise GravityError.new("couldn't perform request! Response was #{response.status}.", response.status) unless response.success?
       JSON.parse(response.body, symbolize_names: true)
+    rescue GravityError => e
+      raise e
     rescue StandardError => e
       raise GravityError, e.message
     end


### PR DESCRIPTION
- Modifies `get_merchant_account` and `get_credit_card` to rescue `GravityError`s. If the error is a 404 raises a more informative error message.
- Checks that credit cards are not deactivated
- Moves merchant account / credit card data validation to `get_merchant_account` and `validate_credit_card` methods
- Adds `status` to `GravityError`