### PR TITLE
Raise error when missing shipping info

### DIFF
--- a/app/services/shipping_service.rb
+++ b/app/services/shipping_service.rb
@@ -20,10 +20,10 @@ module ShippingService
   end
 
   def self.calculate_domestic(artwork)
-    artwork[:domestic_shipping_fee_cents] || 0
+    artwork[:domestic_shipping_fee_cents] || raise(Errors::OrderError, 'Artwork is missing shipping fee.')
   end
 
   def self.calculate_international(artwork)
-    artwork[:international_shipping_fee_cents] || 0
+    artwork[:international_shipping_fee_cents] || raise(Errors::OrderError, 'Artwork is missing shipping fee.')
   end
 end

--- a/spec/services/shipping_service_spec.rb
+++ b/spec/services/shipping_service_spec.rb
@@ -83,8 +83,8 @@ describe ShippingService, type: :services do
           location: artwork_location
         }
       end
-      it 'returns 0' do
-        expect(ShippingService.calculate_domestic(artwork)).to eq 0
+      it 'raises error' do
+        expect { ShippingService.calculate_domestic(artwork) }.to raise_error(Errors::OrderError, /Artwork is missing shipping fee/)
       end
     end
   end
@@ -101,8 +101,8 @@ describe ShippingService, type: :services do
           location: artwork_location
         }
       end
-      it 'returns 0' do
-        expect(ShippingService.calculate_international(artwork)).to eq 0
+      it 'raises error' do
+        expect { ShippingService.calculate_international(artwork) }.to raise_error(Errors::OrderError, /Artwork is missing shipping fee/)
       end
     end
   end


### PR DESCRIPTION
# Problem
When `domestic_shipping_fee_cents` and `international_shipping_fee_cents` are not set we were assuming that means they are 0 but it actually means partner never confirmed/set the shipping cost on this artwork and we should raise error.