### PR TITLE
Refactor shipping related Mutations and Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ mutation($input: SetShippingInput!) {
       userId
       partnerId
       state
+      fulfillment{
+        ... on Ship{
+          addressLine1
+          country
+        }
+      }
     }
     errors
   }
@@ -119,12 +125,14 @@ For input:
   "input": {
     "id": "<order id>",
     "fulfillmentType": "SHIP/PICKUP",
-    "shippingAddressLine1": "",
-    "shippingAddressLine2": "",
-    "shippingCity": "",
-    "shippingRegion": "",
-    "shippingCountry": "",
-    "shippingPostalCode": ""
+    "shipping": {
+      "addressLine1": "",
+      "addressLine2": "",
+      "city": "",
+      "region": "",
+      "country": "",
+      "postalCode": ""
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ mutation($input: SetShippingInput!) {
       partnerId
       state
       fulfillment{
-        ... on Ship{
+        __typename
+        ... on Ship {
           addressLine1
           country
         }
@@ -124,14 +125,14 @@ For input:
 {
   "input": {
     "id": "<order id>",
-    "fulfillmentType": "SHIP/PICKUP",
+    "fulfillmentType": "<SHIP/PICKUP>",
     "shipping": {
-      "addressLine1": "",
+      "addressLine1": "Vanak v1",
       "addressLine2": "",
-      "city": "",
-      "region": "",
-      "country": "",
-      "postalCode": ""
+      "city": "Tehran",
+      "region": "Tehran",
+      "country": "IR",
+      "postalCode": "09821"
     }
   }
 }

--- a/app/graphql/inputs/fulfillment_attributes.rb
+++ b/app/graphql/inputs/fulfillment_attributes.rb
@@ -1,4 +1,4 @@
-class Types::FulfillmentAttributes < Types::BaseInputObject
+class Inputs::FulfillmentAttributes < Types::BaseInputObject
   description 'Attributes of a Fulfillment'
 
   argument :courier, String, required: true

--- a/app/graphql/inputs/shipping_attributes.rb
+++ b/app/graphql/inputs/shipping_attributes.rb
@@ -1,0 +1,11 @@
+class Inputs::ShippingAttributes < Types::BaseInputObject
+  description 'Shipping information'
+
+  argument :name, String, required: false
+  argument :address_line1, String, required: false
+  argument :address_line2, String, required: false
+  argument :city, String, required: false
+  argument :region, String, required: false
+  argument :country, String, required: false
+  argument :postal_code, String, required: false
+end

--- a/app/graphql/mutations/fulfill_at_once.rb
+++ b/app/graphql/mutations/fulfill_at_once.rb
@@ -3,7 +3,7 @@ class Mutations::FulfillAtOnce < Mutations::BaseMutation
   description 'Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order'
 
   argument :id, ID, required: true
-  argument :fulfillment, Types::FulfillmentAttributes, required: true
+  argument :fulfillment, Inputs::FulfillmentAttributes, required: true
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -2,14 +2,8 @@ class Mutations::SetShipping < Mutations::BaseMutation
   null true
 
   argument :id, ID, required: true
-  argument :shipping_name, String, required: false
-  argument :shipping_address_line1, String, required: false
-  argument :shipping_address_line2, String, required: false
-  argument :shipping_city, String, required: false
-  argument :shipping_region, String, required: false
-  argument :shipping_country, String, required: false
-  argument :shipping_postal_code, String, required: false
   argument :fulfillment_type, Types::OrderFulfillmentTypeEnum, required: false
+  argument :shipping, Inputs::ShippingAttributes, required: false
 
   field :order, Types::OrderType, null: true
   field :errors, [String], null: false

--- a/app/graphql/types/fulfillment_union_type.rb
+++ b/app/graphql/types/fulfillment_union_type.rb
@@ -1,0 +1,34 @@
+class Types::Ship < Types::BaseObject
+  field :name, String, null: true
+  field :address_line1, String, null: true
+  field :address_line2, String, null: true
+  field :city, String, null: true
+  field :region, String, null: true
+  field :country, String, null: true
+  field :postal_code, String, null: true
+
+  # generate methods for mapping above fields to field name on the model
+  %w[name address_line1 address_line2 city region country postal_code].each do |field_name|
+    define_method field_name do
+      object.send("shipping_#{field_name}".to_sym)
+    end
+  end
+end
+
+class Types::Pickup < Types::BaseObject; end
+
+class Types::FulfillmentUnionType < Types::BaseUnion
+  description 'Represents either a shipping information or pickup'
+  possible_types Types::Ship, Types::Pickup
+
+  def self.resolve_type(object, _context)
+    case object.fulfillment_type
+    when Order::SHIP
+      Types::Ship
+    when Order::PICKUP
+      Types::Pickup
+    else
+      raise "Unexpected Return value: #{object.inspect}"
+    end
+  end
+end

--- a/app/graphql/types/fulfillment_union_type.rb
+++ b/app/graphql/types/fulfillment_union_type.rb
@@ -1,14 +1,7 @@
 class Types::Ship < Types::BaseObject
-  field :name, String, null: true
-  field :address_line1, String, null: true
-  field :address_line2, String, null: true
-  field :city, String, null: true
-  field :region, String, null: true
-  field :country, String, null: true
-  field :postal_code, String, null: true
-
-  # generate methods for mapping above fields to field name on the model
+  # generate methods for shipping fields to field name on the model (add shipping_)
   %w[name address_line1 address_line2 city region country postal_code].each do |field_name|
+    field field_name.to_sym, String, null: true
     define_method field_name do
       object.send("shipping_#{field_name}".to_sym)
     end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -9,14 +9,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
-  field :shipping_name, String, null: true
-  field :shipping_address_line1, String, null: true
-  field :shipping_address_line2, String, null: true
-  field :shipping_city, String, null: true
-  field :shipping_region, String, null: true
-  field :shipping_country, String, null: true
-  field :shipping_postal_code, String, null: true
-  field :fulfillment_type, Types::OrderFulfillmentTypeEnum, null: true
+  field :fulfillment, Types::FulfillmentUnionType, null: true
   field :items_total_cents, Integer, null: false
   field :shipping_total_cents, Integer, null: true
   field :tax_total_cents, Integer, null: true
@@ -29,4 +22,11 @@ class Types::OrderType < Types::BaseObject
   field :state_updated_at, Types::DateTimeType, null: true
   field :state_expires_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
+
+  def fulfillment
+    # fulfillment is not a field on order so we have to resolve it here
+    # it uses our union, for that to work we need to pass order (aka object)
+    # to our Fulfillment
+    object
+  end
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -7,26 +7,23 @@ module OrderService
     order
   end
 
-  def self.set_shipping!(order, attributes)
+  def self.set_shipping!(order, fulfillment_type:, shipping: {})
     raise Errors::OrderError, 'Cannot set shipping info on non-pending orders' unless order.state == Order::PENDING
-
     Order.transaction do
       attrs = {
-        shipping_total_cents: order.line_items.map { |li| ShippingService.calculate_shipping(li, attributes.slice(:shipping_country, :fulfillment_type)) }.sum,
+        shipping_total_cents: order.line_items.map { |li| ShippingService.calculate_shipping(li, shipping_country: shipping[:country], fulfillment_type: fulfillment_type) }.sum,
         tax_total_cents: 100_00 # TODO: 🚨 replace this with real tax calculation 🚨
       }
       order.update!(
         attrs.merge(
-          attributes.slice(
-            :shipping_name,
-            :shipping_address_line1,
-            :shipping_address_line2,
-            :shipping_city,
-            :shipping_region,
-            :shipping_country,
-            :shipping_postal_code,
-            :fulfillment_type
-          )
+          fulfillment_type: fulfillment_type,
+          shipping_name: shipping[:name],
+          shipping_address_line1: shipping[:address_line1],
+          shipping_address_line2: shipping[:address_line2],
+          shipping_city: shipping[:city],
+          shipping_region: shipping[:region],
+          shipping_country: shipping[:country],
+          shipping_postal_code: shipping[:postal_code]
         )
       )
     end

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -19,7 +19,12 @@ describe Api::GraphqlController, type: :request do
               userId
               partnerId
               state
-              fulfillmentType
+              fulfillment {
+                __typename
+                ... on Ship {
+                  addressLine1
+                }
+              }
               shippingTotalCents
             }
             errors
@@ -33,13 +38,15 @@ describe Api::GraphqlController, type: :request do
         input: {
           id: order.id.to_s,
           fulfillmentType: fulfillment_type,
-          shippingName: 'Fname Lname',
-          shippingCountry: shipping_country,
-          shippingCity: 'Tehran',
-          shippingRegion: 'Tehran',
-          shippingPostalCode: '02198912',
-          shippingAddressLine1: 'Vanak',
-          shippingAddressLine2: 'P 80'
+          shipping: {
+            name: 'Fname Lname',
+            country: shipping_country,
+            city: 'Tehran',
+            region: 'Tehran',
+            postalCode: '02198912',
+            addressLine1: 'Vanak',
+            addressLine2: 'P 80'
+          }
         }
       }
     end
@@ -69,6 +76,7 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.set_shipping.order.id).to eq order.id.to_s
         expect(response.data.set_shipping.order.state).to eq 'PENDING'
         expect(response.data.set_shipping.errors).to match []
+        expect(response.data.set_shipping.order.fulfillment.address_line1).to eq 'Vanak'
         expect(order.reload.fulfillment_type).to eq Order::SHIP
         expect(order.state).to eq Order::PENDING
         expect(order.shipping_country).to eq 'IR'


### PR DESCRIPTION
# Problem
There were some discussions started https://github.com/artsy/reaction/pull/1151/files/67bc80c99850925eafbad027eaf5daac9e76ae12#diff-58473875e67f62dffa8c78534cbfaa5e which lead to following decisions:
- Update `order` type to use a union for returning shipping related fields and basically don't return them for orders with `pickup` fulfillment type.
- In the union returned, remove redundant `shipping_` from all the fields now that we are already in a newly added `Ship` type
- Update `setShipping` mutation to wrap shipping related input fields under `shipping` so we can remove redundant `shipping_` from those fields and also have more structured data.

# Solution
Basically do all the above. There are some weird looking code that needed to be added for this to work, i'll comment on those lines.

# Upgrade Notes
## Querying (CC: **Purchase/Sell Team)
in your queries wherever you are asking for order shipping details you need to change:

```graphql
{
  id
  shippingAddressLine1
  shippingCity
  .
  .
}
```
to 
```graphql
{
  id
  fulfillment {
   ... on Ship {
      addressLine1
      city
   }
}
````

## Mutations (CC: **Purchase Team)
instead of passing input like
```json
{
  "input": {
    "id": "<order id>",
    "fulfillmentType": "SHIP/PICKUP",
    "shippingAddressLine1": "",
    "shippingAddressLine2": "",
    "shippingCity": "",
    "shippingRegion": "",
    "shippingCountry": "",
    "shippingPostalCode": ""
  }
}
```

use
```json
{
  "input": {
    "id": "<order id>",
    "fulfillmentType": "SHIP/PICKUP",
    "shipping": {
      "addressLine1": "",
      "addressLine2": "",
      "city": "",
      "region": "",
      "country": "",
      "postalCode": ""
    }
  }
}
```