### PR TITLE
remove Events:: namespace from OrderEvent call

### DIFF
--- a/app/jobs/post_notification_job.rb
+++ b/app/jobs/post_notification_job.rb
@@ -3,6 +3,6 @@ class PostNotificationJob < ApplicationJob
 
   def perform(order_id, action, user_id)
     order = Order.find(order_id)
-    Events::OrderEvent.post(order, action, user_id)
+    OrderEvent.post(order, action, user_id)
   end
 end

--- a/spec/jobs/post_notification_job_spec.rb
+++ b/spec/jobs/post_notification_job_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe PostNotificationJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:order) { Fabricate(:order) }
+  it 'finds the order and posts the event' do
+    action = Order::SUBMITTED
+    expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(OrderEvent))
+    PostNotificationJob.new.perform(order.id, action, order.user_id)
+  end
 end


### PR DESCRIPTION
`PostNotificationJob#perform` calls `Events::OrderEvent#post`, but there is no `Events` namespace. As a result AMQP jobs are quietly retrying.

https://github.com/artsy/exchange/blob/4a38e435751b25553c5a5784a8e81ef0c48ea7ee/app/events/order_event.rb#L1
