### PR TITLE
Better error handling for Gravity requests

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -17,7 +17,7 @@ module CreateOrderService
 
   def self.get_artwork(artwork_id)
     Adapters::GravityV1.request("/artwork/#{artwork_id}")
-  rescue Adapters::GravityError => e
+  rescue Adapters::GravityError, StandardError => e
     Rails.logger.warn("Could not fetch artwork #{artwork_id} from gravity: #{e.message}")
     nil
   end

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -1,6 +1,6 @@
 module CreateOrderService
   def self.with_artwork!(user_id:, artwork_id:, edition_set_id: nil, quantity:)
-    artwork = get_artwork(artwork_id)
+    artwork = GravityService.get_artwork(artwork_id)
     raise Errors::OrderError, "Unknown artwork #{artwork_id}" if artwork.nil? || (edition_set_id && !find_edition_set(artwork, edition_set_id))
 
     Order.transaction do
@@ -13,13 +13,6 @@ module CreateOrderService
       )
       order
     end
-  end
-
-  def self.get_artwork(artwork_id)
-    Adapters::GravityV1.request("/artwork/#{artwork_id}")
-  rescue Adapters::GravityError, StandardError => e
-    Rails.logger.warn("Could not fetch artwork #{artwork_id} from gravity: #{e.message}")
-    nil
   end
 
   def self.artwork_price(external_artwork, edition_set_id: nil)

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -26,4 +26,11 @@ module GravityService
   rescue Adapters::GravityError, StandardError => e
     raise Errors::OrderError, e.message
   end
+
+  def self.get_artwork(artwork_id)
+    Adapters::GravityV1.request("/artwork/#{artwork_id}")
+  rescue Adapters::GravityError, StandardError => e
+    Rails.logger.warn("Could not fetch artwork #{artwork_id} from gravity: #{e.message}")
+    nil
+  end
 end

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -3,6 +3,10 @@ module GravityService
     Rails.cache.fetch("gravity_partner_#{partner_id}", expire_in: Rails.application.config_for(:gravity)['partner_cache_in_seconds']) do
       Adapters::GravityV1.request("/partner/#{partner_id}/all")
     end
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Unable to find partner'
+  rescue Adapters::GravityError, StandardError => e
+    raise Errors::OrderError, e.message
   end
 
   def self.get_merchant_account(partner_id)
@@ -11,7 +15,7 @@ module GravityService
     merchant_account
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Unable to find partner or merchant account'
-  rescue Adapters::GravityError => e
+  rescue Adapters::GravityError, StandardError => e
     raise Errors::OrderError, e.message
   end
 
@@ -19,7 +23,7 @@ module GravityService
     Adapters::GravityV1.request("/credit_card/#{credit_card_id}")
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Credit card not found'
-  rescue Adapters::GravityError => e
+  rescue Adapters::GravityError, StandardError => e
     raise Errors::OrderError, e.message
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -45,9 +45,6 @@ module OrderSubmitService
   def self.calculate_commission(order)
     partner = GravityService.fetch_partner(order.partner_id)
     order.items_total_cents * partner[:effective_commission_rate]
-  rescue Adapters::GravityError => e
-    Rails.logger.error("Could not fetch partner for order #{order.id}: #{e.message}")
-    raise Errors::OrderError, 'Cannot fetch partner'
   end
 
   def self.calculate_transaction_fee(order)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_192056) do
     t.string "courier"
     t.string "tracking_id"
     t.date "estimated_delivery"
+    t.string "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -8,8 +8,6 @@ module Adapters
       raise GravityNotFoundError if response.status == 404
       raise GravityError, "couldn't perform request! Response was #{response.status}." unless response.success?
       JSON.parse(response.body, symbolize_names: true)
-    rescue StandardError => e
-      raise GravityError, e.message
     end
 
     def self.headers

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -49,13 +49,6 @@ describe CreateOrderService, type: :services do
     end
   end
 
-  describe '#get_artwork' do
-    it 'rescues GravityError' do
-      expect(Adapters::GravityV1).to receive(:request).and_raise(Adapters::GravityError, 'timeout')
-      expect(CreateOrderService.get_artwork('some-id')).to be_nil
-    end
-  end
-
   describe '#artwork_price' do
     context 'for artwork' do
       it 'returns artwork price' do

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -74,4 +74,19 @@ describe GravityService, type: :services do
       end
     end
   end
+
+  describe '#get_artwork' do
+    let(:artwork_id) { 'some-id' }
+    it 'calls the /artwork endpoint' do
+      allow(Adapters::GravityV1).to receive(:request).with("/artwork/#{artwork_id}")
+      GravityService.get_artwork(artwork_id)
+      expect(Adapters::GravityV1).to have_received(:request).with("/artwork/#{artwork_id}")
+    end
+    context 'with failed gravity call' do
+      it 'returns nil' do
+        expect(Adapters::GravityV1).to receive(:request).and_raise(Adapters::GravityError, 'timeout')
+        expect(GravityService.get_artwork(artwork_id)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -1,9 +1,29 @@
 require 'rails_helper'
+require 'webmock/rspec'
 require 'support/gravity_helper'
 
 describe GravityService, type: :services do
+  let(:partner_id) { 'partner-1' }
+  describe '#fetch_partner' do
+    it 'calls the /partner endpoint' do
+      allow(Adapters::GravityV1).to receive(:request).with("/partner/#{partner_id}/all")
+      GravityService.fetch_partner(partner_id)
+      expect(Adapters::GravityV1).to have_received(:request).with("/partner/#{partner_id}/all")
+    end
+
+    context 'with failed gravity call' do
+      before do
+        stub_request(:get, %r{partner\/#{partner_id}}).to_return(status: 404, body: { error: 'not found' }.to_json)
+      end
+      it 'raises OrderError' do
+        expect do
+          GravityService.fetch_partner(partner_id)
+        end.to raise_error(Errors::OrderError, /Unable to find partner/)
+      end
+    end
+  end
+
   describe '#get_merchant_account' do
-    let(:partner_id) { 'partner-1' }
     let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
     it 'calls the /merchant_accounts Gravity endpoint' do
       allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return(partner_merchant_accounts)
@@ -21,6 +41,17 @@ describe GravityService, type: :services do
       allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return([])
       expect { GravityService.get_merchant_account(partner_id) }.to raise_error(Errors::OrderError)
     end
+
+    context 'with failed gravity call' do
+      before do
+        stub_request(:get, /merchant_accounts\?partner_id=#{partner_id}/).to_return(status: 404, body: { error: 'not found' }.to_json)
+      end
+      it 'raises OrderError' do
+        expect do
+          GravityService.get_merchant_account(partner_id)
+        end.to raise_error(Errors::OrderError, /Unable to find partner or merchant account/)
+      end
+    end
   end
 
   describe '#get_credit_card' do
@@ -30,6 +61,17 @@ describe GravityService, type: :services do
       allow(Adapters::GravityV1).to receive(:request).with("/credit_card/#{credit_card_id}").and_return(credit_card)
       GravityService.get_credit_card(credit_card_id)
       expect(Adapters::GravityV1).to have_received(:request).with("/credit_card/#{credit_card_id}")
+    end
+
+    context 'with failed gravity call' do
+      before do
+        stub_request(:get, %r{credit_card\/#{credit_card_id}}).to_return(status: 404, body: { error: 'not found' }.to_json)
+      end
+      it 'raises OrderError' do
+        expect do
+          GravityService.get_credit_card(credit_card_id)
+        end.to raise_error(Errors::OrderError, /Credit card not found/)
+      end
     end
   end
 end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -105,16 +105,6 @@ describe OrderSubmitService, type: :services do
         expect(OrderSubmitService.calculate_commission(order)).to eq 8000_00.0
       end
     end
-    context 'with failed gravity call' do
-      before do
-        stub_request(:get, %r{partner\/#{partner_id}}).to_return(status: 404, body: { error: 'not found' }.to_json)
-      end
-      it 'raises OrderError' do
-        expect do
-          OrderSubmitService.calculate_commission(order)
-        end.to raise_error(Errors::OrderError, /Unable to find partner/)
-      end
-    end
   end
 
   describe '#calculate_transaction' do

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -112,7 +112,7 @@ describe OrderSubmitService, type: :services do
       it 'raises OrderError' do
         expect do
           OrderSubmitService.calculate_commission(order)
-        end.to raise_error(Errors::OrderError, /Cannot fetch partner/)
+        end.to raise_error(Errors::OrderError, /Unable to find partner/)
       end
     end
   end


### PR DESCRIPTION
### Problem
During BNMO demo we found our error handling for 404's from Gravity was not very robust or informative. This was partially because we raise a `GravityNotFoundError` in `GravityV1.request` and then end up rescuing it and re-raising a `GravityError`, leading to less helpful error handling.

### Solution
Allow `GravityV1.request` to raise whatever errors it wants and let the methods that wrap it rescue errors with the correct error messages.

### What changed
- Removes rescuing from `GravityV1.request`
- Adds rescues for `StandardError` in addition to `GravityError` for `GravityService` methods
- Adds error handling for `GravityService.fetch_partner`
- Adds tests to ensure that `GravityService` methods properly catch 404's
- Opportunistically adds a column that apparently wasn't previously committed to `schema.rb`.