### PR TITLE
@williardx => add shipping and pricing fields to amqp event

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -18,12 +18,17 @@ class OrderEvent < Events::BaseEvent
       created_at: @object.created_at,
       currency_code: @object.currency_code,
       items_total_cents: @object.items_total_cents,
+      shipping_total_cents: @object.shipping_total_cents,
+      tax_total_cents: @object.tax_total_cents,
+      buyer_total_cents: @object.buyer_total_cents,
       line_items: @object.line_items.map { |li| line_item_detail(li) },
       partner_id: @object.partner_id,
       shipping_address_line1: @object.shipping_address_line1,
+      shipping_address_line2: @object.shipping_address_line2,
       shipping_city: @object.shipping_city,
       shipping_country: @object.shipping_country,
       shipping_postal_code: @object.shipping_postal_code,
+      shipping_region: @object.shipping_region,
       state: @object.state,
       updated_at: @object.updated_at
     }

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -6,12 +6,22 @@ describe OrderEvent, type: :events do
   let(:shipping_info) do
     {
       shipping_address_line1: '123 Main St',
+      shipping_address_line2: 'Apt 2',
       shipping_city: 'Chicago',
       shipping_country: 'USA',
-      shipping_postal_code: '60618'
+      shipping_postal_code: '60618',
+      shipping_region: 'IL'
     }
   end
-  let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id, currency_code: 'usd', **shipping_info) }
+  let(:order) do
+    Fabricate(:order,
+              partner_id: partner_id,
+              user_id: user_id,
+              currency_code: 'usd',
+              shipping_total_cents: 50,
+              tax_total_cents: 30,
+              **shipping_info)
+  end
   let!(:line_items) do
     [
       Fabricate(:line_item, price_cents: 200, order: order),
@@ -46,13 +56,18 @@ describe OrderEvent, type: :events do
       expect(event.properties[:currency_code]).to eq 'usd'
       expect(event.properties[:state]).to eq 'pending'
       expect(event.properties[:items_total_cents]).to eq 300
+      expect(event.properties[:shipping_total_cents]).to eq 50
+      expect(event.properties[:tax_total_cents]).to eq 30
+      expect(event.properties[:buyer_total_cents]).to eq 380
       expect(event.properties[:updated_at]).not_to be_nil
       expect(event.properties[:created_at]).not_to be_nil
       expect(event.properties[:line_items].count).to eq 2
-      expect(event.properties[:shipping_address_line1]).to eq shipping_info[:shipping_address_line1]
-      expect(event.properties[:shipping_city]).to eq shipping_info[:shipping_city]
-      expect(event.properties[:shipping_country]).to eq shipping_info[:shipping_country]
-      expect(event.properties[:shipping_postal_code]).to eq shipping_info[:shipping_postal_code]
+      expect(event.properties[:shipping_address_line1]).to eq '123 Main St'
+      expect(event.properties[:shipping_address_line2]).to eq 'Apt 2'
+      expect(event.properties[:shipping_city]).to eq 'Chicago'
+      expect(event.properties[:shipping_country]).to eq 'USA'
+      expect(event.properties[:shipping_postal_code]).to eq '60618'
+      expect(event.properties[:shipping_region]).to eq 'IL'
     end
   end
 end


### PR DESCRIPTION
blocks https://github.com/artsy/pulse/pull/228

This minor PR adds shipping and pricing details to the rabbitMQ event for an order.