### PR TITLE
Update inventory

### DIFF
--- a/app/controllers/errors/inventory_error.rb
+++ b/app/controllers/errors/inventory_error.rb
@@ -1,0 +1,9 @@
+module Errors
+  class InventoryError < ApplicationError
+    attr_reader :message, :line_item
+    def initialize(message, line_item)
+      @message = message
+      @line_item = line_item
+    end
+  end
+end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -10,7 +10,7 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     order = Order.find(id)
     validate_request!(order)
     {
-      order: OrderSubmitService.submit!(order, by: context[:current_user]['id']),
+      order: OrderSubmitService.call!(order, by: context[:current_user]['id']),
       errors: []
     }
   rescue Errors::ApplicationError, Errors::PaymentError => e

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -63,6 +63,6 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Credit card not found'
   rescue Adapters::GravityError => e
-    raise Errors::OrderError, e.message
+    raise Errors::InventoryError.new(e.message, line_item)
   end
 end

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -50,8 +50,8 @@ module GravityService
     end
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Credit card not found'
-  rescue Adapters::GravityError, StandardError => e
-    raise Errors::OrderError, e.message
+  rescue Adapters::GravityError => e
+    raise Errors::InventoryError.new(e.message, line_item)
   end
 
   def self.undeduct_inventory(line_item)
@@ -62,7 +62,7 @@ module GravityService
     end
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Credit card not found'
-  rescue Adapters::GravityError, StandardError => e
+  rescue Adapters::GravityError => e
     raise Errors::OrderError, e.message
   end
 end

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -1,7 +1,7 @@
 module GravityService
   def self.fetch_partner(partner_id)
     Rails.cache.fetch("gravity_partner_#{partner_id}", expire_in: Rails.application.config_for(:gravity)['partner_cache_in_seconds']) do
-      Adapters::GravityV1.request("/partner/#{partner_id}/all")
+      Adapters::GravityV1.get("/partner/#{partner_id}/all")
     end
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Unable to find partner'
@@ -10,7 +10,7 @@ module GravityService
   end
 
   def self.get_merchant_account(partner_id)
-    merchant_account = Adapters::GravityV1.request("/merchant_accounts?partner_id=#{partner_id}").first
+    merchant_account = Adapters::GravityV1.get('/merchant_accounts', params: { partner_id: partner_id }).first
     raise Errors::OrderError, 'Partner does not have merchant account' if merchant_account.nil?
     merchant_account
   rescue Adapters::GravityNotFoundError
@@ -20,7 +20,7 @@ module GravityService
   end
 
   def self.get_credit_card(credit_card_id)
-    Adapters::GravityV1.request("/credit_card/#{credit_card_id}")
+    Adapters::GravityV1.get("/credit_card/#{credit_card_id}")
   rescue Adapters::GravityNotFoundError
     raise Errors::OrderError, 'Credit card not found'
   rescue Adapters::GravityError, StandardError => e
@@ -28,7 +28,7 @@ module GravityService
   end
 
   def self.get_artwork(artwork_id)
-    Adapters::GravityV1.request("/artwork/#{artwork_id}")
+    Adapters::GravityV1.get("/artwork/#{artwork_id}")
   rescue Adapters::GravityError, StandardError => e
     Rails.logger.warn("Could not fetch artwork #{artwork_id} from gravity: #{e.message}")
     nil
@@ -37,8 +37,32 @@ module GravityService
   def self.fetch_partner_location(partner_id)
     partner = fetch_partner(partner_id)
     location = Rails.cache.fetch("gravity_partner_location_#{partner[:billing_location_id]}", expire_in: Rails.application.config_for(:gravity)['partner_cache_in_seconds']) do
-      Adapters::GravityV1.request("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
+      Adapters::GravityV1.get("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
     end
     location.slice(:address, :address_2, :city, :state, :country, :postal_code)
+  end
+
+  def self.deduct_inventory(line_item)
+    if line_item.edition_set_id
+      Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/edition_set/#{line_item.edition_set_id}/inventory", params: { deduct: line_item.quantity })
+    else
+      Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/inventory", params: { deduct: line_item.quantity })
+    end
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Credit card not found'
+  rescue Adapters::GravityError, StandardError => e
+    raise Errors::OrderError, e.message
+  end
+
+  def self.undeduct_inventory(line_item)
+    if line_item.edition_set_id
+      Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/edition_set/#{line_item.edition_set_id}/inventory", params: { undeduct: line_item.quantity })
+    else
+      Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/inventory", params: { undeduct: line_item.quantity })
+    end
+  rescue Adapters::GravityNotFoundError
+    raise Errors::OrderError, 'Credit card not found'
+  rescue Adapters::GravityError, StandardError => e
+    raise Errors::OrderError, e.message
   end
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -69,7 +69,7 @@ module OrderService
 
   def self.reject!(order, by)
     order.reject! do
-      release_inventory_refund(order)
+      refund(order)
     end
     PostNotificationJob.perform_later(order.id, Order::REJECTED, by)
     order
@@ -81,7 +81,7 @@ module OrderService
 
   def self.seller_lapse!(order)
     order.seller_lapse! do
-      release_inventory_refund(order)
+      refund(order)
     end
     PostNotificationJob.perform_later(order.id, Order::SELLER_LAPSED)
     order
@@ -95,7 +95,7 @@ module OrderService
     Order::SUPPORTED_CURRENCIES.include?(currency_code.downcase)
   end
 
-  def self.release_inventory_refund(order)
+  def self.refund(order)
     refund = PaymentService.refund_charge(order.external_charge_id)
     transaction = {
       external_id: refund.id,

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -69,7 +69,7 @@ module OrderService
 
   def self.reject!(order, by)
     order.reject! do
-      refund(order)
+      release_inventory_refund(order)
     end
     PostNotificationJob.perform_later(order.id, Order::REJECTED, by)
     order
@@ -81,7 +81,7 @@ module OrderService
 
   def self.seller_lapse!(order)
     order.seller_lapse! do
-      refund(order)
+      release_inventory_refund(order)
     end
     PostNotificationJob.perform_later(order.id, Order::SELLER_LAPSED)
     order
@@ -95,7 +95,7 @@ module OrderService
     Order::SUPPORTED_CURRENCIES.include?(currency_code.downcase)
   end
 
-  def self.refund(order)
+  def self.release_inventory_refund(order)
     refund = PaymentService.refund_charge(order.external_charge_id)
     transaction = {
       external_id: refund.id,
@@ -104,5 +104,6 @@ module OrderService
       status: Transaction::SUCCESS
     }
     TransactionService.create!(order, transaction)
+    order.line_items.each { |li| GravityService.undeduct_inventory(li) }
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -1,29 +1,35 @@
-module OrderSubmitService
-  def self.submit!(order, by: nil)
-    # verify price change?
-    raise Errors::OrderError, "Missing info for submitting order(#{order.id})" unless can_submit?(order)
+class OrderSubmitService
+  def self.call!(order, by: nil)
+    new(order, by).process!
+  end
 
-    merchant_account = GravityService.get_merchant_account(order.partner_id)
-    credit_card = GravityService.get_credit_card(order.credit_card_id)
-    validate_credit_card!(credit_card)
-    charge_params = construct_charge_params(order, credit_card, merchant_account)
+  attr_accessor :order, :credit_card, :merchant_account, :partner
+  def initialize(order, by)
+    @order = order
+    @by = by
+    @credit_card = nil
+    @merchant_account = nil
+    @partner = nil
+  end
+
+  def process!
+    raise Errors::OrderError, "Missing info for submitting order(#{@order.id})" unless can_submit?
+    # verify price change?
+    pre_process!
     deducted_inventory = []
-    order.submit! do
+    @order.submit! do
       # Try holding artwork and deduct inventory
-      order.line_items.each do |li|
+      @order.line_items.each do |li|
         GravityService.deduct_inventory(li)
         deducted_inventory << li
       end
-      charge = PaymentService.authorize_charge(charge_params)
-      order.external_charge_id = charge.id
+      charge = PaymentService.authorize_charge(construct_charge_params)
       transaction = construct_transaction_success(charge)
-      TransactionService.create!(order, transaction)
-      order.update!(commission_fee_cents: calculate_commission(order), transaction_fee_cents: calculate_transaction_fee(order))
+      TransactionService.create!(@order, transaction)
+      @order.update!(external_charge_id: charge.id, commission_fee_cents: calculate_commission_fee, transaction_fee_cents: calculate_transaction_fee)
     end
-
-    PostNotificationJob.perform_later(order.id, Order::SUBMITTED, by)
-    OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
-    order
+    post_process!
+    @order
   rescue Errors::InventoryError => e
     # deduct failed for one of the line items, undeduct all already deducted inventory
     deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
@@ -31,12 +37,26 @@ module OrderSubmitService
   rescue Errors::PaymentError => e
     # there was an issue in processing charge, undeduct all already deducted inventory
     deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
-    TransactionService.create!(order, e.body)
-    Rails.logger.error("Could not submit order #{order.id}: #{e.message}")
+    TransactionService.create!(@order, e.body)
+    Rails.logger.error("Could not submit order #{@order.id}: #{e.message}")
     raise e
   end
 
-  def self.construct_transaction_success(charge)
+  private
+
+  def pre_process!
+    @credit_card = GravityService.get_credit_card(@order.credit_card_id)
+    assert_credit_card!
+    @partner = GravityService.fetch_partner(@order.partner_id)
+    @merchant_account = GravityService.get_merchant_account(@order.partner_id)
+  end
+
+  def post_process!
+    PostNotificationJob.perform_later(@order.id, Order::SUBMITTED, @by)
+    OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
+  end
+
+  def construct_transaction_success(charge)
     {
       external_id: charge.id,
       source_id: charge.source,
@@ -49,33 +69,32 @@ module OrderSubmitService
     }
   end
 
-  def self.construct_charge_params(order, credit_card, merchant_account)
+  def construct_charge_params
     {
-      source_id: credit_card[:external_id],
-      customer_id: credit_card[:customer_account][:external_id],
-      destination_id: merchant_account[:external_id],
-      amount: order.buyer_total_cents,
-      currency_code: order.currency_code
+      source_id: @credit_card[:external_id],
+      customer_id: @credit_card[:customer_account][:external_id],
+      destination_id: @merchant_account[:external_id],
+      amount: @order.buyer_total_cents,
+      currency_code: @order.currency_code
     }
   end
 
-  def self.validate_credit_card!(credit_card)
-    raise Errors::OrderError, 'Credit card does not have external id' if credit_card[:external_id].blank?
-    raise Errors::OrderError, 'Credit card does not have customer id' if credit_card.dig(:customer_account, :external_id).blank?
-    raise Errors::OrderError, 'Credit card is deactivated' unless credit_card[:deactivated_at].nil?
+  def assert_credit_card!
+    raise Errors::OrderError, 'Credit card does not have external id' if @credit_card[:external_id].blank?
+    raise Errors::OrderError, 'Credit card does not have customer' if @credit_card.dig(:customer_account, :external_id).blank?
+    raise Errors::OrderError, 'Credit card is deactivated' unless @credit_card[:deactivated_at].nil?
   end
 
-  def self.can_submit?(order)
-    order.shipping_info? && order.payment_info?
+  def can_submit?
+    @order.shipping_info? && @order.payment_info?
   end
 
-  def self.calculate_commission(order)
-    partner = GravityService.fetch_partner(order.partner_id)
-    order.items_total_cents * partner[:effective_commission_rate]
+  def calculate_commission_fee
+    @order.items_total_cents * @partner[:effective_commission_rate]
   end
 
-  def self.calculate_transaction_fee(order)
+  def calculate_transaction_fee
     # This is based on Stripe US fee, it will be different for other countries
-    (Money.new(order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
+    (Money.new(@order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
   end
 end

--- a/lib/adapters/gravity_v1.rb
+++ b/lib/adapters/gravity_v1.rb
@@ -2,9 +2,19 @@ module Adapters
   class GravityError < StandardError; end
   class GravityNotFoundError < GravityError; end
   class GravityV1
-    def self.request(url)
+    def self.get(url, params: {})
       url = "#{Rails.application.config_for(:gravity)['api_v1_root']}#{url}"
-      response = Faraday.get(url, {}, headers)
+      response = Faraday.get(url, params, headers)
+      process(response)
+    end
+
+    def self.put(url, params: {})
+      url = "#{Rails.application.config_for(:gravity)['api_v1_root']}#{url}"
+      response = Faraday.put(url, params, headers)
+      process(response)
+    end
+
+    def self.process(response)
       raise GravityNotFoundError if response.status == 404
       raise GravityError, "couldn't perform request! Response was #{response.status}." unless response.success?
       JSON.parse(response.body, symbolize_names: true)

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -50,7 +50,7 @@ describe Api::GraphqlController, type: :request do
 
       context 'with failed artwork fetch' do
         before do
-          expect(Adapters::GravityV1).to receive(:request).with('/artwork/artwork-id').and_raise(Adapters::GravityError.new('Timeout'))
+          expect(Adapters::GravityV1).to receive(:get).with('/artwork/artwork-id').and_raise(Adapters::GravityError.new('Timeout'))
         end
         it 'does not create order and returns proper error' do
           expect do

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -84,8 +84,8 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'sets shipping info and sales tax on the order' do
-        allow(Adapters::GravityV1).to receive(:request).twice.with('/artwork/a-1').and_return(artwork1)
-        allow(Adapters::GravityV1).to receive(:request).twice.with('/artwork/a-2').and_return(artwork2)
+        allow(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
+        allow(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
         allow(GravityService).to receive(:fetch_partner).and_return(partner)
         allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
         response = client.execute(mutation, set_shipping_input)
@@ -108,8 +108,8 @@ describe Api::GraphqlController, type: :request do
 
       describe '#shipping_total_cents' do
         before do
-          expect(Adapters::GravityV1).to receive(:request).twice.with('/artwork/a-1').and_return(artwork1)
-          expect(Adapters::GravityV1).to receive(:request).twice.with('/artwork/a-2').and_return(artwork2)
+          expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
+          expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
           allow(GravityService).to receive(:fetch_partner).and_return(partner)
           allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
         end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -7,6 +7,7 @@ describe Api::GraphqlController, type: :request do
   describe 'submit_order mutation' do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
+    let(:partner) { { effective_commission_rate: 0.1 } }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
     let(:merchant_account) { { external_id: 'ma-1' } }
@@ -94,6 +95,7 @@ describe Api::GraphqlController, type: :request do
         it 'returns error' do
           allow(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
           allow(GravityService).to receive(:get_credit_card).and_return(credit_card)
+          allow(GravityService).to receive(:fetch_partner).and_return(partner)
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.errors).to include 'Invalid action on this approved order'
           expect(order.reload.state).to eq Order::APPROVED

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -103,7 +103,7 @@ describe Api::GraphqlController, type: :request do
       it 'submits the order' do
         expect(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
         expect(GravityService).to receive(:get_credit_card).and_return(credit_card)
-        expect(Adapters::GravityV1).to receive(:request).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
+        expect(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
         response = client.execute(mutation, submit_order_input)
         expect(response.data.submit_order.order.id).to eq order.id.to_s
         expect(response.data.submit_order.order.state).to eq 'SUBMITTED'

--- a/spec/lib/adapters/gravity_v1_spec.rb
+++ b/spec/lib/adapters/gravity_v1_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
-require 'webmock/rspec'
 
 describe Adapters::GravityV1 do
   it 'raises Gravity Error when get 404' do
     stub_request(:get, /artwork/).to_return(status: 404, body: { error: 'cannot find' }.to_json)
     expect do
-      Adapters::GravityV1.request('artwork/2')
+      Adapters::GravityV1.get('artwork/2')
     end.to raise_error(Adapters::GravityError)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -6,7 +6,7 @@ describe CreateOrderService, type: :services do
     let(:user_id) { 'user-id' }
     context 'with known artwork' do
       before do
-        expect(Adapters::GravityV1).to receive(:request).and_return(gravity_v1_artwork)
+        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork)
       end
       context 'without edition set' do
         it 'create order with proper data' do
@@ -46,7 +46,7 @@ describe CreateOrderService, type: :services do
     end
     context 'with unknown artwork' do
       before do
-        expect(Adapters::GravityV1).to receive(:request).and_raise(Adapters::GravityError.new('unknown artwork'))
+        expect(Adapters::GravityV1).to receive(:get).and_raise(Adapters::GravityError.new('unknown artwork'))
       end
       it 'raises Errors::OrderError' do
         expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error(Errors::OrderError)

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
-require 'webmock/rspec'
 require 'support/gravity_helper'
 
 describe GravityService, type: :services do
   let(:partner_id) { 'partner-1' }
   describe '#fetch_partner' do
     it 'calls the /partner endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/partner/#{partner_id}/all")
+      allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/all")
       GravityService.fetch_partner(partner_id)
-      expect(Adapters::GravityV1).to have_received(:request).with("/partner/#{partner_id}/all")
+      expect(Adapters::GravityV1).to have_received(:get).with("/partner/#{partner_id}/all")
     end
 
     context 'with failed gravity call' do
@@ -25,20 +24,22 @@ describe GravityService, type: :services do
 
   describe '#get_merchant_account' do
     let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
-    it 'calls the /merchant_accounts Gravity endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return(partner_merchant_accounts)
-      GravityService.get_merchant_account(partner_id)
-      expect(Adapters::GravityV1).to have_received(:request).with("/merchant_accounts?partner_id=#{partner_id}")
-    end
-
-    it "returns the first merchant account of the partner's merchant accounts" do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return(partner_merchant_accounts)
-      result = GravityService.get_merchant_account(partner_id)
-      expect(result).to be(partner_merchant_accounts.first)
+    context 'with merchant account' do
+      before do
+        allow(Adapters::GravityV1).to receive(:get).with('/merchant_accounts', params: { partner_id: partner_id }).and_return(partner_merchant_accounts)
+      end
+      it 'calls the /merchant_accounts Gravity endpoint' do
+        GravityService.get_merchant_account(partner_id)
+        expect(Adapters::GravityV1).to have_received(:get).with('/merchant_accounts', params: { partner_id: partner_id })
+      end
+      it "returns the first merchant account of the partner's merchant accounts" do
+        result = GravityService.get_merchant_account(partner_id)
+        expect(result).to be(partner_merchant_accounts.first)
+      end
     end
 
     it 'raises an error if the partner does not have a merchant account' do
-      allow(Adapters::GravityV1).to receive(:request).with("/merchant_accounts?partner_id=#{partner_id}").and_return([])
+      allow(Adapters::GravityV1).to receive(:get).with('/merchant_accounts', params: { partner_id: partner_id }).and_return([])
       expect { GravityService.get_merchant_account(partner_id) }.to raise_error(Errors::OrderError)
     end
 
@@ -58,9 +59,9 @@ describe GravityService, type: :services do
     let(:credit_card_id) { 'cc-1' }
     let(:credit_card) { { external_id: 'card-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil } }
     it 'calls the /credit_card Gravity endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/credit_card/#{credit_card_id}").and_return(credit_card)
+      allow(Adapters::GravityV1).to receive(:get).with("/credit_card/#{credit_card_id}").and_return(credit_card)
       GravityService.get_credit_card(credit_card_id)
-      expect(Adapters::GravityV1).to have_received(:request).with("/credit_card/#{credit_card_id}")
+      expect(Adapters::GravityV1).to have_received(:get).with("/credit_card/#{credit_card_id}")
     end
 
     context 'with failed gravity call' do
@@ -78,13 +79,13 @@ describe GravityService, type: :services do
   describe '#get_artwork' do
     let(:artwork_id) { 'some-id' }
     it 'calls the /artwork endpoint' do
-      allow(Adapters::GravityV1).to receive(:request).with("/artwork/#{artwork_id}")
+      allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}")
       GravityService.get_artwork(artwork_id)
-      expect(Adapters::GravityV1).to have_received(:request).with("/artwork/#{artwork_id}")
+      expect(Adapters::GravityV1).to have_received(:get).with("/artwork/#{artwork_id}")
     end
     context 'with failed gravity call' do
       it 'returns nil' do
-        expect(Adapters::GravityV1).to receive(:request).and_raise(Adapters::GravityError, 'timeout')
+        expect(Adapters::GravityV1).to receive(:get).and_raise(Adapters::GravityError, 'timeout')
         expect(GravityService.get_artwork(artwork_id)).to be_nil
       end
     end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -1,14 +1,28 @@
 require 'rails_helper'
 
 describe OrderService, type: :services do
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id) }
-  let(:user_id) { 'user-id' }
   include_context 'use stripe mock'
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id) }
+  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1'), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2)] }
+  let(:user_id) { 'user-id' }
   describe '#reject!' do
+    let(:artwork_inventory_deduct_request_status) { 200 }
+    let(:edition_set_inventory_deduct_request_status) { 200 }
+    let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
+    let(:edition_set_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json) }
     before do
       order.update! state: Order::SUBMITTED
     end
     context 'with a successful refund' do
+      before do
+        artwork_inventory_undeduct_request
+        edition_set_inventory_undeduct_request
+      end
+      it 'calls to undeduct inventory' do
+        OrderService.reject!(order, user_id)
+        expect(artwork_inventory_undeduct_request).to have_been_requested
+        expect(edition_set_inventory_undeduct_request).to have_been_requested
+      end
       it 'records the transaction' do
         OrderService.reject!(order, user_id)
         expect(order.transactions.last.external_id).to_not eq nil
@@ -21,12 +35,20 @@ describe OrderService, type: :services do
       end
     end
     context 'with an unsuccessful refund' do
-      it 'raises a PaymentError and records the transaction' do
+      before do
+        artwork_inventory_undeduct_request
+        edition_set_inventory_undeduct_request
         StripeMock.prepare_card_error(:card_declined, :new_refund)
         expect { OrderService.reject!(order, user_id) }.to raise_error(Errors::PaymentError)
+      end
+      it 'raises a PaymentError and records the transaction' do
         expect(order.transactions.last.external_id).to eq captured_charge.id
         expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
         expect(order.transactions.last.status).to eq Transaction::FAILURE
+      end
+      it 'does not undeduct inventory' do
+        expect(artwork_inventory_undeduct_request).not_to have_been_requested
+        expect(edition_set_inventory_undeduct_request).not_to have_been_requested
       end
     end
   end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -42,14 +42,11 @@ describe OrderSubmitService, type: :services do
           edition_set_inventory_deduct_request
           artwork_inventory_undeduct_request
           edition_set_inventory_undeduct_request
-        end
-        it 'raises error and not stores transaction' do
           expect do
             service.process!
           end.to raise_error(Errors::InventoryError).and change(order.transactions, :count).by(0)
         end
         it 'does not call to update edition set inventory' do
-          expect { service.process! }.to raise_error(Errors::InventoryError)
           expect(artwork_inventory_deduct_request).to have_been_requested
           expect(edition_set_inventory_deduct_request).to_not have_been_requested
           expect(artwork_inventory_undeduct_request).not_to have_been_requested
@@ -63,14 +60,11 @@ describe OrderSubmitService, type: :services do
           edition_set_inventory_deduct_request
           artwork_inventory_undeduct_request
           edition_set_inventory_undeduct_request
-        end
-        it 'raises error and does not create transaction' do
           expect do
             service.process!
           end.to raise_error(Errors::InventoryError).and change(order.transactions, :count).by(0)
         end
         it 'deducts and then undeducts artwork inventory' do
-          expect { service.process! }.to raise_error(Errors::InventoryError)
           expect(artwork_inventory_deduct_request).to have_been_requested
           expect(edition_set_inventory_deduct_request).to have_been_requested
           expect(artwork_inventory_undeduct_request).to have_been_requested
@@ -137,19 +131,15 @@ describe OrderSubmitService, type: :services do
           StripeMock.prepare_card_error(:card_declined, :new_charge)
           allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
           allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
-        end
-        it 'raises PaymentError' do
           expect { service.process! }.to raise_error(Errors::PaymentError)
         end
         it 'deducts and then undeducts the inventory for both artwork and edition set' do
-          expect { service.process! }.to raise_error(Errors::PaymentError)
           expect(artwork_inventory_deduct_request).to have_been_requested
           expect(edition_set_inventory_deduct_request).to have_been_requested
           expect(artwork_inventory_undeduct_request).to have_been_requested
           expect(edition_set_inventory_undeduct_request).to have_been_requested
         end
         it 'records failed transaction' do
-          expect { service.process! }.to raise_error(Errors::PaymentError)
           expect(order.transactions.last.transaction_type).to eq Transaction::HOLD
           expect(order.transactions.last.status).to eq Transaction::FAILURE
         end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -23,16 +23,19 @@ describe OrderSubmitService, type: :services do
 
   describe '#submit!' do
     context 'with a partner with a merchant account' do
-      let(:inventory_deduct_request_status) { 200 }
-      let(:artwork_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: inventory_deduct_request_status, body: {}.to_json) }
-      let(:edition_set_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/edition_set/es-1/inventory").with(body: { deduct: 2 }).to_return(status: inventory_deduct_request_status, body: {}.to_json) }
+      let(:artwork_inventory_deduct_request_status) { 200 }
+      let(:edition_set_inventory_deduct_request_status) { 200 }
+      let(:artwork_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
+      let(:edition_set_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { deduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json) }
+      let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
+      let(:edition_set_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json) }
       before do
         allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
         allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
       end
-      context 'with failed inventory deduct' do
-        let(:inventory_deduct_request_status) { 400 }
+      context 'with failed artwork inventory deduct' do
+        let(:artwork_inventory_deduct_request_status) { 400 }
         before do
           artwork_inventory_deduct_request
           edition_set_inventory_deduct_request
@@ -40,14 +43,39 @@ describe OrderSubmitService, type: :services do
         it 'raises error' do
           expect do
             OrderSubmitService.submit!(order)
-          end.to raise_error(Errors::OrderError).and change(order.transactions, :count).by(0)
+            expect(artwork_inventory_deduct_request).to have_been_requested
+            expect(edition_set_inventory_deduct_request).to_not have_been_requested
+          end.to raise_error(Errors::InventoryError).and change(order.transactions, :count).by(0)
+        end
+      end
+      context 'with failed edition_set inventory deduct' do
+        let(:edition_set_inventory_deduct_request_status) { 400 }
+        before do
+          artwork_inventory_deduct_request
+          edition_set_inventory_deduct_request
+          artwork_inventory_undeduct_request
+        end
+        it 'raises error and undeducts artwork deduction' do
+          expect do
+            OrderSubmitService.submit!(order)
+            expect(artwork_inventory_deduct_request).to have_been_requested
+            expect(edition_set_inventory_deduct_request).to_not have_been_requested
+            expect(artwork_inventory_undeduct_request).to have_been_requested
+            expect(edition_set_inventory_undeduct_request).not_to have_been_requested
+          end.to raise_error(Errors::InventoryError).and change(order.transactions, :count).by(0)
         end
       end
       context 'with a successful transaction' do
         before(:each) do
+          artwork_inventory_deduct_request
+          edition_set_inventory_deduct_request
           OrderSubmitService.submit!(order)
         end
 
+        it 'calls gravity to update inventory' do
+          expect(artwork_inventory_deduct_request).to have_been_requested
+          expect(edition_set_inventory_deduct_request).to have_been_requested
+        end
         it 'creates a record of the transaction' do
           expect(order.transactions.last.external_id).not_to be_nil
           expect(order.transactions.last.transaction_type).to eq Transaction::HOLD
@@ -89,11 +117,23 @@ describe OrderSubmitService, type: :services do
       end
 
       context 'with an unsuccessful transaction' do
+        before do
+          artwork_inventory_deduct_request
+          edition_set_inventory_deduct_request
+          artwork_inventory_undeduct_request
+          edition_set_inventory_undeduct_request
+        end
         it 'creates a record of the transaction' do
           StripeMock.prepare_card_error(:card_declined, :new_charge)
           allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
           allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
-          expect { OrderSubmitService.submit!(order) }.to raise_error(Errors::PaymentError)
+          expect do
+            OrderSubmitService.submit!(order)
+            expect(artwork_inventory_deduct_request).to have_been_requested
+            expect(edition_set_inventory_deduct_request).to have_been_requested
+            expect(artwork_inventory_undeduct_request).to have_been_requested
+            expect(edition_set_inventory_undeduct_request).to have_been_requested
+          end.to raise_error(Errors::PaymentError)
           expect(order.transactions.last.transaction_type).to eq Transaction::HOLD
           expect(order.transactions.last.status).to eq Transaction::FAILURE
         end

--- a/spec/services/shipping_service_spec.rb
+++ b/spec/services/shipping_service_spec.rb
@@ -21,7 +21,7 @@ describe ShippingService, type: :services do
     let(:line_item) { Fabricate(:line_item, artwork_id: 'gravity-id') }
     context 'with successful artwork fetch call' do
       before do
-        allow(Adapters::GravityV1).to receive(:request).with('/artwork/gravity-id').and_return(artwork)
+        allow(Adapters::GravityV1).to receive(:get).with('/artwork/gravity-id').and_return(artwork)
       end
       context 'with pickup fulfillment type' do
         it 'returns 0' do
@@ -50,7 +50,7 @@ describe ShippingService, type: :services do
 
     context 'with failed artwork fetch call' do
       before do
-        allow(Adapters::GravityV1).to receive(:request).with('/artwork/gravity-id').and_raise(Adapters::GravityError.new('unknown artwork'))
+        allow(Adapters::GravityV1).to receive(:get).with('/artwork/gravity-id').and_raise(Adapters::GravityError.new('unknown artwork'))
       end
       it 'raises Errors::OrderError' do
         expect do


### PR DESCRIPTION
# Problem
We want to deduct inventory when a user _submits_ an order. We need to un-deduct inventory in reject , seller-lapse and other edge cases.

# Solution
We first deduct all the inventory, then we call Stripe to hold the charge. We need to handle following cases.

## Submit order
<table>
<tr>
<th> Scenario </th>
<th> What happens </th>
</tr>

<tr>
<td>Fails to deduct one of the line items</td>
<td>Keep track of all deducted line items and when one fails make sure we un-deduct only the already deducted ones</td>
</tr>

<tr>
<td>Stripe charge fails</td>
<td>We've already deducted inventory for all line items, we need to un-deduct all of them</td>
</tr>
</table> 

## Reject/Seller Lapse
Un-deduct all line items.

# Other Changes
Ended up making `OrderSubmitServer` actual class with instance methods which we can instantiate with an `order` and call `process!` on it. Provided a `call` class method that actually does that.

# Note
We could make Gravity calls less complicated if there was an endpoint in Gravity that could get list of inventory deductions and do all in one call (wonder if GraphQL could help here). This logic will be as complicated on Gravity's end (maybe more since there are no transactions there) but wanted to mention as an alternative.
