### PR TITLE
@ashkan18 => allow shipping_name to be null in graphql schema

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -9,7 +9,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
-  field :shipping_name, String, null: false
+  field :shipping_name, String, null: true
   field :shipping_address_line1, String, null: true
   field :shipping_address_line2, String, null: true
   field :shipping_city, String, null: true


### PR DESCRIPTION
#minor but when orders are created, they won't have this field set (so we are getting errors on the initial mutation for a null field not being nullable).