### PR TITLE
Add new mutation for finalizing orders with one fulfillment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,6 @@ Naming/AccessorMethodName:
 Rails/ActiveRecordAliases:
   Exclude:
     - 'spec/controllers/api/requests/approve_order_mutation_request_spec.rb'
-    - 'spec/controllers/api/requests/finalize_order_mutation_request_spec.rb'
     - 'spec/controllers/api/requests/reject_order_mutation_request_spec.rb'
     - 'spec/controllers/api/requests/submit_order_mutation_request_spec.rb'
 

--- a/README.md
+++ b/README.md
@@ -209,14 +209,29 @@ For input:
 
 #### Finalize an Order
 ```graphql
-# finalize order
-mutation($input: FinalizeOrderInput!) {
-  finalizeOrder(input: $input) {
+# finalize order with one fulfillment
+mutation($input: FinalizeWithOneFulfillmentInput!) {
+  finalizeWithOneFulfillment(input: $input) {
     order {
       id
       userId
       partnerId
       state
+      lineItems{
+        edges{
+          node{
+            fulfillments{
+              edges{
+                node{
+                  courier
+                  trackingId
+                  estimatedDelivery
+                }
+              }
+            }
+          }
+        }
+      }
     }
     errors
   }
@@ -226,7 +241,11 @@ For input:
 ```json
 {
   "input": {
-    "id": "<order id>"
+    "id": "<order id>",
+    "fulfillment": {
+      "courier": "FedEx",
+      "trackingId": "track-431"
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In order to talk to Exchange GraphQL endpoint:
 
 ## Order Lifecycle
 
-Users create and submit orders. Partners then approve and finalize or reject the order.
+Users create and submit orders. Partners then approve and fulfill or reject the order.
 
 ### As a User
 
@@ -207,11 +207,11 @@ For input:
 ```
 
 
-#### Finalize an Order
+#### Fulfill an Order
 ```graphql
-# finalize order with one fulfillment
-mutation($input: FinalizeWithOneFulfillmentInput!) {
-  finalizeWithOneFulfillment(input: $input) {
+# fulfill order with one fulfillment
+mutation($input: FulfillWithOneFulfillmentInput!) {
+  fulfillWithOneFulfillment(input: $input) {
     order {
       id
       userId

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ For input:
 #### Fulfill an Order
 ```graphql
 # fulfill order with one fulfillment
-mutation($input: FulfillWithOneFulfillmentInput!) {
-  fulfillWithOneFulfillment(input: $input) {
+mutation($input: FulfillAtOnceInput!) {
+  fulfillAtOnce(input: $input) {
     order {
       id
       userId

--- a/app/graphql/mutations/finalize_with_one_fulfillment.rb
+++ b/app/graphql/mutations/finalize_with_one_fulfillment.rb
@@ -1,16 +1,18 @@
-class Mutations::FinalizeOrder < Mutations::BaseMutation
+class Mutations::FinalizeWithOneFulfillment < Mutations::BaseMutation
   null true
+  description 'Finalizes an order with one Fulfillment, it sets this fulfillment to each line item in order'
 
   argument :id, ID, required: true
+  argument :fulfillment, Types::FulfillmentAttributes, required: true
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false
 
-  def resolve(id:)
+  def resolve(id:, fulfillment:)
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.finalize!(order),
+      order: OrderService.finalize_with_one_fulfillment!(order, fulfillment.to_h, context[:current_user][:id]),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/fulfill_at_once.rb
+++ b/app/graphql/mutations/fulfill_at_once.rb
@@ -1,4 +1,4 @@
-class Mutations::FulfillWithOneFulfillment < Mutations::BaseMutation
+class Mutations::FulfillAtOnce < Mutations::BaseMutation
   null true
   description 'Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order'
 
@@ -12,7 +12,7 @@ class Mutations::FulfillWithOneFulfillment < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.fulfill_with_one_fulfillment!(order, fulfillment.to_h, context[:current_user][:id]),
+      order: OrderService.fulfill_at_once!(order, fulfillment.to_h, context[:current_user][:id]),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/fulfill_with_one_fulfillment.rb
+++ b/app/graphql/mutations/fulfill_with_one_fulfillment.rb
@@ -1,6 +1,6 @@
-class Mutations::FinalizeWithOneFulfillment < Mutations::BaseMutation
+class Mutations::FulfillWithOneFulfillment < Mutations::BaseMutation
   null true
-  description 'Finalizes an order with one Fulfillment, it sets this fulfillment to each line item in order'
+  description 'Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order'
 
   argument :id, ID, required: true
   argument :fulfillment, Types::FulfillmentAttributes, required: true
@@ -12,7 +12,7 @@ class Mutations::FinalizeWithOneFulfillment < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderService.finalize_with_one_fulfillment!(order, fulfillment.to_h, context[:current_user][:id]),
+      order: OrderService.fulfill_with_one_fulfillment!(order, fulfillment.to_h, context[:current_user][:id]),
       errors: []
     }
   rescue Errors::ApplicationError => e

--- a/app/graphql/types/date_type.rb
+++ b/app/graphql/types/date_type.rb
@@ -1,13 +1,14 @@
-class Types::DateTimeType < Types::BaseScalar
-  description 'DateTime'
+class Types::DateType < Types::BaseScalar
+  description 'Date in YYYY-MM-DD format'
+  DATE_FORMAT = '%Y-%m-%d'.freeze
 
   def self.coerce_input(input_value, _context)
     # Parse the incoming object into a DateTime
-    input_value.to_datetime
+    Date.strptime(input_value, DATE_FORMAT)
   end
 
   def self.coerce_result(ruby_value, _context)
     # It's transported as a string, so stringify it
-    ruby_value.to_s
+    ruby_value.strftime(DATE_FORMAT)
   end
 end

--- a/app/graphql/types/fulfillment_attributes.rb
+++ b/app/graphql/types/fulfillment_attributes.rb
@@ -1,0 +1,8 @@
+class Types::FulfillmentAttributes < Types::BaseInputObject
+  description 'Attributes of a Fulfillment'
+
+  argument :courier, String, required: true
+  argument :tracking_id, String, required: false
+  argument :estimated_delivery, Types::DateType, required: false
+  argument :notes, String, required: false
+end

--- a/app/graphql/types/fulfillment_type.rb
+++ b/app/graphql/types/fulfillment_type.rb
@@ -1,0 +1,12 @@
+class Types::FulfillmentType < Types::BaseObject
+  description 'A Fulfillment for an order'
+  graphql_name 'Fulfillment'
+
+  field :id, ID, null: false
+  field :courier, String, null: false
+  field :tracking_id, String, null: true
+  field :estimated_delivery, Types::DateType, null: true
+  field :notes, String, null: true
+  field :created_at, Types::DateTimeType, null: false
+  field :updated_at, Types::DateTimeType, null: false
+end

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -9,4 +9,5 @@ class Types::LineItemType < Types::BaseObject
   field :quantity, Integer, null: false
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
+  field :fulfillments, Types::FulfillmentType.connection_type, null: true
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,5 @@ class Types::MutationType < Types::BaseObject
   field :submit_order, mutation: Mutations::SubmitOrder
   field :approve_order, mutation: Mutations::ApproveOrder
   field :reject_order, mutation: Mutations::RejectOrder
-  field :finalize_order, mutation: Mutations::FinalizeOrder
+  field :finalize_with_one_fulfillment, mutation: Mutations::FinalizeWithOneFulfillment
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,5 @@ class Types::MutationType < Types::BaseObject
   field :submit_order, mutation: Mutations::SubmitOrder
   field :approve_order, mutation: Mutations::ApproveOrder
   field :reject_order, mutation: Mutations::RejectOrder
-  field :fulfill_with_one_fulfillment, mutation: Mutations::FulfillWithOneFulfillment
+  field :fulfill_at_once, mutation: Mutations::FulfillAtOnce
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,5 @@ class Types::MutationType < Types::BaseObject
   field :submit_order, mutation: Mutations::SubmitOrder
   field :approve_order, mutation: Mutations::ApproveOrder
   field :reject_order, mutation: Mutations::RejectOrder
-  field :finalize_with_one_fulfillment, mutation: Mutations::FinalizeWithOneFulfillment
+  field :fulfill_with_one_fulfillment, mutation: Mutations::FulfillWithOneFulfillment
 end

--- a/app/graphql/types/order_state_enum.rb
+++ b/app/graphql/types/order_state_enum.rb
@@ -3,5 +3,5 @@ class Types::OrderStateEnum < Types::BaseEnum
   value 'SUBMITTED', 'order is submitted by collector', value: Order::SUBMITTED
   value 'APPROVED', 'order is approved by partner', value: Order::APPROVED
   value 'REJECTED', 'order is rejected by partner', value: Order::REJECTED
-  value 'FINALIZED', 'order is finalized by partner', value: Order::FINALIZED
+  value 'FULFILLED', 'order is fulfilled by partner', value: Order::FULFILLED
 end

--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -1,0 +1,4 @@
+class Fulfillment < ApplicationRecord
+  has_many :line_item_fulfillments, dependent: :destroy
+  has_many :line_items, through: :line_item_fulfillments
+end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,3 +1,5 @@
 class LineItem < ApplicationRecord
   belongs_to :order
+  has_many :line_item_fulfillments, dependent: :destroy
+  has_many :fulfillments, through: :line_item_fulfillments
 end

--- a/app/models/line_item_fulfillment.rb
+++ b/app/models/line_item_fulfillment.rb
@@ -1,0 +1,4 @@
+class LineItemFulfillment < ApplicationRecord
+  belongs_to :line_item
+  belongs_to :fulfillment
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -14,7 +14,7 @@ class Order < ApplicationRecord
     # Items have been deemed unavailable and hold is voided.
     REJECTED = 'rejected'.freeze,
 
-    FINALIZED = 'finalized'.freeze
+    FULFILLED = 'fulfilled'.freeze
   ].freeze
 
   STATE_EXPIRATIONS = {
@@ -28,7 +28,7 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  ACTIONS = %i[abandon submit approve reject finalize].freeze
+  ACTIONS = %i[abandon submit approve reject fulfill].freeze
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'
   has_many :transactions, dependent: :destroy
@@ -97,7 +97,7 @@ class Order < ApplicationRecord
     machine.when(:submit, PENDING => SUBMITTED)
     machine.when(:approve, SUBMITTED => APPROVED)
     machine.when(:reject, SUBMITTED => REJECTED)
-    machine.when(:finalize, APPROVED => FINALIZED)
+    machine.when(:fulfill, APPROVED => FULFILLED)
     machine.on(:any) do
       self.state = machine.state
     end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -49,8 +49,9 @@ module OrderService
 
   def self.finalize_with_one_fulfillment!(order, fulfillment, by)
     Order.transaction do
+      fulfillment = Fulfillment.create!(fulfillment.slice(:courier, :tracking_id, :estimated_delivery))
       order.line_items.each do |li|
-        li.fulfillments.create!(fulfillment.slice(:courier, :tracking_id, :estimated_delivery))
+        li.line_item_fulfillments.create!(fulfillment_id: fulfillment.id)
       end
       order.finalize!
       order.save!

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -47,7 +47,7 @@ module OrderService
     raise e
   end
 
-  def self.fulfill_with_one_fulfillment!(order, fulfillment, by)
+  def self.fulfill_at_once!(order, fulfillment, by)
     Order.transaction do
       fulfillment = Fulfillment.create!(fulfillment.slice(:courier, :tracking_id, :estimated_delivery))
       order.line_items.each do |li|

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -47,10 +47,14 @@ module OrderService
     raise e
   end
 
-  def self.finalize!(order)
+  def self.finalize_with_one_fulfillment!(order, fulfillment, by)
     Order.transaction do
+      order.line_items.each do |li|
+        li.fulfillments.create!(fulfillment.slice(:courier, :tracking_id, :estimated_delivery))
+      end
       order.finalize!
       order.save!
+      PostNotificationJob.perform_later(order.id, Order::FINALIZED, by)
     end
     order
   end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -47,15 +47,15 @@ module OrderService
     raise e
   end
 
-  def self.finalize_with_one_fulfillment!(order, fulfillment, by)
+  def self.fulfill_with_one_fulfillment!(order, fulfillment, by)
     Order.transaction do
       fulfillment = Fulfillment.create!(fulfillment.slice(:courier, :tracking_id, :estimated_delivery))
       order.line_items.each do |li|
         li.line_item_fulfillments.create!(fulfillment_id: fulfillment.id)
       end
-      order.finalize!
+      order.fulfill!
       order.save!
-      PostNotificationJob.perform_later(order.id, Order::FINALIZED, by)
+      PostNotificationJob.perform_later(order.id, Order::FULFILLED, by)
     end
     order
   end

--- a/db/migrate/20180730173716_create_fulfillments.rb
+++ b/db/migrate/20180730173716_create_fulfillments.rb
@@ -1,0 +1,12 @@
+class CreateFulfillments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :fulfillments do |t|
+      t.string :courier
+      t.string :tracking_id
+      t.date :estimated_delivery
+      t.string :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180730173943_create_line_item_fulfillments.rb
+++ b/db/migrate/20180730173943_create_line_item_fulfillments.rb
@@ -1,0 +1,10 @@
+class CreateLineItemFulfillments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :line_item_fulfillments do |t|
+      t.references :line_item, foreign_key: true
+      t.references :fulfillment, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2018_07_30_173943) do
     t.string "courier"
     t.string "tracking_id"
     t.date "estimated_delivery"
+    t.string "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_23_192428) do
+ActiveRecord::Schema.define(version: 2018_07_30_173943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "fulfillments", force: :cascade do |t|
+    t.string "courier"
+    t.string "tracking_id"
+    t.date "estimated_delivery"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "line_item_fulfillments", force: :cascade do |t|
+    t.bigint "line_item_id"
+    t.bigint "fulfillment_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fulfillment_id"], name: "index_line_item_fulfillments_on_fulfillment_id"
+    t.index ["line_item_id"], name: "index_line_item_fulfillments_on_line_item_id"
+  end
 
   create_table "line_items", force: :cascade do |t|
     t.bigint "order_id"
@@ -80,6 +97,8 @@ ActiveRecord::Schema.define(version: 2018_07_23_192428) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "line_item_fulfillments", "fulfillments"
+  add_foreign_key "line_item_fulfillments", "line_items"
   add_foreign_key "line_items", "orders"
   add_foreign_key "transactions", "orders"
 end

--- a/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
@@ -1,22 +1,40 @@
 require 'rails_helper'
 
 describe Api::GraphqlController, type: :request do
-  describe 'finalize_order mutation' do
+  describe 'finalize_with_one_fulfillment mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
     let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
+    let!(:line_items) do
+      Array.new(2) { Fabricate(:line_item, order: order, price_cents: 200) }
+    end
 
     let(:mutation) do
       <<-GRAPHQL
-        mutation($input: FinalizeOrderInput!) {
-          finalizeOrder(input: $input) {
+        mutation($input: FinalizeWithOneFulfillmentInput!) {
+          finalizeWithOneFulfillment(input: $input) {
             order {
               id
               userId
               partnerId
               state
+              lineItems{
+                edges{
+                  node{
+                    fulfillments{
+                      edges{
+                        node{
+                          courier
+                          trackingId
+                          estimatedDelivery
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
             errors
           }
@@ -24,18 +42,24 @@ describe Api::GraphqlController, type: :request do
       GRAPHQL
     end
 
-    let(:finalize_order_input) do
+    let(:courier) { 'FedEx' }
+    let(:finalize_with_one_fulfillment_input) do
       {
         input: {
-          id: order.id.to_s
+          id: order.id.to_s,
+          fulfillment: {
+            courier: courier,
+            trackingId: 'fedx-123',
+            estimatedDelivery: '2018-12-15'
+          }
         }
       }
     end
     context 'with user without permission to this partner' do
       let(:partner_id) { 'another-partner-id' }
       it 'returns permission error' do
-        response = client.execute(mutation, finalize_order_input)
-        expect(response.data.finalize_order.errors).to include 'Not permitted'
+        response = client.execute(mutation, finalize_with_one_fulfillment_input)
+        expect(response.data.finalize_with_one_fulfillment.errors).to include 'Not permitted'
         expect(order.reload.state).to eq Order::PENDING
       end
     end
@@ -45,8 +69,8 @@ describe Api::GraphqlController, type: :request do
         order.update_attributes! state: Order::SUBMITTED
       end
       it 'returns error' do
-        response = client.execute(mutation, finalize_order_input)
-        expect(response.data.finalize_order.errors).to include 'Invalid action on this submitted order'
+        response = client.execute(mutation, finalize_with_one_fulfillment_input)
+        expect(response.data.finalize_with_one_fulfillment.errors).to include 'Invalid action on this submitted order'
         expect(order.reload.state).to eq Order::SUBMITTED
       end
     end
@@ -56,11 +80,26 @@ describe Api::GraphqlController, type: :request do
         order.update_attributes! state: Order::APPROVED
       end
       it 'finalizes the order' do
-        response = client.execute(mutation, finalize_order_input)
-        expect(response.data.finalize_order.order.id).to eq order.id.to_s
-        expect(response.data.finalize_order.order.state).to eq 'FINALIZED'
-        expect(response.data.finalize_order.errors).to match []
-        expect(order.reload.state).to eq Order::FINALIZED
+        expect do
+          response = client.execute(mutation, finalize_with_one_fulfillment_input)
+          expect(response.data.finalize_with_one_fulfillment.order.id).to eq order.id.to_s
+          expect(response.data.finalize_with_one_fulfillment.order.state).to eq 'FINALIZED'
+          response.data.finalize_with_one_fulfillment.order.line_items.edges.each do |li|
+            li.node.fulfillments.edges.each do |f|
+              expect(f.node.courier).to eq 'FedEx'
+              expect(f.node.tracking_id).to eq 'fedx-123'
+              expect(f.node.estimated_delivery).to eq '2018-12-15'
+            end
+          end
+          expect(response.data.finalize_with_one_fulfillment.errors).to match []
+          expect(order.reload.state).to eq Order::FINALIZED
+          order.line_items.each do |li|
+            expect(li.fulfillments.count).to eq 1
+            expect(li.fulfillments.first.courier).to eq 'FedEx'
+            expect(li.fulfillments.first.tracking_id).to eq 'fedx-123'
+            expect(li.fulfillments.first.estimated_delivery).to eq Date.strptime('2018-12-15', '%Y-%m-%d')
+          end
+        end.to change(Fulfillment, :count).by(2).and change(LineItemFulfillment, :count).by(2)
       end
     end
   end

--- a/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/finalize_order_mutation_request_spec.rb
@@ -99,7 +99,7 @@ describe Api::GraphqlController, type: :request do
             expect(li.fulfillments.first.tracking_id).to eq 'fedx-123'
             expect(li.fulfillments.first.estimated_delivery).to eq Date.strptime('2018-12-15', '%Y-%m-%d')
           end
-        end.to change(Fulfillment, :count).by(2).and change(LineItemFulfillment, :count).by(2)
+        end.to change(Fulfillment, :count).by(1).and change(LineItemFulfillment, :count).by(2)
       end
     end
   end

--- a/spec/controllers/api/requests/fulfill_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/fulfill_order_mutation_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Api::GraphqlController, type: :request do
-  describe 'finalize_with_one_fulfillment mutation' do
+  describe 'fulfill_with_one_fulfillment mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
@@ -13,8 +13,8 @@ describe Api::GraphqlController, type: :request do
 
     let(:mutation) do
       <<-GRAPHQL
-        mutation($input: FinalizeWithOneFulfillmentInput!) {
-          finalizeWithOneFulfillment(input: $input) {
+        mutation($input: FulfillWithOneFulfillmentInput!) {
+          fulfillWithOneFulfillment(input: $input) {
             order {
               id
               userId
@@ -43,7 +43,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     let(:courier) { 'FedEx' }
-    let(:finalize_with_one_fulfillment_input) do
+    let(:fulfill_with_one_fulfillment_input) do
       {
         input: {
           id: order.id.to_s,
@@ -58,41 +58,41 @@ describe Api::GraphqlController, type: :request do
     context 'with user without permission to this partner' do
       let(:partner_id) { 'another-partner-id' }
       it 'returns permission error' do
-        response = client.execute(mutation, finalize_with_one_fulfillment_input)
-        expect(response.data.finalize_with_one_fulfillment.errors).to include 'Not permitted'
+        response = client.execute(mutation, fulfill_with_one_fulfillment_input)
+        expect(response.data.fulfill_with_one_fulfillment.errors).to include 'Not permitted'
         expect(order.reload.state).to eq Order::PENDING
       end
     end
 
     context 'with order not in approved state' do
       before do
-        order.update_attributes! state: Order::SUBMITTED
+        order.update! state: Order::SUBMITTED
       end
       it 'returns error' do
-        response = client.execute(mutation, finalize_with_one_fulfillment_input)
-        expect(response.data.finalize_with_one_fulfillment.errors).to include 'Invalid action on this submitted order'
+        response = client.execute(mutation, fulfill_with_one_fulfillment_input)
+        expect(response.data.fulfill_with_one_fulfillment.errors).to include 'Invalid action on this submitted order'
         expect(order.reload.state).to eq Order::SUBMITTED
       end
     end
 
     context 'with proper permission' do
       before do
-        order.update_attributes! state: Order::APPROVED
+        order.update! state: Order::APPROVED
       end
-      it 'finalizes the order' do
+      it 'fulfills the order' do
         expect do
-          response = client.execute(mutation, finalize_with_one_fulfillment_input)
-          expect(response.data.finalize_with_one_fulfillment.order.id).to eq order.id.to_s
-          expect(response.data.finalize_with_one_fulfillment.order.state).to eq 'FINALIZED'
-          response.data.finalize_with_one_fulfillment.order.line_items.edges.each do |li|
+          response = client.execute(mutation, fulfill_with_one_fulfillment_input)
+          expect(response.data.fulfill_with_one_fulfillment.order.id).to eq order.id.to_s
+          expect(response.data.fulfill_with_one_fulfillment.order.state).to eq 'FULFILLED'
+          response.data.fulfill_with_one_fulfillment.order.line_items.edges.each do |li|
             li.node.fulfillments.edges.each do |f|
               expect(f.node.courier).to eq 'FedEx'
               expect(f.node.tracking_id).to eq 'fedx-123'
               expect(f.node.estimated_delivery).to eq '2018-12-15'
             end
           end
-          expect(response.data.finalize_with_one_fulfillment.errors).to match []
-          expect(order.reload.state).to eq Order::FINALIZED
+          expect(response.data.fulfill_with_one_fulfillment.errors).to match []
+          expect(order.reload.state).to eq Order::FULFILLED
           order.line_items.each do |li|
             expect(li.fulfillments.count).to eq 1
             expect(li.fulfillments.first.courier).to eq 'FedEx'

--- a/spec/models/fulfillment_spec.rb
+++ b/spec/models/fulfillment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Fulfillment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/line_item_fulfillment_spec.rb
+++ b/spec/models/line_item_fulfillment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LineItemFulfillment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Problem
We started to introduce `Fulfillment` in #86  for tracking fulfillments per order. After some discussion we decided that the modeling could be better where we track fulfillment per `lineItem` instead of per order. 

Basically each line item can have many fulfillments (Imagine a big sculpture, or a line item with quantity more than one) and also each fulfillment could possibly handle multiple line items.

fixes #71 

# Solution
Added `Fulfillment` and `LineItemFulfillment` which is the connection model between `LineItem` and `Fulfillment`.
A `LineItem` can have many `fulfillments` and a `Fulfillment` can have many `line_items`.

We talked about having two separate mutations for this possibly, one for adding fulfillments and one for finalizing order. While this seems to be the proper way overall, in order to handle our current use case (one fulfillment per order) we only now provide one _helper_ mutation that gets order id and a fulfillment. For each line item in that order we set their fulfillments to this current one and then we finalize the order.

