### PR TITLE
Add support for totalCount on orders

### DIFF
--- a/app/graphql/types/order_connection_with_total_count_type.rb
+++ b/app/graphql/types/order_connection_with_total_count_type.rb
@@ -1,0 +1,14 @@
+class Types::OrderEdgeType < GraphQL::Types::Relay::BaseEdge
+  node_type(Types::OrderType)
+end
+
+class Types::OrderConnectionWithTotalCountType < GraphQL::Types::Relay::BaseConnection
+  edge_type(Types::OrderEdgeType)
+
+  field :total_count, Integer, null: false
+  def total_count
+    # - `object` is the Connection
+    # - `object.nodes` is the collection of Orders
+    object.nodes.size
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,7 +7,7 @@ class Types::QueryType < Types::BaseObject
     argument :id, ID, required: true
   end
 
-  field :orders, Types::OrderType.connection_type, null: true do
+  field :orders, Types::OrderConnectionWithTotalCountType, null: true, connection: true do
     description 'Find list of orders'
     argument :seller_id, String, required: false
     argument :seller_type, String, required: false

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ default: &default
 
 development:
   <<: *default
-  database: exchange_development
+  database: <%= ENV['DATABASE_NAME'] %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PLATFORM-835
From clients we sometimes want to show just the total count of specific query.

# Solution
Added a custom connection type for our `Order` model which defines `total_count` field and used it in returning `orders` query. You can ask for `totalCounts` now on the same level as edges.
```graphql
query($sellerId: String, $buyerId: String, $state: OrderStateEnum, $sort: OrderConnectionSortEnum) {
            orders(sellerId: $sellerId, buyerId: $buyerId, state: $state, sort: $sort, first: 2) {
              totalCount
              edges {
                node {
                  id
                }
              }
            }
          }
```
In sample ☝️ we'll only get first 2 orders (note `first: 2` in the query)back but we'll get total count of all orders.