### PR TITLE
Expose Gravity's credit card id

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -6,6 +6,7 @@ class Types::OrderType < Types::BaseObject
   field :code, String, null: false
   field :user_id, String, null: false
   field :partner_id, String, null: false
+  field :credit_card_id, String, null: true
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
   field :shipping_address_line1, String, null: true

--- a/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
@@ -5,7 +5,7 @@ describe Api::GraphqlController, type: :request do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
-    let(:credit_card_id) { 'cc-1' }
+    let(:credit_card_id) { 'gravity-cc-1' }
     let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
 
     let(:mutation) do
@@ -17,6 +17,7 @@ describe Api::GraphqlController, type: :request do
               userId
               partnerId
               state
+              creditCardId
             }
             errors
           }
@@ -57,6 +58,7 @@ describe Api::GraphqlController, type: :request do
         response = client.execute(mutation, set_payment_input)
         expect(response.data.set_payment.order.id).to eq order.id.to_s
         expect(response.data.set_payment.order.state).to eq 'PENDING'
+        expect(response.data.set_payment.order.credit_card_id).to eq 'gravity-cc-1'
         expect(response.data.set_payment.errors).to match []
         expect(order.reload.credit_card_id).to eq credit_card_id
         expect(order.state).to eq Order::PENDING


### PR DESCRIPTION
# Problem
We want to be able to show last 4 digits and expiration on confirmation page and somewhere in CMS.

# Solution
Expose `creditCardId` from Exchange so we can resolve it later in MP to actual details.

# Follow up
Update MP's schema with this change.