### PR TITLE
add order data to rabbitmq event

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -1,5 +1,5 @@
 class OrderEvent < Events::BaseEvent
-  TOPIC = 'BNMO'.freeze
+  TOPIC = 'ecommerce'.freeze
 
   def self.post(order, action, user_id)
     event = new(user: user_id, action: action, model: order)
@@ -15,13 +15,23 @@ class OrderEvent < Events::BaseEvent
   def properties
     {
       code: @object.code,
-      partner_id: @object.partner_id,
+      created_at: @object.created_at,
       currency_code: @object.currency_code,
-      state: @object.state,
       items_total_cents: @object.items_total_cents,
       line_items: @object.line_items.map { |li| line_item_detail(li) },
-      updated_at: @object.updated_at,
-      created_at: @object.created_at
+      partner_id: @object.partner_id,
+      shipping_info: shipping_info(@object),
+      state: @object.state,
+      updated_at: @object.updated_at
+    }
+  end
+
+  def shipping_info(order)
+    {
+      shipping_address_line1: order.shipping_address_line1,
+      shipping_city: order.shipping_city,
+      shipping_country: order.shipping_country,
+      shipping_postal_code: order.shipping_postal_code
     }
   end
 

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -1,5 +1,5 @@
 class OrderEvent < Events::BaseEvent
-  TOPIC = 'ecommerce'.freeze
+  TOPIC = 'commerce'.freeze
 
   def self.post(order, action, user_id)
     event = new(user: user_id, action: action, model: order)
@@ -20,18 +20,12 @@ class OrderEvent < Events::BaseEvent
       items_total_cents: @object.items_total_cents,
       line_items: @object.line_items.map { |li| line_item_detail(li) },
       partner_id: @object.partner_id,
-      shipping_info: shipping_info(@object),
+      shipping_address_line1: @object.shipping_address_line1,
+      shipping_city: @object.shipping_city,
+      shipping_country: @object.shipping_country,
+      shipping_postal_code: @object.shipping_postal_code,
       state: @object.state,
       updated_at: @object.updated_at
-    }
-  end
-
-  def shipping_info(order)
-    {
-      shipping_address_line1: order.shipping_address_line1,
-      shipping_city: order.shipping_city,
-      shipping_country: order.shipping_country,
-      shipping_postal_code: order.shipping_postal_code
     }
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -73,6 +73,10 @@ class Order < ApplicationRecord
     credit_card_id.present?
   end
 
+  def to_s
+    "Order #{id}"
+  end
+
   private
 
   def set_code

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -3,7 +3,15 @@ require 'rails_helper'
 describe OrderEvent, type: :events do
   let(:partner_id) { 'partner-1' }
   let(:user_id) { 'user-1' }
-  let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id, currency_code: 'usd') }
+  let(:shipping_info) do
+    {
+      shipping_address_line1: '123 Main St',
+      shipping_city: 'Chicago',
+      shipping_country: 'USA',
+      shipping_postal_code: '60618'
+    }
+  end
+  let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id, currency_code: 'usd', **shipping_info) }
   let!(:line_items) do
     [
       Fabricate(:line_item, price_cents: 200, order: order),
@@ -14,7 +22,7 @@ describe OrderEvent, type: :events do
 
   describe 'post' do
     it 'calls ArtsyEventService to post event' do
-      expect(Artsy::EventService).to receive(:post_event).with(topic: 'BNMO', event: instance_of(OrderEvent))
+      expect(Artsy::EventService).to receive(:post_event).with(topic: 'ecommerce', event: instance_of(OrderEvent))
       OrderEvent.post(order, Order::SUBMITTED, user_id)
     end
   end
@@ -41,6 +49,7 @@ describe OrderEvent, type: :events do
       expect(event.properties[:updated_at]).not_to be_nil
       expect(event.properties[:created_at]).not_to be_nil
       expect(event.properties[:line_items].count).to eq 2
+      expect(event.properties[:shipping_info]).to eq shipping_info
     end
   end
 end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -22,7 +22,7 @@ describe OrderEvent, type: :events do
 
   describe 'post' do
     it 'calls ArtsyEventService to post event' do
-      expect(Artsy::EventService).to receive(:post_event).with(topic: 'ecommerce', event: instance_of(OrderEvent))
+      expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(OrderEvent))
       OrderEvent.post(order, Order::SUBMITTED, user_id)
     end
   end
@@ -49,7 +49,10 @@ describe OrderEvent, type: :events do
       expect(event.properties[:updated_at]).not_to be_nil
       expect(event.properties[:created_at]).not_to be_nil
       expect(event.properties[:line_items].count).to eq 2
-      expect(event.properties[:shipping_info]).to eq shipping_info
+      expect(event.properties[:shipping_address_line1]).to eq shipping_info[:shipping_address_line1]
+      expect(event.properties[:shipping_city]).to eq shipping_info[:shipping_city]
+      expect(event.properties[:shipping_country]).to eq shipping_info[:shipping_country]
+      expect(event.properties[:shipping_postal_code]).to eq shipping_info[:shipping_postal_code]
     end
   end
 end


### PR DESCRIPTION
This PR: 
- updates `OrderEvent` to use the more general 'ecommerce' `TOPIC` name I've been using in pulse
- adds a collected `shipping_info` object to the properties payload
- adds a `#to_s` method to prevent sending an ugly ruby object through amqp.

Tracked in https://artsyproduct.atlassian.net/browse/PURCHASE-369