### PR TITLE
Fetch credit card and store credit card details in setPayment mutation

### DIFF
--- a/db/migrate/20180813175841_add_external_credit_card_id_to_orders.rb
+++ b/db/migrate/20180813175841_add_external_credit_card_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddExternalCreditCardIdToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :external_credit_card_id, :string
+  end
+end

--- a/db/migrate/20180813180037_add_external_customer_id_to_orders.rb
+++ b/db/migrate/20180813180037_add_external_customer_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddExternalCustomerIdToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :external_customer_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_13_175841) do
+ActiveRecord::Schema.define(version: 2018_08_13_180037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2018_08_13_175841) do
     t.string "shipping_region"
     t.string "external_charge_id"
     t.string "external_credit_card_id"
+    t.string "external_customer_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_192056) do
+ActiveRecord::Schema.define(version: 2018_08_13_175841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_192056) do
     t.string "courier"
     t.string "tracking_id"
     t.date "estimated_delivery"
+    t.string "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -80,6 +81,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_192056) do
     t.string "fulfillment_type"
     t.string "shipping_region"
     t.string "external_charge_id"
+    t.string "external_credit_card_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require 'webmock/rspec'
+require 'support/gravity_helper'
+
+describe OrderService, type: :services do
+  let(:credit_card_id) { 'abc123' }
+  let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' } } }
+  let(:invalid_credit_card) { { external_id: 'card-1' } }
+  let(:order) { Fabricate(:order) }
+  describe '#set_payment!' do
+    it 'fetches a credit card given the credit card ID' do
+      expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
+      OrderService.set_payment!(order, credit_card_id: credit_card_id)
+    end
+    context 'with a valid credit card' do
+      it 'updates the order' do
+        allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
+        OrderService.set_payment!(order, credit_card_id: credit_card_id)
+        expect(order.credit_card_id).to eq credit_card_id
+        expect(order.external_credit_card_id).to eq credit_card[:external_id]
+        expect(order.external_customer_id).to eq credit_card[:customer_account][:external_id]
+      end
+    end
+    context 'with an invalid credit card' do
+      it 'raises an OrderError' do
+        allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
+        expect { OrderService.set_payment!(order, credit_card_id: credit_card_id) }.to raise_error(Errors::OrderError)
+      end
+    end
+  end
+
+  describe '#validate_credit_card!' do
+    it 'raises an error if the credit card does not have an external id' do
+      expect { OrderService.validate_credit_card!(customer_account: { external_id: 'cust-1' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
+    end
+    it 'raises an error if the credit card does not have a customer id' do
+      expect { OrderService.validate_credit_card!(external_id: 'cc-1') }.to raise_error(Errors::OrderError)
+      expect { OrderService.validate_credit_card!(external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil) }.to raise_error(Errors::OrderError)
+    end
+    it 'raises an error if the card is deactivated' do
+      expect { OrderService.validate_credit_card!(external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 'today') }.to raise_error(Errors::OrderError)
+    end
+  end
+end


### PR DESCRIPTION
### Problem
See https://github.com/artsy/exchange/issues/54#issuecomment-411809399.

### Solution
- Moves fetching the user's credit card from Gravity from `OrderSubmitService` to `OrderService.set_payment!`
- Adds `external_credit_card_id` and `external_customer_id` columns to `orders`
- Saves Stripe credit card and customer ID on order model