### PR TITLE
Rename and change submitted_at and approved_at to fetch last timestamp order entered those states

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -21,8 +21,8 @@ class Types::OrderType < Types::BaseObject
   field :updated_at, Types::DateTimeType, null: false
   field :state_updated_at, Types::DateTimeType, null: true
   field :state_expires_at, Types::DateTimeType, null: true
-  field :submitted_at, Types::DateTimeType, null: true
-  field :approved_at, Types::DateTimeType, null: true
+  field :last_submitted_at, Types::DateTimeType, null: true
+  field :last_approved_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
 
   def buyer

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -93,12 +93,12 @@ class Order < ApplicationRecord
     "Order #{id}"
   end
 
-  def submitted_at
-    state_histories.find_by(state: Order::SUBMITTED)&.updated_at
+  def last_submitted_at
+    get_last_state_timestamp(Order::SUBMITTED)
   end
 
-  def approved_at
-    state_histories.find_by(state: Order::APPROVED)&.updated_at
+  def last_approved_at
+    get_last_state_timestamp(Order::APPROVED)
   end
 
   private
@@ -110,6 +110,10 @@ class Order < ApplicationRecord
   def update_state_timestamps
     self.state_updated_at = Time.now.utc
     self.state_expires_at = STATE_EXPIRATIONS.key?(state) ? state_updated_at + STATE_EXPIRATIONS[state] : nil
+  end
+
+  def get_last_state_timestamp(state)
+    state_histories.where(state: state).order(:updated_at).last&.updated_at
   end
 
   def create_state_history

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -153,31 +153,31 @@ RSpec.describe Order, type: :model do
     end
   end
 
-  describe '#submitted_at' do
+  describe '#last_submitted_at' do
     context 'with a submitted order' do
       it 'returns the time at which the order was submitted' do
         order.submit!
-        expect(order.submitted_at.to_i).to eq order.state_histories.find_by(state: Order::SUBMITTED).updated_at.to_i
+        expect(order.last_submitted_at.to_i).to eq order.state_histories.find_by(state: Order::SUBMITTED).updated_at.to_i
       end
     end
     context 'with an unsubmitted order' do
       it 'returns nil' do
-        expect(order.submitted_at).to be_nil
+        expect(order.last_submitted_at).to be_nil
       end
     end
   end
 
-  describe '#approved_at' do
+  describe '#last_approved_at' do
     context 'with an approved order' do
       it 'returns the time at which the order was approved' do
         order.update!(state: Order::SUBMITTED)
         order.approve!
-        expect(order.approved_at.to_i).to eq order.state_histories.find_by(state: Order::APPROVED).updated_at.to_i
+        expect(order.last_approved_at.to_i).to eq order.state_histories.find_by(state: Order::APPROVED).updated_at.to_i
       end
     end
     context 'with an un-approved order' do
       it 'returns nil' do
-        expect(order.approved_at).to be_nil
+        expect(order.last_approved_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
Followup from https://github.com/artsy/exchange/pull/134#discussion_r213509183, this a quick update to rename `submitted_at` -> `last_submitted_at` and `approved_at` -> `last_approved_at` to return the most recent timestamps at which the order entered those states. Also adds new helper method `get_last_state_timestamp`.