### PR TITLE
Adds shipping name to db, GraphQL schema

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -23,6 +23,7 @@ class OrderEvent < Events::BaseEvent
       buyer_total_cents: @object.buyer_total_cents,
       line_items: @object.line_items.map { |li| line_item_detail(li) },
       partner_id: @object.partner_id,
+      shipping_name: @object.shipping_name,
       shipping_address_line1: @object.shipping_address_line1,
       shipping_address_line2: @object.shipping_address_line2,
       shipping_city: @object.shipping_city,

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -2,6 +2,7 @@ class Mutations::SetShipping < Mutations::BaseMutation
   null true
 
   argument :id, ID, required: true
+  argument :shipping_name, String, required: false
   argument :shipping_address_line1, String, required: false
   argument :shipping_address_line2, String, required: false
   argument :shipping_city, String, required: false

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -9,6 +9,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
+  field :shipping_name, String, null: false
   field :shipping_address_line1, String, null: true
   field :shipping_address_line2, String, null: true
   field :shipping_city, String, null: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -66,7 +66,7 @@ class Order < ApplicationRecord
 
   def shipping_info?
     fulfillment_type == PICKUP ||
-      (fulfillment_type == SHIP && %i[shipping_address_line1 shipping_city shipping_country shipping_postal_code].all? { |sh_field| send(sh_field).present? })
+      (fulfillment_type == SHIP && complete_shipping_details?)
   end
 
   def payment_info?
@@ -107,5 +107,9 @@ class Order < ApplicationRecord
       self.state = machine.state
     end
     machine
+  end
+
+  def complete_shipping_details?
+    [shipping_name, shipping_address_line1, shipping_city, shipping_country, shipping_postal_code].all?(&:present?)
   end
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -18,6 +18,7 @@ module OrderService
       order.update!(
         attrs.merge(
           attributes.slice(
+            :shipping_name,
             :shipping_address_line1,
             :shipping_address_line2,
             :shipping_city,

--- a/db/migrate/20180815204249_add_shipping_name.rb
+++ b/db/migrate/20180815204249_add_shipping_name.rb
@@ -1,0 +1,5 @@
+class AddShippingName < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :shipping_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_192056) do
+ActiveRecord::Schema.define(version: 2018_08_15_204249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_192056) do
     t.string "fulfillment_type"
     t.string "shipping_region"
     t.string "external_charge_id"
+    t.string "shipping_name"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -33,6 +33,7 @@ describe Api::GraphqlController, type: :request do
         input: {
           id: order.id.to_s,
           fulfillmentType: fulfillment_type,
+          shippingName: 'Fname Lname',
           shippingCountry: shipping_country,
           shippingCity: 'Tehran',
           shippingRegion: 'Tehran',
@@ -74,6 +75,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.shipping_city).to eq 'Tehran'
         expect(order.shipping_region).to eq 'Tehran'
         expect(order.shipping_postal_code).to eq '02198912'
+        expect(order.shipping_name).to eq 'Fname Lname'
         expect(order.shipping_address_line1).to eq 'Vanak'
         expect(order.shipping_address_line2).to eq 'P 80'
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -17,6 +17,7 @@ describe Api::GraphqlController, type: :request do
         partner_id: partner_id,
         user_id: user_id,
         credit_card_id: credit_card_id,
+        shipping_name: 'Fname Lname',
         shipping_address_line1: '12 Vanak St',
         shipping_address_line2: 'P 80',
         shipping_city: 'Tehran',

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -5,6 +5,7 @@ describe OrderEvent, type: :events do
   let(:user_id) { 'user-1' }
   let(:shipping_info) do
     {
+      shipping_name: 'Fname Lname',
       shipping_address_line1: '123 Main St',
       shipping_address_line2: 'Apt 2',
       shipping_city: 'Chicago',
@@ -62,6 +63,7 @@ describe OrderEvent, type: :events do
       expect(event.properties[:updated_at]).not_to be_nil
       expect(event.properties[:created_at]).not_to be_nil
       expect(event.properties[:line_items].count).to eq 2
+      expect(event.properties[:shipping_name]).to eq 'Fname Lname'
       expect(event.properties[:shipping_address_line1]).to eq '123 Main St'
       expect(event.properties[:shipping_address_line2]).to eq 'Apt 2'
       expect(event.properties[:shipping_city]).to eq 'Chicago'

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -66,17 +66,17 @@ RSpec.describe Order, type: :model do
   describe '#shipping_info' do
     context 'with Ship fulfillment type' do
       it 'returns true when all required shipping data available' do
-        order.update!(fulfillment_type: Order::PICKUP, shipping_country: 'IR', shipping_address_line1: 'Vanak', shipping_address_line2: nil, shipping_postal_code: '09821', shipping_city: 'Tehran')
+        order.update!(fulfillment_type: Order::PICKUP, shipping_name: 'Fname Lname', shipping_country: 'IR', shipping_address_line1: 'Vanak', shipping_address_line2: nil, shipping_postal_code: '09821', shipping_city: 'Tehran')
         expect(order.shipping_info?).to be true
       end
       it 'returns false if missing any shipping data' do
-        order.update!(fulfillment_type: Order::SHIP, shipping_country: 'IR', shipping_address_line1: nil, shipping_postal_code: nil)
+        order.update!(fulfillment_type: Order::SHIP, shipping_name: 'Fname Lname', shipping_country: 'IR', shipping_address_line1: nil, shipping_postal_code: nil)
         expect(order.shipping_info?).to be false
       end
     end
     context 'with Pickup fulfillment type' do
       it 'returns true' do
-        order.update!(fulfillment_type: Order::PICKUP, shipping_country: nil, shipping_address_line1: nil, shipping_postal_code: nil)
+        order.update!(fulfillment_type: Order::PICKUP, shipping_name: 'Fname Lname', shipping_country: nil, shipping_address_line1: nil, shipping_postal_code: nil)
         expect(order.shipping_info?).to be true
       end
     end


### PR DESCRIPTION
This PR addresses [PURCHASE-377](https://artsyproduct.atlassian.net/browse/PURCHASE-377), adding `shipping_name` to the Order db table and the various parts of the GraphQL schema.

~This PR is a work-in-progress because I have not yet tested it locally (but unit tests pass!).~

Here's it working in action:

<img width="1624" alt="screen shot 2018-08-16 at 10 01 55 am" src="https://user-images.githubusercontent.com/498212/44213369-89b0ae00-a13b-11e8-877c-2df9d9275043.png">

Once this is merged, I will send a PR to metaphysics to update its copy of the Exchange schema. 