### PR TITLE
Record timestamp when order enters a new state

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -22,6 +22,10 @@ class Types::OrderType < Types::BaseObject
   field :state_updated_at, Types::DateTimeType, null: true
   field :state_expires_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
+  field :submitted_at, Types::DateTimeType, null: true
+  field :approved_at, Types::DateTimeType, null: true
+  field :rejected_at, Types::DateTimeType, null: true
+  field :fulfilled_at, Types::DateTimeType, null: true
 
   def fulfillment
     # fulfillment is not a field on order so we have to resolve it here

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -90,7 +90,7 @@ class Order < ApplicationRecord
 
   def update_state_timestamps
     self.state_updated_at = Time.now.utc
-    self.send("#{self.state}_at=", Time.now.utc) unless self.state == Order::PENDING
+    send("#{state}_at=", Time.now.utc) unless state == Order::PENDING
     self.state_expires_at = STATE_EXPIRATIONS.key?(state) ? state_updated_at + STATE_EXPIRATIONS[state] : nil
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -90,6 +90,7 @@ class Order < ApplicationRecord
 
   def update_state_timestamps
     self.state_updated_at = Time.now.utc
+    self.send("#{self.state}_at=", Time.now.utc) unless self.state == Order::PENDING
     self.state_expires_at = STATE_EXPIRATIONS.key?(state) ? state_updated_at + STATE_EXPIRATIONS[state] : nil
   end
 

--- a/db/migrate/20180823210216_add_abandoned_at_to_orders.rb
+++ b/db/migrate/20180823210216_add_abandoned_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddAbandonedAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :abandoned_at, :datetime
+  end
+end

--- a/db/migrate/20180823210234_add_submitted_at_to_orders.rb
+++ b/db/migrate/20180823210234_add_submitted_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :submitted_at, :datetime
+  end
+end

--- a/db/migrate/20180823210250_add_approved_at_to_orders.rb
+++ b/db/migrate/20180823210250_add_approved_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddApprovedAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :approved_at, :datetime
+  end
+end

--- a/db/migrate/20180823210305_add_rejected_at_to_orders.rb
+++ b/db/migrate/20180823210305_add_rejected_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddRejectedAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :rejected_at, :datetime
+  end
+end

--- a/db/migrate/20180823210320_add_fulfilled_at_to_orders.rb
+++ b/db/migrate/20180823210320_add_fulfilled_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddFulfilledAtToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :fulfilled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_15_204249) do
+ActiveRecord::Schema.define(version: 2018_08_23_210320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,11 @@ ActiveRecord::Schema.define(version: 2018_08_15_204249) do
     t.string "shipping_region"
     t.string "external_charge_id"
     t.string "shipping_name"
+    t.datetime "abandoned_at"
+    t.datetime "submitted_at"
+    t.datetime "approved_at"
+    t.datetime "rejected_at"
+    t.datetime "fulfilled_at"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["partner_id"], name: "index_orders_on_partner_id"
     t.index ["state"], name: "index_orders_on_state"

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -69,6 +69,7 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.state).to eq Order::APPROVED
           expect(order.reload.transactions.last.external_id).to eq uncaptured_charge.id
           expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
+          expect(order.reload.approved_at).not_to be_nil
         end.to change(order, :state_expires_at)
       end
 

--- a/spec/controllers/api/requests/fulfill_at_once_request_spec.rb
+++ b/spec/controllers/api/requests/fulfill_at_once_request_spec.rb
@@ -93,6 +93,7 @@ describe Api::GraphqlController, type: :request do
           end
           expect(response.data.fulfill_at_once.errors).to match []
           expect(order.reload.state).to eq Order::FULFILLED
+          expect(order.fulfilled_at).not_to be_nil
           order.line_items.each do |li|
             expect(li.fulfillments.count).to eq 1
             expect(li.fulfillments.first.courier).to eq 'FedEx'

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -65,6 +65,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.reload.state).to eq Order::REJECTED
         expect(order.transactions.last.external_id).to_not eq nil
         expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        expect(order.rejected_at).to_not be_nil
       end
     end
   end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -113,6 +113,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.commission_fee_cents).to eq 800_00
         expect(order.state_updated_at).not_to be_nil
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+        expect(order.submitted_at).to_not be_nil
         expect(order.reload.transactions.last.external_id).not_to be_nil
         expect(order.reload.transactions.last.transaction_type).to eq Transaction::HOLD
       end


### PR DESCRIPTION
This PR addresses [PLATFORM-773](https://artsyproduct.atlassian.net/browse/PLATFORM-773) and updates a timestamp when an order becomes abandoned, submitted, approved, rejected or fulfilled.

Metaphysics PR forthcoming!

### What Changed
- Adds 5 new datetime columns to the orders table: `abandoned_at`, `submitted_at`, `approved_at`, `rejected_at` and `fulfilled_at`.
- Sets `order.$STATE_at` for each state except pending whenever the state changes.
- Adds `submitted_at`, `approved_at`, `rejected_at` and `fulfilled_at` to the GraphQL schema.