### PR TITLE
Limit access to fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Rails/NotNullColumn:
 
 Style/AsciiComments:
   Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,0 +1,27 @@
+class Types::BaseField < GraphQL::Schema::Field
+  def initialize(buyer_only: false, seller_only: false, **kwargs, &block)
+    @buyer_only = buyer_only
+    @seller_only = seller_only
+    super(**kwargs, &block)
+  end
+
+  def authorized?(obj, ctx)
+    case obj
+    when Order then order_field_authorized?(obj, ctx[:current_user])
+    else
+      super
+    end
+  end
+
+  private
+
+  def order_field_authorized?(obj, current_user)
+    if @buyer_only && current_user['id'] != obj.user_id
+      false
+    elsif @seller_only && !current_user[:partner_ids].include?(obj.partner_id)
+      false
+    else
+      true
+    end
+  end
+end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -16,12 +16,8 @@ class Types::BaseField < GraphQL::Schema::Field
   private
 
   def order_field_authorized?(obj, current_user)
-    if @buyer_only && current_user['id'] != obj.user_id
-      false
-    elsif @seller_only && !current_user[:partner_ids].include?(obj.partner_id)
-      false
-    else
-      true
-    end
+    return current_user[:id] == obj.user_id if @buyer_only
+    return current_user[:partner_ids].include?(obj.partner_id) if @seller_only
+    true
   end
 end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,2 +1,3 @@
 class Types::BaseObject < GraphQL::Schema::Object
+  field_class Types::BaseField
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -19,10 +19,10 @@ class Types::OrderType < Types::BaseObject
   field :items_total_cents, Integer, null: false
   field :shipping_total_cents, Integer, null: true
   field :tax_total_cents, Integer, null: true
-  field :transaction_fee_cents, Integer, null: true
-  field :commission_fee_cents, Integer, null: true
-  field :buyer_total_cents, Integer, null: true
-  field :seller_total_cents, Integer, null: true
+  field :transaction_fee_cents, Integer, null: true, seller_only: true
+  field :commission_fee_cents, Integer, null: true, seller_only: true
+  field :seller_total_cents, Integer, null: true, seller_only: true
+  field :buyer_total_cents, Integer, null: true, buyer_only: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :state_updated_at, Types::DateTimeType, null: true

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -22,7 +22,7 @@ class Types::OrderType < Types::BaseObject
   field :transaction_fee_cents, Integer, null: true, seller_only: true
   field :commission_fee_cents, Integer, null: true, seller_only: true
   field :seller_total_cents, Integer, null: true, seller_only: true
-  field :buyer_total_cents, Integer, null: true, buyer_only: true
+  field :buyer_total_cents, Integer, null: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :state_updated_at, Types::DateTimeType, null: true

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -67,7 +67,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.user_id).to eq jwt_user_id
               expect(order.partner_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 540_012
+              expect(order.line_items.first.price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 2
@@ -86,7 +86,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.user_id).to eq jwt_user_id
               expect(order.partner_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 420_042
+              expect(order.line_items.first.price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
               expect(order.line_items.first.quantity).to eq 2
@@ -105,7 +105,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.user_id).to eq jwt_user_id
               expect(order.partner_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 540_012
+              expect(order.line_items.first.price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 1

--- a/spec/controllers/api/requests/order_field_permissions_spec.rb
+++ b/spec/controllers/api/requests/order_field_permissions_spec.rb
@@ -47,7 +47,7 @@ describe Api::GraphqlController, type: :request do
           }
         GRAPHQL
       end
-      it 'returns nil for seller_only fields' do
+      it 'returns nil for buyer_only fields' do
         result = client.execute(order_query_with_buyer_fields, id: order.id)
         expect(result.data.order.buyer_total_cents).to be_nil
         expect(result.data.order.seller_total_cents).to eq 1050_00

--- a/spec/controllers/api/requests/order_field_permissions_spec.rb
+++ b/spec/controllers/api/requests/order_field_permissions_spec.rb
@@ -47,9 +47,9 @@ describe Api::GraphqlController, type: :request do
           }
         GRAPHQL
       end
-      it 'returns nil for buyer_only fields' do
+      it 'returns seller_only fields' do
         result = client.execute(order_query_with_buyer_fields, id: order.id)
-        expect(result.data.order.buyer_total_cents).to be_nil
+        expect(result.data.order.buyer_total_cents).to eq 1100_00
         expect(result.data.order.seller_total_cents).to eq 1050_00
         expect(result.data.order.commission_fee_cents).to eq 30_00
       end

--- a/spec/controllers/api/requests/order_field_permissions_spec.rb
+++ b/spec/controllers/api/requests/order_field_permissions_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'order query field permissions' do
+    include_context 'GraphQL Client'
+    let(:partner_id) { 'partner-1' }
+    let(:user_id) { 'user-i' }
+    let!(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id, updated_at: 1.day.ago, shipping_total_cents: 100_00, commission_fee_cents: 30_00, transaction_fee_cents: 20_00) }
+    let!(:line_item) { Fabricate(:line_item, price_cents: 1000_00, order: order) }
+    context 'as buyer' do
+      let(:jwt_partner_ids) { [] }
+      let(:jwt_user_id) { user_id }
+      let(:order_query_with_seller_fields) do
+        <<-GRAPHQL
+          query($id: ID!) {
+            order(id: $id) {
+              id
+              commissionFeeCents
+              transactionFeeCents
+              sellerTotalCents
+              buyerTotalCents
+            }
+          }
+        GRAPHQL
+      end
+      it 'returns nil for seller_only fields' do
+        result = client.execute(order_query_with_seller_fields, id: order.id)
+        expect(result.data.order.commission_fee_cents).to be_nil
+        expect(result.data.order.transaction_fee_cents).to be_nil
+        expect(result.data.order.seller_total_cents).to be_nil
+        expect(result.data.order.buyer_total_cents).to eq 1100_00
+      end
+    end
+
+    context 'as seller' do
+      let(:jwt_user_id) { 'gallery-person-1' }
+      let(:jwt_partner_ids) { [partner_id] }
+      let(:order_query_with_buyer_fields) do
+        <<-GRAPHQL
+          query($id: ID!) {
+            order(id: $id) {
+              id
+              buyerTotalCents
+              commissionFeeCents
+              sellerTotalCents
+            }
+          }
+        GRAPHQL
+      end
+      it 'returns nil for seller_only fields' do
+        result = client.execute(order_query_with_buyer_fields, id: order.id)
+        expect(result.data.order.buyer_total_cents).to be_nil
+        expect(result.data.order.seller_total_cents).to eq 1050_00
+        expect(result.data.order.commission_fee_cents).to eq 30_00
+      end
+    end
+  end
+end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -73,8 +73,14 @@ describe Api::GraphqlController, type: :request do
           expect(result.data.order.currency_code).to eq 'usd'
           expect(result.data.order.state).to eq 'PENDING'
           expect(result.data.order.items_total_cents).to eq 0
-          expect(result.data.order.seller_total_cents).to eq user2_order1.seller_total_cents
-          expect(result.data.order.buyer_total_cents).to eq user2_order1.buyer_total_cents
+        end
+
+        it 'cannot access seller_only buyer_only fields' do
+          # TODO: we may want to change this logic later but for now not allowing
+          # those fields for trusted apps
+          result = client.execute(query, id: user2_order1.id)
+          expect(result.data.order.seller_total_cents).to be_nil
+          expect(result.data.order.buyer_total_cents).to be_nil
         end
       end
 

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -75,12 +75,11 @@ describe Api::GraphqlController, type: :request do
           expect(result.data.order.items_total_cents).to eq 0
         end
 
-        it 'cannot access seller_only buyer_only fields' do
+        it 'cannot access seller_only fields' do
           # TODO: we may want to change this logic later but for now not allowing
           # those fields for trusted apps
           result = client.execute(query, id: user2_order1.id)
           expect(result.data.order.seller_total_cents).to be_nil
-          expect(result.data.order.buyer_total_cents).to be_nil
         end
       end
 

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -26,7 +26,7 @@ describe Api::GraphqlController, type: :request do
       )
     end
     let(:line_item) do
-      Fabricate(:line_item, order: order, price_cents: 100_000)
+      Fabricate(:line_item, order: order, price_cents: 1000_00)
     end
 
     let(:mutation) do

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -16,7 +16,7 @@ describe CreateOrderService, type: :services do
             expect(order.user_id).to eq user_id
             expect(order.partner_id).to eq 'gravity-partner-id'
             expect(order.line_items.count).to eq 1
-            expect(order.line_items.first.price_cents).to eq 540_012
+            expect(order.line_items.first.price_cents).to eq 5400_12
             expect(order.line_items.first.artwork_id).to eq 'artwork-id'
             expect(order.line_items.first.edition_set_id).to be_nil
             expect(order.line_items.first.quantity).to eq 2
@@ -31,7 +31,7 @@ describe CreateOrderService, type: :services do
             expect(order.user_id).to eq user_id
             expect(order.partner_id).to eq 'gravity-partner-id'
             expect(order.line_items.count).to eq 1
-            expect(order.line_items.first.price_cents).to eq 420_042
+            expect(order.line_items.first.price_cents).to eq 4200_42
             expect(order.line_items.first.artwork_id).to eq 'artwork-id'
             expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
             expect(order.line_items.first.quantity).to eq 2
@@ -59,12 +59,12 @@ describe CreateOrderService, type: :services do
   describe '#artwork_price' do
     context 'for artwork' do
       it 'returns artwork price' do
-        expect(CreateOrderService.artwork_price(gravity_v1_artwork)).to eq 540_012
+        expect(CreateOrderService.artwork_price(gravity_v1_artwork)).to eq 5400_12
       end
     end
     context 'for edition set' do
       it 'returns edition_set_price for known edition set id' do
-        expect(CreateOrderService.artwork_price(gravity_v1_artwork, edition_set_id: 'edition-set-id')).to eq 420_042
+        expect(CreateOrderService.artwork_price(gravity_v1_artwork, edition_set_id: 'edition-set-id')).to eq 4200_42
       end
       it 'raises Errors::OrderError for unknown edition set id' do
         expect { CreateOrderService.artwork_price(gravity_v1_artwork, edition_set_id: 'random-id') }.to raise_error(Errors::OrderError, /Unknown edition set/)

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -4,7 +4,7 @@ require 'support/gravity_helper'
 describe OrderSubmitService, type: :services do
   let(:partner_id) { 'partner-1' }
   let(:order) { Fabricate(:order, partner_id: partner_id, credit_card_id: 'cc-1', fulfillment_type: Order::PICKUP) }
-  let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 200_000), Fabricate(:line_item, order: order, price_cents: 800_000)] }
+  let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 2000_00), Fabricate(:line_item, order: order, price_cents: 8000_00)] }
   let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' } } }
   let(:merchant_account_id) { 'ma-1' }
   let(:charge_success) { { id: 'ch-1' } }
@@ -54,7 +54,7 @@ describe OrderSubmitService, type: :services do
         end
 
         it 'sets commission_fee_cents' do
-          expect(order.commission_fee_cents).to eq 800_000
+          expect(order.commission_fee_cents).to eq 8000_00
         end
       end
 
@@ -113,7 +113,7 @@ describe OrderSubmitService, type: :services do
         stub_request(:get, %r{partner\/#{partner_id}/all}).to_return(status: 200, body: gravity_v1_partner.to_json)
       end
       it 'returns calculated commission fee' do
-        expect(OrderSubmitService.calculate_commission(order)).to eq 800_000.0
+        expect(OrderSubmitService.calculate_commission(order)).to eq 8000_00.0
       end
     end
     context 'with failed gravity call' do


### PR DESCRIPTION
# Problem
Current schema allows for clients to request all available fields, this is not the desired behavior since we don't want buyer to see seller specific fields like `transaction_fee_cents` and etc.

# Solution
Used GraphQL Ruby's [Authorization](http://graphql-ruby.org/authorization/authorization) approach. We added `BaseField` in which:
- We added `buyer_only` and `seller_only` attributes which can be set on field definition
```ruby
field :seller_total_cents, Integer, null: true, seller_only: true
field :buyer_total_cents, Integer, null: true, buyer_only: true
```
- We added `authorized?` method to `BaseField` which is called by graphql ruby on every field being returned, current code only supports `buyer_only` and `seller_only` on `Order` type, but if needed we can add it to other Types too.
- In `authorized?` we check if Object passed in is an `Order` and if any of `buyer_only` or `seller_only` was defined on the field, based on the setting we check if current user is buyer or seller. This logic works fine on checking buyer since we check `order`'s `user_id` with current sessions and if they match current session is buyer. On the seller side we check if `order`'s `partner_id` was in the list of `partner_ids` in the session we allow accessing the field.

**Note** we still allow accessing all fields, we just return `nil` if user is not authorized.

# Ignore in this PR
ignore what I asked rubocop to ignore :) basically all price cents values no longer need `_` on every 3 digits since it was annoying on cents related fields.