### PR TITLE
Bring back exchange_development

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ default: &default
 
 development:
   <<: *default
-  database: <%= ENV['DATABASE_NAME'] %>
+  database: exchange_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
this was result of me trying to use staging db, for local we can hardcode it back to `exchange_development`