### PR TITLE
Transaction fee cents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'faraday'
 gem 'graphql'
 gem 'jwt'
 gem 'micromachine'
+gem 'money' # Library for dealing with money and currency conversion
 gem 'paper_trail'
 gem 'sidekiq'
 gem 'stripe'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    money (6.12.0)
+      i18n (>= 0.6.4, < 1.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     nio4r (2.3.1)
@@ -227,6 +229,7 @@ DEPENDENCIES
   jwt
   listen
   micromachine
+  money
   paper_trail
   pg
   puma

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -4,4 +4,22 @@ module GravityService
       Adapters::GravityV1.request("/partner/#{partner_id}/all")
     end
   end
+
+  def self.get_merchant_account(partner_id)
+    merchant_account = Adapters::GravityV1.request("/merchant_accounts?partner_id=#{partner_id}").first
+    raise Errors::OrderError, 'Partner does not have merchant account' if merchant_account.nil?
+    merchant_account
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Unable to find partner or merchant account'
+  rescue Adapters::GravityError => e
+    raise Errors::OrderError, e.message
+  end
+
+  def self.get_credit_card(credit_card_id)
+    Adapters::GravityV1.request("/credit_card/#{credit_card_id}")
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Credit card not found'
+  rescue Adapters::GravityError => e
+    raise Errors::OrderError, e.message
+  end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -3,8 +3,9 @@ module OrderSubmitService
     # verify price change?
     raise Errors::OrderError, "Missing info for submitting order(#{order.id})" unless can_submit?(order)
 
-    merchant_account = get_merchant_account(order)
-    credit_card = get_credit_card(order)
+    merchant_account = GravityService.get_merchant_account(order.partner_id)
+    credit_card = GravityService.get_credit_card(order.credit_card_id)
+    validate_credit_card!(credit_card)
 
     charge_params = {
       source_id: credit_card[:external_id],
@@ -20,6 +21,7 @@ module OrderSubmitService
       order.external_charge_id = charge[:id]
       TransactionService.create_success!(order, charge)
       order.commission_fee_cents = calculate_commission(order)
+      order.transaction_fee_cents = calculate_transaction_fee(order)
       order.save!
       PostNotificationJob.perform_later(order.id, Order::SUBMITTED, by)
     end
@@ -30,27 +32,7 @@ module OrderSubmitService
     raise e
   end
 
-  def self.get_merchant_account(order)
-    merchant_account = Adapters::GravityV1.request("/merchant_accounts?partner_id=#{order.partner_id}").first
-    raise Errors::OrderError, 'Partner does not have merchant account' if merchant_account.nil?
-    merchant_account
-  rescue Adapters::GravityNotFoundError
-    raise Errors::OrderError, 'Unable to find partner or merchant account'
-  rescue Adapters::GravityError => e
-    raise Errors::OrderError, e.message
-  end
-
-  def self.get_credit_card(order)
-    credit_card = Adapters::GravityV1.request("/credit_card/#{order.credit_card_id}")
-    validate_credit_card(credit_card)
-    credit_card
-  rescue Adapters::GravityNotFoundError
-    raise Errors::OrderError, 'Credit card not found'
-  rescue Adapters::GravityError => e
-    raise Errors::OrderError, e.message
-  end
-
-  def self.validate_credit_card(credit_card)
+  def self.validate_credit_card!(credit_card)
     raise Errors::OrderError, 'Credit card does not have external id' if credit_card[:external_id].blank?
     raise Errors::OrderError, 'Credit card does not have customer id' if credit_card.dig(:customer_account, :external_id).blank?
     raise Errors::OrderError, 'Credit card is deactivated' unless credit_card[:deactivated_at].nil?
@@ -66,5 +48,10 @@ module OrderSubmitService
   rescue Adapters::GravityError => e
     Rails.logger.error("Could not fetch partner for order #{order.id}: #{e.message}")
     raise Errors::OrderError, 'Cannot fetch partner'
+  end
+
+  def self.calculate_transaction_fee(order)
+    # This is based on Stripe US fee, it will be different for other countries
+    (Money.new(order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
   end
 end

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -8,8 +8,6 @@ module Adapters
       raise GravityNotFoundError if response.status == 404
       raise GravityError, "couldn't perform request! Response was #{response.status}." unless response.success?
       JSON.parse(response.body, symbolize_names: true)
-    rescue GravityNotFoundError => e
-      raise e
     rescue StandardError => e
       raise GravityError, e.message
     end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -91,8 +91,8 @@ describe Api::GraphqlController, type: :request do
           order.update_attributes! state: Order::APPROVED
         end
         it 'returns error' do
-          allow(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
-          allow(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)
+          allow(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
+          allow(GravityService).to receive(:get_credit_card).and_return(credit_card)
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.errors).to include 'Invalid action on this approved order'
           expect(order.reload.state).to eq Order::APPROVED
@@ -100,8 +100,8 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'submits the order' do
-        expect(OrderSubmitService).to receive(:get_merchant_account).and_return(merchant_account)
-        expect(OrderSubmitService).to receive(:get_credit_card).and_return(credit_card)
+        expect(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
+        expect(GravityService).to receive(:get_credit_card).and_return(credit_card)
         expect(Adapters::GravityV1).to receive(:request).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
         response = client.execute(mutation, submit_order_input)
         expect(response.data.submit_order.order.id).to eq order.id.to_s

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe GravityService, type: :services do
+  describe '#get_merchant_account' do
+    let(:partner_id) { 'partner-1' }
+    let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
+    it 'calls the /merchant_accounts Gravity endpoint' do
+      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return(partner_merchant_accounts)
+      GravityService.get_merchant_account(partner_id)
+      expect(Adapters::GravityV1).to have_received(:request).with("/merchant_accounts?partner_id=#{partner_id}")
+    end
+
+    it "returns the first merchant account of the partner's merchant accounts" do
+      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return(partner_merchant_accounts)
+      result = GravityService.get_merchant_account(partner_id)
+      expect(result).to be(partner_merchant_accounts.first)
+    end
+
+    it 'raises an error if the partner does not have a merchant account' do
+      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return([])
+      expect { GravityService.get_merchant_account(partner_id) }.to raise_error(Errors::OrderError)
+    end
+  end
+
+  describe '#get_credit_card' do
+    let(:credit_card_id) { 'cc-1' }
+    let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil } }
+    it 'calls the /credit_card Gravity endpoint' do
+      allow(Adapters::GravityV1).to receive(:request).with("/credit_card/#{credit_card_id}").and_return(credit_card)
+      GravityService.get_credit_card(credit_card_id)
+      expect(Adapters::GravityV1).to have_received(:request).with("/credit_card/#{credit_card_id}")
+    end
+  end
+end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
+require 'webmock/rspec'
 require 'support/gravity_helper'
 
 describe OrderSubmitService, type: :services do
   let(:partner_id) { 'partner-1' }
-  let(:order) { Fabricate(:order, partner_id: partner_id, credit_card_id: 'cc-1', fulfillment_type: Order::PICKUP) }
+  let(:credit_card_id) { 'cc-1' }
+  let(:order) { Fabricate(:order, partner_id: partner_id, credit_card_id: credit_card_id, fulfillment_type: Order::PICKUP) }
   let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 2000_00), Fabricate(:line_item, order: order, price_cents: 8000_00)] }
   let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil } }
   let(:merchant_account_id) { 'ma-1' }
@@ -25,8 +27,8 @@ describe OrderSubmitService, type: :services do
       context 'with a successful transaction' do
         before(:each) do
           ActiveJob::Base.queue_adapter = :test
-          allow(OrderSubmitService).to receive(:get_merchant_account).with(order).and_return(partner_merchant_accounts.first)
-          allow(OrderSubmitService).to receive(:get_credit_card).with(order).and_return(credit_card)
+          allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
+          allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
           allow(PaymentService).to receive(:authorize_charge).with(authorize_charge_params).and_return(charge_success)
           allow(TransactionService).to receive(:create_success!).with(order, charge_success)
           allow(Adapters::GravityV1).to receive(:request).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
@@ -64,8 +66,8 @@ describe OrderSubmitService, type: :services do
 
       context 'with an unsuccessful transaction' do
         it 'creates a record of the transaction' do
-          allow(OrderSubmitService).to receive(:get_merchant_account).with(order).and_return(partner_merchant_accounts.first)
-          allow(OrderSubmitService).to receive(:get_credit_card).with(order).and_return(credit_card)
+          allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
+          allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
           allow(PaymentService).to receive(:authorize_charge).with(authorize_charge_params).and_raise(Errors::PaymentError.new('some_error', charge_failure))
           allow(TransactionService).to receive(:create_failure!).with(order, charge_failure)
           expect { OrderSubmitService.submit!(order) }.to raise_error(Errors::PaymentError)
@@ -75,47 +77,18 @@ describe OrderSubmitService, type: :services do
     end
   end
 
-  describe '#get_merchant_account' do
-    it 'calls the /merchant_accounts Gravity endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(partner_merchant_accounts)
-      OrderSubmitService.get_merchant_account(order)
-      expect(Adapters::GravityV1).to have_received(:request).with("/merchant_accounts?partner_id=#{order.partner_id}")
-    end
-
-    it "returns the first merchant account of the partner's merchant accounts" do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return(partner_merchant_accounts)
-      result = OrderSubmitService.get_merchant_account(order)
-      expect(result).to be(partner_merchant_accounts.first)
-    end
-
-    it 'raises an error if the partner does not have a merchant account' do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{order.partner_id}").and_return([])
-      expect { OrderSubmitService.get_merchant_account(order) }.to raise_error(Errors::OrderError)
-    end
-  end
-
-  describe '#get_credit_card' do
-    it 'calls the /credit_card Gravity endpoint and validates the credit card' do
-      allow(Adapters::GravityV1).to receive(:request).with("/credit_card/#{order.credit_card_id}").and_return(credit_card)
-      allow(OrderSubmitService).to receive(:validate_credit_card).with(credit_card)
-      OrderSubmitService.get_credit_card(order)
-      expect(Adapters::GravityV1).to have_received(:request).with("/credit_card/#{order.credit_card_id}")
-      expect(OrderSubmitService).to have_received(:validate_credit_card).with(credit_card)
-    end
-  end
-
-  describe '#validate_credit_card' do
+  describe '#validate_credit_card!' do
     it 'raises an error if the credit card does not have an external id' do
-      expect { OrderSubmitService.validate_credit_card(customer_account: { external_id: 'cust-1' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
+      expect { OrderSubmitService.validate_credit_card!(customer_account: { external_id: 'cust-1' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
     end
 
     it 'raises an error if the credit card does not have a customer id' do
-      expect { OrderSubmitService.validate_credit_card(external_id: 'cc-1') }.to raise_error(Errors::OrderError)
-      expect { OrderSubmitService.validate_credit_card(external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
+      expect { OrderSubmitService.validate_credit_card!(external_id: 'cc-1') }.to raise_error(Errors::OrderError)
+      expect { OrderSubmitService.validate_credit_card!(external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
     end
 
     it 'raises an error if the card is deactivated' do
-      expect { OrderSubmitService.validate_credit_card(external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 'today') }.to raise_error(Errors::OrderError)
+      expect { OrderSubmitService.validate_credit_card!(external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 'today') }.to raise_error(Errors::OrderError)
     end
   end
 

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -62,6 +62,10 @@ describe OrderSubmitService, type: :services do
         it 'sets commission_fee_cents' do
           expect(order.commission_fee_cents).to eq 8000_00
         end
+
+        it 'sets transaction_fee_cents' do
+          expect(order.transaction_fee_cents).to eq 290_30
+        end
       end
 
       context 'with an unsuccessful transaction' do
@@ -110,6 +114,12 @@ describe OrderSubmitService, type: :services do
           OrderSubmitService.calculate_commission(order)
         end.to raise_error(Errors::OrderError, /Cannot fetch partner/)
       end
+    end
+  end
+
+  describe '#calculate_transaction' do
+    it 'returns proper transaction fee' do
+      expect(OrderSubmitService.calculate_transaction_fee(order)).to eq 290_30
     end
   end
 end


### PR DESCRIPTION
# Problem
We want to calculate Transaction fee when an order is submitted.

# Solution
We now calculate and set `transaction_fee_cents` on an order when order is submitted. This fee currently matches Stripe's US fee which would work for us as long as Partner's merchant account is setup in a US bank.

# Some Refactor
@williardx based on what we talked about before, i moved `get_merchant_account` and `get_credit_card` methods to `GravityService`, let me know what you think 👍 