### PR TITLE
Fix issue with returning abandoned state

### DIFF
--- a/app/graphql/types/order_state_enum.rb
+++ b/app/graphql/types/order_state_enum.rb
@@ -1,4 +1,5 @@
 class Types::OrderStateEnum < Types::BaseEnum
+  value 'ABANDONED', 'order is abandoned by collector and never submitted', value: Order::ABANDONED
   value 'PENDING', 'order is still pending submission by collector', value: Order::PENDING
   value 'SUBMITTED', 'order is submitted by collector', value: Order::SUBMITTED
   value 'APPROVED', 'order is approved by partner', value: Order::APPROVED


### PR DESCRIPTION
# Problem
When there are abandoned orders in the returning results, we get graphql errors rendering the response.

fixes #88 

# Solution
We were missing matching enum for `ABANDONED` orders, add it.