### PR TITLE
Raise error when calculating shipping for artwork without location

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For input:
   "input": {
     "id": "<order id>",
     "fulfillmentType": "SHIP/PICKUP",
-    "shippingAddresLine1": "",
+    "shippingAddressLine1": "",
     "shippingAddressLine2": "",
     "shippingCity": "",
     "shippingRegion": "",

--- a/app/services/shipping_service.rb
+++ b/app/services/shipping_service.rb
@@ -4,6 +4,7 @@ module ShippingService
     return 0 if Rails.application.config_for(:dev_features)['disable_shipping_calculation']
     artwork = ArtworkService.find(line_item.artwork_id)
     raise Errors::OrderError, 'Cannot calculate shipping, unknown artwork' unless artwork
+    raise Errors::OrderError, 'Cannot calculate shipping, missing artwork location' if artwork[:location].blank?
 
     if fulfillment_type == Order::PICKUP
       0

--- a/spec/services/shipping_service_spec.rb
+++ b/spec/services/shipping_service_spec.rb
@@ -38,6 +38,14 @@ describe ShippingService, type: :services do
           expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'Iran')).to eq 500_00
         end
       end
+      context 'without artwork location' do
+        let(:artwork_location) { nil }
+        it 'raises Errors::OrderError' do
+          expect do
+            expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'US'))
+          end.to raise_error(Errors::OrderError, 'Cannot calculate shipping, missing artwork location')
+        end
+      end
     end
 
     context 'with failed artwork fetch call' do


### PR DESCRIPTION
https://artsy.slack.com/archives/CB110C6LE/p1533670813000231

We saw a `Cannot match against 'undefined' or 'null'.` error when using MP to set shipping for artworks without location. This makes it raise proper error with messages when location is missing.

Another case not addressed here is a location without country will be treated as international, given current implementation. Not sure if this will happen in Gravity but want to raise it here. 

![screen shot 2018-08-07 at 5 51 36 pm](https://user-images.githubusercontent.com/796573/43804628-ac88a9aa-9a6a-11e8-8b5f-31eb27ac08d2.png)
