### PR TITLE
Refund charges for rejected orders

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -28,6 +28,12 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
+  REJECTION_REASONS = [
+    EXPIRED = 'expired'.freeze,
+    CANCELED = 'canceled'.freeze,
+    FRAUDULENT = 'fraudulent'.freeze
+  ]
+
   ACTIONS = %i[abandon submit approve reject fulfill].freeze
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -28,12 +28,6 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  REJECTION_REASONS = [
-    EXPIRED = 'expired'.freeze,
-    CANCELED = 'canceled'.freeze,
-    FRAUDULENT = 'fraudulent'.freeze
-  ]
-
   ACTIONS = %i[abandon submit approve reject fulfill].freeze
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -6,4 +6,9 @@ class Transaction < ApplicationRecord
     CAPTURE = 'capture'.freeze,
     REFUND = 'refund'.freeze
   ].freeze
+
+  STATUSES = [
+    SUCCESS = 'success'.freeze,
+    FAILURE = 'failure'.freeze
+  ].freeze
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,6 +3,7 @@ class Transaction < ApplicationRecord
 
   TYPES = [
     HOLD = 'hold'.freeze,
-    CAPTURE = 'capture'.freeze
+    CAPTURE = 'capture'.freeze,
+    REFUND = 'refund'.freeze
   ].freeze
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -86,6 +86,7 @@ module OrderService
     rescue Errors::PaymentError => e
       TransactionService.create!(order, e.body)
       Rails.logger.error("Could not reject order #{order.id}: #{e.message}")
+      raise e
     end
     order
   end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -64,8 +64,10 @@ module OrderService
   def self.reject!(order)
     Order.transaction do
       order.reject!
+      refund = PaymentService.refund_charge(order.external_charge_id)
+      order.external_refund_id = refund.id
+      TransactionService.create_success!(order, refund)
       order.save!
-      # TODO: release the charge
     end
     order
   end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -76,7 +76,7 @@ module OrderService
       order.reject!
       refund = PaymentService.refund_charge(order.external_charge_id)
       transaction = {
-        external_id: order.external_charge_id,
+        external_id: refund.id,
         amount_cents: refund.amount,
         transaction_type: Transaction::REFUND,
         status: Transaction::SUCCESS

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -50,7 +50,7 @@ module PaymentService
     failed_refund = {
       id: charge_id,
       failure_code: body[:code],
-      failure_message: body[:message]
+      failure_message: body[:message],
       transaction_type: Transaction::REFUND
     }
     raise Errors::PaymentError.new(e.message, failed_refund)

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -40,4 +40,17 @@ module PaymentService
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
+
+  def self.refund_charge(charge_id)
+    refund = Stripe::Refund.create(charge: charge_id)
+    refund.transaction_type = Transaction::REFUND
+    refund
+  rescue Stripe::StripeError => e
+    body = e.json_body[:error]
+    failed_refund = {
+      transaction_type: Transaction::REFUND
+    }
+    raise Errors::PaymentError.new(e.message, failed_refund)
+  end
+
 end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -15,7 +15,7 @@ module PaymentService
     body = e.json_body[:error]
     failed_charge = {
       amount: amount,
-      id: body[:charge],
+      external_id: body[:charge],
       source_id: source_id,
       destination_id: destination_id,
       failure_code: body[:code],
@@ -34,7 +34,7 @@ module PaymentService
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_charge = {
-      id: charge_id,
+      external_id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message],
       transaction_type: Transaction::CAPTURE,
@@ -50,7 +50,7 @@ module PaymentService
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_refund = {
-      id: charge_id,
+      external_id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message],
       transaction_type: Transaction::REFUND,

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -58,5 +58,4 @@ module PaymentService
     }
     raise Errors::PaymentError.new(e.message, failed_refund)
   end
-
 end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -48,6 +48,9 @@ module PaymentService
   rescue Stripe::StripeError => e
     body = e.json_body[:error]
     failed_refund = {
+      id: charge_id,
+      failure_code: body[:code],
+      failure_message: body[:message]
       transaction_type: Transaction::REFUND
     }
     raise Errors::PaymentError.new(e.message, failed_refund)

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -20,7 +20,8 @@ module PaymentService
       destination_id: destination_id,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: Transaction::HOLD
+      transaction_type: Transaction::HOLD,
+      status: Transaction::FAILURE
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
@@ -36,7 +37,8 @@ module PaymentService
       id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: Transaction::CAPTURE
+      transaction_type: Transaction::CAPTURE,
+      status: Transaction::FAILURE
     }
     raise Errors::PaymentError.new(e.message, failed_charge)
   end
@@ -51,7 +53,8 @@ module PaymentService
       id: charge_id,
       failure_code: body[:code],
       failure_message: body[:message],
-      transaction_type: Transaction::REFUND
+      transaction_type: Transaction::REFUND,
+      status: Transaction::FAILURE
     }
     raise Errors::PaymentError.new(e.message, failed_refund)
   end

--- a/app/services/transaction_service.rb
+++ b/app/services/transaction_service.rb
@@ -1,27 +1,16 @@
 module TransactionService
-  def self.create_failure!(order, error)
+  def self.create!(order, transaction)
     order.transactions.create!(
-      external_id: error[:id],
-      source_id: error[:source_id],
-      destination_id: error[:destination_id],
-      amount_cents: error[:amount],
-      failure_code: error[:failure_code],
-      failure_message: error[:failure_message],
-      transaction_type: error[:transaction_type],
-      status: 'failure'
-    )
-  end
-
-  def self.create_success!(order, charge)
-    order.transactions.create!(
-      external_id: charge.id,
-      source_id: charge.source,
-      destination_id: charge.destination,
-      amount_cents: charge.amount,
-      failure_code: charge.failure_code,
-      failure_message: charge.failure_message,
-      transaction_type: charge.transaction_type,
-      status: 'success'
+      transaction.slice(
+        :external_id,
+        :source_id,
+        :destination_id,
+        :amount_cents,
+        :failure_code,
+        :failure_message,
+        :transaction_type,
+        :status
+      )
     )
   end
 end

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
+
   describe 'reject_order mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id) }
+    let(:order) { Fabricate(:order, partner_id: partner_id, user_id: user_id, external_charge_id: captured_charge.id) }
 
     let(:mutation) do
       <<-GRAPHQL
@@ -61,6 +63,8 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.reject_order.order.state).to eq 'REJECTED'
         expect(response.data.reject_order.errors).to match []
         expect(order.reload.state).to eq Order::REJECTED
+        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
       end
     end
   end

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -63,7 +63,7 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.reject_order.order.state).to eq 'REJECTED'
         expect(response.data.reject_order.errors).to match []
         expect(order.reload.state).to eq Order::REJECTED
-        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.external_id).to_not eq nil
         expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
       end
     end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -10,7 +10,7 @@ describe OrderService, type: :services do
     context 'with a successful refund' do
       it 'records the transaction' do
         OrderService.reject!(order)
-        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.external_id).to_not eq nil
         expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
         expect(order.transactions.last.status).to eq Transaction::SUCCESS
       end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -5,7 +5,7 @@ describe OrderService, type: :services do
   include_context 'use stripe mock'
   describe '#reject!' do
     before do
-      order.update_attributes! state: Order::SUBMITTED
+      order.update! state: Order::SUBMITTED
     end
     context 'with a successful refund' do
       it 'records the transaction' do

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -1,6 +1,4 @@
 require 'rails_helper'
-require 'webmock/rspec'
-require 'support/gravity_helper'
 
 describe OrderService, type: :services do
   let(:order) { Fabricate(:order, external_charge_id: captured_charge.id) }

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'webmock/rspec'
+require 'support/gravity_helper'
+
+describe OrderService, type: :services do
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id) }
+  include_context 'use stripe mock'
+  describe '#reject!' do
+    before do
+      order.update_attributes! state: Order::SUBMITTED
+    end
+    context 'with a successful refund' do
+      it 'records the transaction' do
+        OrderService.reject!(order)
+        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        expect(order.transactions.last.status).to eq Transaction::SUCCESS
+      end
+      it 'updates the order state' do
+        OrderService.reject!(order)
+        expect(order.state).to eq Order::REJECTED
+      end
+    end
+    context 'with an unsuccessful refund' do
+      it 'raises a PaymentError and records the transaction' do
+        StripeMock.prepare_card_error(:card_declined, :new_refund)
+        expect { OrderService.reject!(order) }.to raise_error(Errors::PaymentError)
+        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        expect(order.transactions.last.status).to eq Transaction::FAILURE
+      end
+    end
+  end
+end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -81,6 +81,7 @@ describe PaymentService, type: :services do
       expect { PaymentService.refund_charge(captured_charge.id) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
+        expect(e.body[:external_id]).to eq captured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
         expect(e.body[:transaction_type]).to eq Transaction::REFUND        

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -61,7 +61,7 @@ describe PaymentService, type: :services do
       expect { PaymentService.capture_charge(uncaptured_charge.id) }.to(raise_error do |e|
         expect(e).to be_a Errors::PaymentError
         expect(e.message).not_to eq nil
-        expect(e.body[:id]).to eq uncaptured_charge.id
+        expect(e.body[:external_id]).to eq uncaptured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
         expect(e.body[:transaction_type]).to eq Transaction::CAPTURE

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -68,4 +68,23 @@ describe PaymentService, type: :services do
       end)
     end
   end
+
+  describe '#refund_charge' do
+    it 'refunds a charge for the full amount' do
+      refund = PaymentService.refund_charge(captured_charge.id)
+      expect(refund.amount).to eq captured_charge.amount
+      expect(refund.charge).to eq captured_charge.id
+      expect(refund.transaction_type).to eq Transaction::REFUND
+    end
+    it 'catches Stripe errors and raises a PaymentError in its place' do
+      StripeMock.prepare_card_error(:processing_error, :new_refund)
+      expect { PaymentService.refund_charge(captured_charge.id) }.to(raise_error do |e|
+        expect(e).to be_a Errors::PaymentError
+        expect(e.message).not_to eq nil
+        expect(e.body[:failure_code]).not_to eq nil
+        expect(e.body[:failure_message]).not_to eq nil
+        expect(e.body[:transaction_type]).to eq Transaction::REFUND        
+      end)
+    end
+  end
 end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -84,7 +84,7 @@ describe PaymentService, type: :services do
         expect(e.body[:external_id]).to eq captured_charge.id
         expect(e.body[:failure_code]).not_to eq nil
         expect(e.body[:failure_message]).not_to eq nil
-        expect(e.body[:transaction_type]).to eq Transaction::REFUND        
+        expect(e.body[:transaction_type]).to eq Transaction::REFUND
       end)
     end
   end

--- a/spec/support/use_stripe_mock.rb
+++ b/spec/support/use_stripe_mock.rb
@@ -19,6 +19,15 @@ RSpec.shared_context 'use stripe mock' do
       capture: false
     )
   end
+  let(:captured_charge) do
+    Stripe::Charge.create(
+      amount: 22_222,
+      currency: 'usd',
+      source: stripe_helper.generate_card_token,
+      destination: 'ma-1',
+      capture: true
+    )
+  end
 end
 
 RSpec.configure do |rspec|


### PR DESCRIPTION
### Problem
We need to refund a charge when an order is rejected.

### Solution
On order rejection, create a new `Stripe::Refund` object with the order's charge ID and record the transaction.

### What changed
- Adds `PaymentService.refund_charge` method, which takes in a Stripe charge ID and refunds it.
- Adds `PaymentService.refund_charge` to `OrderService.reject!` as well as a record of the refund transaction. The refund transaction stores the charge ID and the amount.
- Removes `TransactionService.create_success!` and `TransactionService.create_failure!` in favor of a single method `TransactionService.create!` that accepts a hash of the fields used in a transaction. Updates associated tests and code.