### PR TITLE
Follow new style mutations for rest of mutations

### DIFF
--- a/app/graphql/mutations/approve_order.rb
+++ b/app/graphql/mutations/approve_order.rb
@@ -3,17 +3,15 @@ class Mutations::ApproveOrder < Mutations::BaseMutation
 
   argument :id, ID, required: true
 
-  field :order, Types::OrderType, null: true
-  field :errors, [String], null: false
+  field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
   def resolve(id:)
     order = Order.find(id)
     validate_seller_request!(order)
     {
-      order: OrderService.approve!(order, by: context[:current_user]['id']),
-      errors: []
+      order_or_error: { order: OrderService.approve!(order, by: context[:current_user]['id']) }
     }
   rescue Errors::ApplicationError => e
-    { order: nil, errors: [e.message] }
+    { order_or_error: { error: Types::MutationErrorType.from_application(e) } }
   end
 end

--- a/app/graphql/mutations/fulfill_at_once.rb
+++ b/app/graphql/mutations/fulfill_at_once.rb
@@ -5,17 +5,15 @@ class Mutations::FulfillAtOnce < Mutations::BaseMutation
   argument :id, ID, required: true
   argument :fulfillment, Inputs::FulfillmentAttributes, required: true
 
-  field :order, Types::OrderType, null: true
-  field :errors, [String], null: false
+  field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
   def resolve(id:, fulfillment:)
     order = Order.find(id)
     validate_seller_request!(order)
     {
-      order: OrderService.fulfill_at_once!(order, fulfillment.to_h, context[:current_user][:id]),
-      errors: []
+      order_or_error: { order: OrderService.fulfill_at_once!(order, fulfillment.to_h, context[:current_user][:id]) }
     }
   rescue Errors::ApplicationError => e
-    { order: nil, errors: [e.message] }
+    { order_or_error: { error: Types::MutationErrorType.from_application(e) } }
   end
 end

--- a/app/graphql/mutations/reject_order.rb
+++ b/app/graphql/mutations/reject_order.rb
@@ -3,17 +3,15 @@ class Mutations::RejectOrder < Mutations::BaseMutation
 
   argument :id, ID, required: true
 
-  field :order, Types::OrderType, null: true
-  field :errors, [String], null: false
+  field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
   def resolve(id:)
     order = Order.find(id)
     validate_seller_request!(order)
     {
-      order: OrderService.reject!(order, context[:current_user][:id]),
-      errors: []
+      order_or_error: { order: OrderService.reject!(order, context[:current_user][:id]) }
     }
   rescue Errors::ApplicationError => e
-    { order: nil, errors: [e.message] }
+    { order_or_error: { error: Types::MutationErrorType.from_application(e) } }
   end
 end

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -5,17 +5,15 @@ class Mutations::SetShipping < Mutations::BaseMutation
   argument :fulfillment_type, Types::OrderFulfillmentTypeEnum, required: false
   argument :shipping, Inputs::ShippingAttributes, required: false
 
-  field :order, Types::OrderType, null: true
-  field :errors, [String], null: false
+  field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
   def resolve(args)
     order = Order.find(args[:id])
     validate_buyer_request!(order)
     {
-      order: OrderService.set_shipping!(order, args.except(:id)),
-      errors: []
+      order_or_error: { order: OrderService.set_shipping!(order, args.except(:id)) }
     }
   rescue Errors::ApplicationError => e
-    { order: nil, errors: [e.message] }
+    { order_or_error: { error: Types::MutationErrorType.from_application(e) } }
   end
 end


### PR DESCRIPTION
# Problem
We've changed how we handle errors for mutation in #93 for create order mutation and we have #128 that does the same for `submitOrder`. This PR does the same thing for rest of the mutations.

This is a breaking change and need MP follow up.