### PR TITLE
[COORDINATED MERGE] Bring back requestedFulfillmentUnion

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ mutation($input: SetShippingInput!) {
           addressLine1
           country
         }
+        ... on Pickup {
+          fulfillmentType
+        }
       }
     }
     errors

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -9,14 +9,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :state, Types::OrderStateEnum, null: false
   field :currency_code, String, null: false
-  field :shipping_name, String, null: true
-  field :shipping_address_line1, String, null: true
-  field :shipping_address_line2, String, null: true
-  field :shipping_city, String, null: true
-  field :shipping_region, String, null: true
-  field :shipping_country, String, null: true
-  field :shipping_postal_code, String, null: true
-  field :fulfillment_type, Types::OrderFulfillmentTypeEnum, null: true
+  field :requested_fulfillment, Types::RequestedFulfillmentUnionType, null: true
   field :items_total_cents, Integer, null: false
   field :shipping_total_cents, Integer, null: true
   field :tax_total_cents, Integer, null: true
@@ -29,4 +22,12 @@ class Types::OrderType < Types::BaseObject
   field :state_updated_at, Types::DateTimeType, null: true
   field :state_expires_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
+
+  def requested_fulfillment
+    # fulfillment is not a field on order so we have to resolve it here
+    # it uses our union, for that to work we need to pass order (aka object)
+    # to our Fulfillment
+    return if object.fulfillment_type.blank?
+    object
+  end
 end

--- a/app/graphql/types/requested_fulfillment_union_type.rb
+++ b/app/graphql/types/requested_fulfillment_union_type.rb
@@ -1,0 +1,30 @@
+class Types::Ship < Types::BaseObject
+  # generate methods for shipping fields to field name on the model (add shipping_)
+  %w[name address_line1 address_line2 city region country postal_code].each do |field_name|
+    field field_name.to_sym, String, null: true
+    define_method field_name do
+      object.send("shipping_#{field_name}".to_sym)
+    end
+  end
+end
+class Types::Pickup < Types::BaseObject
+  field :fulfillment_type, String, null: false
+  def fulfillment_type
+    Order::PICKUP
+  end
+end
+
+class Types::RequestedFulfillmentUnionType < Types::BaseUnion
+  description 'Represents either a shipping information or pickup'
+  possible_types Types::Ship, Types::Pickup
+  def self.resolve_type(object, _context)
+    case object.fulfillment_type
+    when Order::SHIP
+      Types::Ship
+    when Order::PICKUP
+      Types::Pickup
+    else
+      raise "Unexpected Return value: #{object.inspect}"
+    end
+  end
+end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -30,6 +30,11 @@ describe Api::GraphqlController, type: :request do
                     }
                   }
                 }
+                requestedFulfillment{
+                  ... on Ship {
+                    name
+                  }
+                }
               }
             }
           }

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -26,8 +26,13 @@ describe Api::GraphqlController, type: :request do
               userId
               partnerId
               state
-              shippingAddressLine1
               shippingTotalCents
+              requestedFulfillment {
+                __typename
+                ... on Ship {
+                  addressLine1
+                }
+              }
             }
             errors
           }
@@ -87,7 +92,7 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.set_shipping.order.id).to eq order.id.to_s
         expect(response.data.set_shipping.order.state).to eq 'PENDING'
         expect(response.data.set_shipping.errors).to match []
-        expect(response.data.set_shipping.order.shipping_address_line1).to eq 'Vanak'
+        expect(response.data.set_shipping.order.requested_fulfillment.address_line1).to eq 'Vanak'
         expect(order.reload.fulfillment_type).to eq Order::SHIP
         expect(order.state).to eq Order::PENDING
         expect(order.shipping_country).to eq 'IR'


### PR DESCRIPTION
# Problem
Because of MP's issues in using `requestedFulfilmentUnion` when getting a connection of `Order`s we reverted the changes we made in #119 and few followups.
We now have  a solution for that issue and can bring this back.

** COORDINATED MERGE ** going to open a MP PR to match these changes, lets merge this with that one around the same time so staging MP -> Exchange stays in sync.