### PR TITLE
Fix compare to `nil` error

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -4,7 +4,15 @@ module CreateOrderService
     raise Errors::OrderError, "Unknown artwork #{artwork_id}" if artwork.nil? || (edition_set_id && !find_edition_set(artwork, edition_set_id))
 
     Order.transaction do
-      order = Order.create!(buyer_id: user_id, buyer_type: Order::USER, seller_id: artwork[:partner][:_id], seller_type: Order::PARTNER, currency_code: artwork[:price_currency], state: Order::PENDING)
+      order = Order.create!(
+        buyer_id: user_id,
+        buyer_type: Order::USER,
+        seller_id: artwork[:partner][:_id],
+        seller_type: Order::PARTNER,
+        currency_code: artwork[:price_currency],
+        state: Order::PENDING,
+        state_expires_at: Order::STATE_EXPIRATIONS[Order::PENDING]
+      )
       order.line_items.create!(
         artwork_id: artwork_id,
         edition_set_id: edition_set_id,

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -22,6 +22,13 @@ describe CreateOrderService, type: :services do
             expect(order.line_items.first.quantity).to eq 2
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
+        it 'sets state_expires_at for newly pending order' do
+          Timecop.freeze(Time.now.utc) do
+            order = CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: nil, quantity: 2)
+            expect(order.state).to eq Order::PENDING
+            expect(order.state_expires_at).to eq 2.days.from_now
+          end
+        end
       end
       context 'with edition set' do
         it 'creates order with proper data' do


### PR DESCRIPTION
Fixes #138 

# Cause
When creating an order, we set the state to pending but we don't set `state_expires_at` so https://github.com/artsy/exchange/blob/master/app/jobs/order_follow_up_job.rb#L6 fails.

# Solution
Set it at order creation.

cc: @williardx 