### PR TITLE
Lock order before submitting or approving

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -33,14 +33,12 @@ module OrderService
   end
 
   def self.approve!(order, by: nil)
-    Order.transaction do
-      order.with_lock do
-        order.approve!
-        charge = PaymentService.capture_charge(order.external_charge_id)
-        TransactionService.create_success!(order, charge)
-        order.save!
-        PostNotificationJob.perform_later(order.id, Order::APPROVED, by)
-      end
+    order.with_lock do
+      order.approve!
+      charge = PaymentService.capture_charge(order.external_charge_id)
+      TransactionService.create_success!(order, charge)
+      order.save!
+      PostNotificationJob.perform_later(order.id, Order::APPROVED, by)
     end
     order
   rescue Errors::PaymentError => e

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -8,18 +8,17 @@ module OrderSubmitService
     validate_credit_card!(credit_card)
     charge_params = construct_charge_params(order, credit_card, merchant_account)
 
-    Order.transaction do
-      order.with_lock do
-        order.submit!
-        charge = PaymentService.authorize_charge(charge_params)
-        order.external_charge_id = charge[:id]
-        TransactionService.create_success!(order, charge)
-        order.commission_fee_cents = calculate_commission(order)
-        order.transaction_fee_cents = calculate_transaction_fee(order)
-        order.save!
-        PostNotificationJob.perform_later(order.id, Order::SUBMITTED, by)
-      end
+    order.with_lock do
+      order.submit!
+      charge = PaymentService.authorize_charge(charge_params)
+      order.external_charge_id = charge[:id]
+      TransactionService.create_success!(order, charge)
+      order.commission_fee_cents = calculate_commission(order)
+      order.transaction_fee_cents = calculate_transaction_fee(order)
+      order.save!
+      PostNotificationJob.perform_later(order.id, Order::SUBMITTED, by)
     end
+
     order
   rescue Errors::PaymentError => e
     TransactionService.create_failure!(order, e.body)


### PR DESCRIPTION
### Problem
It's currently possible to enter a race condition and submit or approve an order twice, resulting in duplicate transactions and Stripe calls.

### Solution
Lock the order when submitting or approving at the database level.

### What changed
- Wrapped order submit and approve code in `order.with_lock`
- Created a method for constructing charge parameters  in `OrderSubmitService.submit!`, mostly to satisfy Rubocop.