### PR TITLE
Track order state history

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*'
 
+Metrics/ClassLength:
+  Max: 150
+
 Rails/ReversibleMigration:
   Enabled: false
 

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -21,6 +21,8 @@ class Types::OrderType < Types::BaseObject
   field :updated_at, Types::DateTimeType, null: false
   field :state_updated_at, Types::DateTimeType, null: true
   field :state_expires_at, Types::DateTimeType, null: true
+  field :submitted_at, Types::DateTimeType, null: true
+  field :approved_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
 
   def buyer

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -93,6 +93,14 @@ class Order < ApplicationRecord
     "Order #{id}"
   end
 
+  def submitted_at
+    state_histories.find_by(state: Order::SUBMITTED)&.updated_at
+  end
+
+  def approved_at
+    state_histories.find_by(state: Order::APPROVED)&.updated_at
+  end
+
   private
 
   def set_code

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -40,6 +40,7 @@ class Order < ApplicationRecord
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'
   has_many :transactions, dependent: :destroy
+  has_many :state_histories, dependent: :destroy
 
   validates :state, presence: true, inclusion: STATES
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -113,7 +113,7 @@ class Order < ApplicationRecord
   end
 
   def create_state_history
-    self.state_histories.create!(state: state, updated_at: self.state_updated_at)
+    state_histories.create!(state: state, updated_at: state_updated_at)
   end
 
   def set_currency_code

--- a/app/models/state_history.rb
+++ b/app/models/state_history.rb
@@ -1,0 +1,3 @@
+class StateHistory < ApplicationRecord
+  belongs_to :order
+end

--- a/db/migrate/20180827150745_create_state_histories.rb
+++ b/db/migrate/20180827150745_create_state_histories.rb
@@ -1,0 +1,9 @@
+class CreateStateHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :state_histories do |t|
+      t.references :order, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180827151116_add_state_to_state_histories.rb
+++ b/db/migrate/20180827151116_add_state_to_state_histories.rb
@@ -1,0 +1,5 @@
+class AddStateToStateHistories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :state_histories, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_22_200144) do
+ActiveRecord::Schema.define(version: 2018_08_27_150745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,13 @@ ActiveRecord::Schema.define(version: 2018_08_22_200144) do
     t.index ["state"], name: "index_orders_on_state"
   end
 
+  create_table "state_histories", force: :cascade do |t|
+    t.bigint "order_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_state_histories_on_order_id"
+  end
+
   create_table "transactions", force: :cascade do |t|
     t.bigint "order_id"
     t.string "external_id"
@@ -118,5 +125,6 @@ ActiveRecord::Schema.define(version: 2018_08_22_200144) do
   add_foreign_key "line_item_fulfillments", "fulfillments"
   add_foreign_key "line_item_fulfillments", "line_items"
   add_foreign_key "line_items", "orders"
+  add_foreign_key "state_histories", "orders"
   add_foreign_key "transactions", "orders"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_27_150745) do
+ActiveRecord::Schema.define(version: 2018_08_27_151116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2018_08_27_150745) do
     t.bigint "order_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "state"
     t.index ["order_id"], name: "index_state_histories_on_order_id"
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -148,7 +148,36 @@ RSpec.describe Order, type: :model do
         order.submit!
         expect(order.state_histories.count).to eq 2 # PENDING and SUBMITTED
         expect(order.state_histories.last.state).to eq Order::SUBMITTED
-        expect(order.state_histories.last.updated_at).to eq order.state_updated_at        
+        expect(order.state_histories.last.updated_at).to eq order.state_updated_at
+      end
+    end
+  end
+
+  describe '#submitted_at' do
+    context 'with a submitted order' do
+      it 'returns the time at which the order was submitted' do
+        order.submit!
+        expect(order.submitted_at).to eq order.state_histories.find_by(state: Order::SUBMITTED).updated_at
+      end
+    end
+    context 'with an unsubmitted order' do
+      it 'returns nil' do
+        expect(order.submitted_at).to be_nil
+      end
+    end
+  end
+
+  describe '#approved_at' do
+    context 'with an approved order' do
+      it 'returns the time at which the order was approved' do
+        order.update!(state: Order::SUBMITTED)
+        order.approve!
+        expect(order.approved_at).to eq order.state_histories.find_by(state: Order::APPROVED).updated_at
+      end
+    end
+    context 'with an un-approved order' do
+      it 'returns nil' do
+        expect(order.approved_at).to be_nil
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -181,5 +181,4 @@ RSpec.describe Order, type: :model do
       end
     end
   end
-
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -133,4 +133,24 @@ RSpec.describe Order, type: :model do
       expect(order.code).to match(/^B\d{6}$/)
     end
   end
+
+  describe '#create_state_history' do
+    context 'when an order is first created' do
+      it 'creates a new state history object with its initial state' do
+        new_order = Order.create!(state: Order::PENDING)
+        expect(new_order.state_histories.count).to eq 1
+        expect(new_order.state_histories.last.state).to eq Order::PENDING
+        expect(new_order.state_histories.last.updated_at).to eq new_order.state_updated_at
+      end
+    end
+    context 'when an order changes state' do
+      it 'creates a new state history object with the new state' do
+        order.submit!
+        expect(order.state_histories.count).to eq 2 # PENDING and SUBMITTED
+        expect(order.state_histories.last.state).to eq Order::SUBMITTED
+        expect(order.state_histories.last.updated_at).to eq order.state_updated_at        
+      end
+    end
+  end
+
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Order, type: :model do
         new_order = Order.create!(state: Order::PENDING)
         expect(new_order.state_histories.count).to eq 1
         expect(new_order.state_histories.last.state).to eq Order::PENDING
-        expect(new_order.state_histories.last.updated_at).to eq new_order.state_updated_at
+        expect(new_order.state_histories.last.updated_at.to_i).to eq new_order.state_updated_at.to_i
       end
     end
     context 'when an order changes state' do
@@ -148,7 +148,7 @@ RSpec.describe Order, type: :model do
         order.submit!
         expect(order.state_histories.count).to eq 2 # PENDING and SUBMITTED
         expect(order.state_histories.last.state).to eq Order::SUBMITTED
-        expect(order.state_histories.last.updated_at).to eq order.state_updated_at
+        expect(order.state_histories.last.updated_at.to_i).to eq order.state_updated_at.to_i
       end
     end
   end
@@ -157,7 +157,7 @@ RSpec.describe Order, type: :model do
     context 'with a submitted order' do
       it 'returns the time at which the order was submitted' do
         order.submit!
-        expect(order.submitted_at).to eq order.state_histories.find_by(state: Order::SUBMITTED).updated_at
+        expect(order.submitted_at.to_i).to eq order.state_histories.find_by(state: Order::SUBMITTED).updated_at.to_i
       end
     end
     context 'with an unsubmitted order' do
@@ -172,7 +172,7 @@ RSpec.describe Order, type: :model do
       it 'returns the time at which the order was approved' do
         order.update!(state: Order::SUBMITTED)
         order.approve!
-        expect(order.approved_at).to eq order.state_histories.find_by(state: Order::APPROVED).updated_at
+        expect(order.approved_at.to_i).to eq order.state_histories.find_by(state: Order::APPROVED).updated_at.to_i
       end
     end
     context 'with an un-approved order' do


### PR DESCRIPTION
This is a follow up PR for https://github.com/artsy/exchange/pull/124, where we decided to create a new `StateHistory` model to keep track of the entire history of an order's state changes.

Addresses [PLATFORM-773](https://artsyproduct.atlassian.net/browse/PLATFORM-773).

### What changed
- Adds `StateHistory` model that's associated with `Order` for tracking state changes in an order. 
- On order creation and after every order action (submit, approve, reject, etc.) a new `StateHistory` record is created that records the time at which the order entered that state.
- Creates `submitted_at` and `approved_at` methods on `Order` that query `StateHistory` for the time at which an order became submitted and approved, respectively.

Metaphysics PR forthcoming.