### PR TITLE
Post transaction to TaxJar on successful order approval and refactor SalesTaxService

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Max: 150
 
+Metrics/ModuleLength:
+  Max: 150
+
 Rails/ReversibleMigration:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
     - 'spec/support/gravity_helper.rb'
     - 'spec/support/taxjar_helper.rb'
     - 'app/admin/**'
+  
+Metrics/ParameterLists:
+  Max: 7
 
 Metrics/AbcSize:
   Max: 40

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -10,7 +10,7 @@ class RecordSalesTaxJob < ApplicationJob
       postal_code: order.shipping_postal_code,
       region: order.shipping_region,
       city: order.shipping_city,
-      address_line_1: order.shipping_address_line1
+      address_line1: order.shipping_address_line1
     }
     SalesTaxService.new(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork[:location]).record_tax_collected
   end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -1,17 +1,16 @@
 class RecordSalesTaxJob < ApplicationJob
   queue_as :default
 
-  def perform(id)
-    line_item = LineItem.find(id)
-    order = Order.find(line_item.order_id)
+  def perform(line_item_id)
+    line_item = LineItem.find(line_item_id)
     artwork = GravityService.get_artwork(line_item.artwork_id)
     shipping = {
-      country: order.shipping_country,
-      postal_code: order.shipping_postal_code,
-      region: order.shipping_region,
-      city: order.shipping_city,
-      address_line1: order.shipping_address_line1
+      country: line_item.order.shipping_country,
+      postal_code: line_item.order.shipping_postal_code,
+      region: line_item.order.shipping_region,
+      city: line_item.order.shipping_city,
+      address_line1: line_item.order.shipping_address_line1
     }
-    SalesTaxService.new(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork[:location]).record_tax_collected
+    SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping, line_item.order.shipping_total_cents, artwork[:location]).record_tax_collected
   end
 end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -1,0 +1,16 @@
+class RecordSalesTaxJob < ApplicationJob
+  queue_as :default
+
+  def perform(id)
+    line_item = LineItem.find(id)
+    order = Order.find(line_item.order_id)
+    shipping = {
+      country: order.shipping_country,
+      postal_code: order.shipping_postal_code,
+      region: order.shipping_region,
+      city: order.shipping_city,
+      address_line_1: order.shipping_address_line1
+    }
+    SalesTaxService.new(line_item, order.fulfillment_type, shipping, order.shipping_total_cents).record_tax_collected
+  end
+end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -4,6 +4,7 @@ class RecordSalesTaxJob < ApplicationJob
   def perform(id)
     line_item = LineItem.find(id)
     order = Order.find(line_item.order_id)
+    artwork = GravityService.get_artwork(line_item.artwork_id)
     shipping = {
       country: order.shipping_country,
       postal_code: order.shipping_postal_code,
@@ -11,6 +12,6 @@ class RecordSalesTaxJob < ApplicationJob
       city: order.shipping_city,
       address_line_1: order.shipping_address_line1
     }
-    SalesTaxService.new(line_item, order.fulfillment_type, shipping, order.shipping_total_cents).record_tax_collected
+    SalesTaxService.new(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork[:location]).record_tax_collected
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -6,5 +6,4 @@ class LineItem < ApplicationRecord
   def total_amount_cents
     price_cents * quantity
   end
-
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -2,4 +2,9 @@ class LineItem < ApplicationRecord
   belongs_to :order
   has_many :line_item_fulfillments, dependent: :destroy
   has_many :fulfillments, through: :line_item_fulfillments
+
+  def total_amount_cents
+    price_cents * quantity
+  end
+
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -52,6 +52,7 @@ module OrderService
       }
       TransactionService.create!(order, transaction)
     end
+    order.line_items.each { |li| RecordSalesTaxJob.perform_later(li.id) }
     PostNotificationJob.perform_later(order.id, Order::APPROVED, by)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     order

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,37 +1,36 @@
-module SalesTaxService
-  REMITTING_STATES = %w[
-    wa
-    nj
-    pa
-  ].freeze
-
-  def self.calculate_total_sales_tax(order, fulfillment_type, shipping, shipping_total_cents)
-    raise 'Dont know how to calculate tax for non-partner sellers' unless order.seller_type == Order::PARTNER
-    shipping_address = {
+class SalesTaxService
+  def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, gravity = GravityService, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
+    @line_item = line_item
+    @fulfillment_type = fulfillment_type
+    @gravity = gravity
+    @shipping_total_cents = shipping_total_cents
+    @tax_client = tax_client
+    @shipping_address = {
       country: shipping[:country],
       postal_code: shipping[:postal_code],
       state: shipping[:region],
       city: shipping[:city],
       address: shipping[:address_line_1]
     }
-    seller_address = GravityService.fetch_partner_location(order.seller_id)
-    order.line_items.map { |li| calculate_line_item_sales_tax(li, seller_address, shipping_address, shipping_total_cents, fulfillment_type) }.sum
   end
 
-  def self.calculate_line_item_sales_tax(line_item, seller_address, shipping_address, shipping_total_cents, fulfillment_type)
-    artwork = GravityService.get_artwork(line_item.artwork_id)
-    origin_address = artwork[:location]
-    destination_address = fulfillment_type == Order::PICKUP ? origin_address : shipping_address
-    sales_tax = fetch_sales_tax(line_item.price_cents, seller_address, origin_address, destination_address, shipping_total_cents)
-    UnitConverter.convert_dollars_to_cents(sales_tax.amount_to_collect)
+  def sales_tax
+    @sales_tax ||= UnitConverter.convert_dollars_to_cents(fetch_sales_tax.amount_to_collect)
   rescue Taxjar::Error => e
     raise Errors::OrderError, e.message
   end
 
-  def self.fetch_sales_tax(amount, seller_address, origin_address, destination_address, shipping_total_cents)
-    client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key'])
-    client.tax_for_order(
-      amount: UnitConverter.convert_cents_to_dollars(amount),
+  def record_tax_collected
+    post_transaction if artsy_should_remit_taxes?
+  rescue Taxjar::Error => e
+    raise Errors::OrderError, e.message
+  end
+
+  private
+
+  def fetch_sales_tax
+    @tax_client.tax_for_order(
+      amount: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents),
       from_country: origin_address[:country],
       from_zip: origin_address[:postal_code],
       from_state: origin_address[:state],
@@ -42,20 +41,49 @@ module SalesTaxService
       to_state: destination_address[:state],
       to_city: destination_address[:city],
       to_street: destination_address[:address],
-      nexus_addresses: [
-        {
-          country: seller_address[:country],
-          zip: seller_address[:postal_code],
-          state: seller_address[:state],
-          city: seller_address[:city],
-          street: seller_address[:address]
-        }
-      ],
-      shipping: UnitConverter.convert_cents_to_dollars(shipping_total_cents)
+      shipping: UnitConverter.convert_cents_to_dollars(@shipping_total_cents)
     )
   end
 
-  def self.artsy_should_remit_taxes?(destination_address)
-    REMITTING_STATES.include? destination_address[:shipping_region].downcase
+  def post_transaction
+    @tax_client.create_order(
+      transaction_id: '',
+      transaction_date: '',
+      amount: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents),
+      from_country: origin_address[:country],
+      from_zip: origin_address[:postal_code],
+      from_state: origin_address[:state],
+      from_city: origin_address[:city],
+      from_street: origin_address[:address],
+      to_country: destination_address[:country],
+      to_zip: destination_address[:postal_code],
+      to_state: destination_address[:state],
+      to_city: destination_address[:city],
+      to_street: destination_address[:address],
+      sales_tax: UnitConverter.convert_cents_to_dollars(@line_item.sales_tax_cents),
+      shipping: UnitConverter.convert_cents_to_dollars(@shipping_total_cents)
+    )
+  end
+
+  def origin_address
+    @origin_address ||= @fulfillment_type == Order::SHIP ? seller_address : artwork_location
+  end
+
+  def destination_address
+    @destination_address ||= @fulfillment_type == Order::SHIP ? @shipping_address : origin_address
+  end
+
+  def seller_address
+    @seller_address ||= @gravity.fetch_partner_location(@line_item.order.seller_id)
+  end
+
+  def artwork_location
+    @artwork_location ||= @gravity.get_artwork(@line_item.artwork_id)[:location]
+  end
+
+  def artsy_should_remit_taxes?
+    return false unless @destination_address[:country] == 'US'
+    remitting_states = %w[wa nj pa].freeze
+    remitting_states.include? @destination_address[:region].downcase
   end
 end

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -10,7 +10,7 @@ class SalesTaxService
       postal_code: shipping[:postal_code],
       state: shipping[:region],
       city: shipping[:city],
-      address: shipping[:address_line_1]
+      address: shipping[:address_line1]
     }
   end
 

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -46,9 +46,10 @@ class SalesTaxService
   end
 
   def post_transaction
+    transaction_date = @line_item.order.approved_at.iso8601
     @tax_client.create_order(
-      transaction_id: '',
-      transaction_date: '',
+      transaction_id: @line_item.id,
+      transaction_date: transaction_date,
       amount: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents),
       from_country: origin_address[:country],
       from_zip: origin_address[:postal_code],
@@ -82,8 +83,8 @@ class SalesTaxService
   end
 
   def artsy_should_remit_taxes?
-    return false unless @destination_address[:country] == 'US'
+    return false unless destination_address[:country] == 'US'
     remitting_states = %w[wa nj pa].freeze
-    remitting_states.include? @destination_address[:region].downcase
+    remitting_states.include? destination_address[:state].downcase
   end
 end

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -4,7 +4,6 @@ class SalesTaxService
   def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, artwork_location, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
     @line_item = line_item
     @fulfillment_type = fulfillment_type
-    @shipping_total_cents = shipping_total_cents
     @tax_client = tax_client
     @artwork_location = artwork_location
     @shipping_address = {
@@ -14,6 +13,7 @@ class SalesTaxService
       city: shipping[:city],
       address: shipping[:address_line1]
     }
+    @shipping_total_cents = artsy_should_remit_taxes? ? shipping_total_cents : 0
   end
 
   def sales_tax

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,8 +1,7 @@
 class SalesTaxService
-  def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, gravity = GravityService, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
+  def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
     @line_item = line_item
     @fulfillment_type = fulfillment_type
-    @gravity = gravity
     @shipping_total_cents = shipping_total_cents
     @tax_client = tax_client
     @shipping_address = {
@@ -46,7 +45,7 @@ class SalesTaxService
   end
 
   def post_transaction
-    transaction_date = @line_item.order.approved_at.iso8601
+    transaction_date = @line_item.order.last_approved_at.iso8601
     @tax_client.create_order(
       transaction_id: @line_item.id,
       transaction_date: transaction_date,
@@ -75,11 +74,11 @@ class SalesTaxService
   end
 
   def seller_address
-    @seller_address ||= @gravity.fetch_partner_location(@line_item.order.seller_id)
+    @seller_address ||= GravityService.fetch_partner_location(@line_item.order.seller_id)
   end
 
   def artwork_location
-    @artwork_location ||= @gravity.get_artwork(@line_item.artwork_id)[:location]
+    @artwork_location ||= GravityService.get_artwork(@line_item.artwork_id)[:location]
   end
 
   def artsy_should_remit_taxes?

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,9 +1,10 @@
 class SalesTaxService
-  def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
+  def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, artwork_location, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
     @line_item = line_item
     @fulfillment_type = fulfillment_type
     @shipping_total_cents = shipping_total_cents
     @tax_client = tax_client
+    @artwork_location = artwork_location
     @shipping_address = {
       country: shipping[:country],
       postal_code: shipping[:postal_code],
@@ -66,7 +67,7 @@ class SalesTaxService
   end
 
   def origin_address
-    @origin_address ||= @fulfillment_type == Order::SHIP ? seller_address : artwork_location
+    @origin_address ||= @fulfillment_type == Order::SHIP ? seller_address : @artwork_location
   end
 
   def destination_address
@@ -75,10 +76,6 @@ class SalesTaxService
 
   def seller_address
     @seller_address ||= GravityService.fetch_partner_location(@line_item.order.seller_id)
-  end
-
-  def artwork_location
-    @artwork_location ||= GravityService.get_artwork(@line_item.artwork_id)[:location]
   end
 
   def artsy_should_remit_taxes?

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,4 +1,6 @@
 class SalesTaxService
+  REMITTING_STATES = %w[wa nj pa].freeze
+
   def initialize(line_item, fulfillment_type, shipping, shipping_total_cents, artwork_location, tax_client = Taxjar::Client.new(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']))
     @line_item = line_item
     @fulfillment_type = fulfillment_type
@@ -80,7 +82,6 @@ class SalesTaxService
 
   def artsy_should_remit_taxes?
     return false unless destination_address[:country] == 'US'
-    remitting_states = %w[wa nj pa].freeze
-    remitting_states.include? destination_address[:state].downcase
+    REMITTING_STATES.include? destination_address[:state].downcase
   end
 end

--- a/app/services/shipping_service.rb
+++ b/app/services/shipping_service.rb
@@ -1,10 +1,7 @@
 module ShippingService
-  def self.calculate_shipping(line_item, fulfillment_type:, shipping_country:)
+  def self.calculate_shipping(artwork:, fulfillment_type:, shipping_country:)
     # TODO: 🚨 remove this feature flag, only needed during development 🚨
     return 0 if Rails.application.config_for(:dev_features)['disable_shipping_calculation']
-    artwork = GravityService.get_artwork(line_item.artwork_id)
-    raise Errors::OrderError, 'Cannot calculate shipping, unknown artwork' unless artwork
-    raise Errors::OrderError, 'Cannot calculate shipping, missing artwork location' if artwork[:location].blank?
 
     if fulfillment_type == Order::PICKUP
       0

--- a/db/migrate/20180830165044_add_sales_tax_cents_to_line_items.rb
+++ b/db/migrate/20180830165044_add_sales_tax_cents_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddSalesTaxCentsToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :sales_tax_cents, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2018_09_03_104007) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "quantity", default: 1, null: false
+    t.integer "sales_tax_cents"
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -112,8 +112,8 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'sets shipping info and sales tax on the order' do
-        allow(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
-        allow(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
+        allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+        allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
         allow(GravityService).to receive(:fetch_partner).and_return(partner)
         allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
         response = client.execute(mutation, set_shipping_input)
@@ -137,12 +137,14 @@ describe Api::GraphqlController, type: :request do
 
       describe '#shipping_total_cents' do
         before do
-          expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
-          expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
           allow(GravityService).to receive(:fetch_partner).and_return(partner)
           allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
         end
         context 'with PICKUP as fulfillment type' do
+          before do
+            expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
+            expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
+          end
           let(:fulfillment_type) { 'PICKUP' }
           it 'sets total shipping cents to 0' do
             response = client.execute(mutation, set_shipping_input)
@@ -151,6 +153,10 @@ describe Api::GraphqlController, type: :request do
           end
         end
         context 'with SHIP as fulfillment type' do
+          before do
+            expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-1').and_return(artwork1)
+            expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-2').and_return(artwork2)
+          end
           context 'with international shipping' do
             it 'sets total shipping cents properly' do
               response = client.execute(mutation, set_shipping_input)

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -132,6 +132,8 @@ describe Api::GraphqlController, type: :request do
         expect(order.shipping_address_line1).to eq 'Vanak'
         expect(order.shipping_address_line2).to eq 'P 80'
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+        expect(line_items[0].reload.sales_tax_cents).to eq 116
+        expect(line_items[1].reload.sales_tax_cents).to eq 116
         expect(order.tax_total_cents).to eq 232
       end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -9,8 +9,8 @@ describe Api::GraphqlController, type: :request do
     let(:user_id) { jwt_user_id }
     let(:order) { Fabricate(:order, seller_id: partner_id, buyer_id: user_id) }
     let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1'), Fabricate(:line_item, order: order, artwork_id: 'a-2')] }
-    let(:artwork1) { gravity_v1_artwork(domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
-    let(:artwork2) { gravity_v1_artwork(domestic_shipping_fee_cents: 400_00, international_shipping_fee_cents: 500_00) }
+    let(:artwork1) { gravity_v1_artwork(_id: 'a-1', domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:artwork2) { gravity_v1_artwork(_id: 'a-2', domestic_shipping_fee_cents: 400_00, international_shipping_fee_cents: 500_00) }
     let(:shipping_country) { 'IR' }
     let(:shipping_region) { 'Tehran' }
     let(:fulfillment_type) { 'SHIP' }
@@ -111,6 +111,22 @@ describe Api::GraphqlController, type: :request do
         end
       end
 
+      context 'with artwork with missing location' do
+        it 'returns an error' do
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
+          response = client.execute(mutation, set_shipping_input)
+          expect(response.data.set_shipping.order_or_error.error.description).to include 'Cannot set shipping, missing artwork location'
+        end
+      end
+
+      context 'with failed artwork fetch call' do
+        it 'returns an error' do
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
+          response = client.execute(mutation, set_shipping_input)
+          expect(response.data.set_shipping.order_or_error.error.description).to include 'Cannot set shipping, unknown artwork'
+        end
+      end
+
       it 'sets shipping info and sales tax on the order' do
         allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
         allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
@@ -144,8 +160,8 @@ describe Api::GraphqlController, type: :request do
         end
         context 'with PICKUP as fulfillment type' do
           before do
-            expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
-            expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-2').and_return(artwork2)
+            expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+            expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
           end
           let(:fulfillment_type) { 'PICKUP' }
           it 'sets total shipping cents to 0' do
@@ -178,7 +194,7 @@ describe Api::GraphqlController, type: :request do
           end
 
           context 'with one free shipping artwork' do
-            let(:artwork1) { gravity_v1_artwork(domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 0) }
+            let(:artwork1) { gravity_v1_artwork(_id: 'a-1', domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 0) }
             it 'sets total shipping cents only based on non-free shipping artwork' do
               response = client.execute(mutation, set_shipping_input)
               expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 500_00

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe RecordSalesTaxJob, type: :job do
+  let(:order) { Fabricate(:order, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
+  let(:shipping) do
+    {
+      country: order.shipping_country,
+      postal_code: order.shipping_postal_code,
+      region: order.shipping_region,
+      city: order.shipping_city,
+      address_line_1: order.shipping_address_line1
+    }
+  end
+  let!(:line_item) { Fabricate(:line_item, order: order) }
+  describe '#perform' do
+    it 'instantiates a new SalesTaxService and calls record_tax_collected' do
+      sales_tax_instance = double
+      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping, order.shipping_total_cents).and_return(sales_tax_instance)
+      expect(sales_tax_instance).to receive(:record_tax_collected)
+      RecordSalesTaxJob.perform_now(line_item.id)
+    end
+  end
+end

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -12,11 +12,13 @@ describe RecordSalesTaxJob, type: :job do
     }
   end
   let!(:line_item) { Fabricate(:line_item, order: order) }
+  let(:artwork_location) { gravity_v1_artwork[:location] }
   describe '#perform' do
     it 'instantiates a new SalesTaxService and calls record_tax_collected' do
       sales_tax_instance = double
-      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping, order.shipping_total_cents).and_return(sales_tax_instance)
+      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork_location).and_return(sales_tax_instance)
       expect(sales_tax_instance).to receive(:record_tax_collected)
+      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
       RecordSalesTaxJob.perform_now(line_item.id)
     end
   end

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -8,7 +8,7 @@ describe RecordSalesTaxJob, type: :job do
       postal_code: order.shipping_postal_code,
       region: order.shipping_region,
       city: order.shipping_city,
-      address_line_1: order.shipping_address_line1
+      address_line1: order.shipping_address_line1
     }
   end
   let!(:line_item) { Fabricate(:line_item, order: order) }

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -5,6 +5,20 @@ describe OrderService, type: :services do
   let(:order) { Fabricate(:order, external_charge_id: captured_charge.id) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
+
+  describe '#approve!' do
+    before do
+      order.submit!
+    end
+    context 'with a successful order approval' do
+      it 'enqueues a RecordSalesTaxJob for each line item' do
+        ActiveJob::Base.queue_adapter = :test
+        OrderService.approve!(order)
+        line_items.each { |li| expect(RecordSalesTaxJob).to have_been_enqueued.with(li.id) }
+      end
+    end
+  end
+
   describe '#reject!' do
     let(:artwork_inventory_deduct_request_status) { 200 }
     let(:edition_set_inventory_deduct_request_status) { 200 }

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -3,9 +3,9 @@ require 'support/taxjar_helper'
 require 'support/gravity_helper'
 
 describe SalesTaxService, type: :services do
+  let(:taxjar_client) { double }
   let(:order) { Fabricate(:order) }
-  let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1'), Fabricate(:line_item, order: order, price_cents: 8000_00)] }
-  let(:fulfillment_type) { Order::SHIP }
+  let!(:line_item) { Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1') }
   let(:shipping_total_cents) { 2222 }
   let(:shipping) do
     {
@@ -40,87 +40,122 @@ describe SalesTaxService, type: :services do
 
   before do
     stub_tax_for_order
+    allow(Taxjar::Client).to receive(:new).with(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']).and_return(taxjar_client)
+    @service_ship = SalesTaxService.new(line_item, Order::SHIP, shipping, shipping_total_cents)
+    @service_pickup = SalesTaxService.new(line_item, Order::PICKUP, shipping, shipping_total_cents)
   end
 
-  describe '#calculate_total_sales_tax' do
-    before do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
-      allow(SalesTaxService).to receive(:calculate_line_item_sales_tax).twice.and_return(1000)
-    end
-    it "fetches the partner's location" do
-      SalesTaxService.calculate_total_sales_tax(order, fulfillment_type, shipping, shipping_total_cents)
-      expect(GravityService).to have_received(:fetch_partner_location).with(order.seller_id)
-    end
-    it 'calculates sales tax for each line item and adds them together' do
-      expect(SalesTaxService.calculate_total_sales_tax(order, fulfillment_type, shipping, shipping_total_cents)).to be 2000
-      expect(SalesTaxService).to have_received(:calculate_line_item_sales_tax).with(line_items[0], partner_location, shipping_address, shipping_total_cents, fulfillment_type)
-      expect(SalesTaxService).to have_received(:calculate_line_item_sales_tax).with(line_items[1], partner_location, shipping_address, shipping_total_cents, fulfillment_type)
+  describe '#seller_address' do
+    it "returns the partner's location" do
+      expect(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
+      expect(@service_ship.send(:seller_address)).to eq partner_location
     end
   end
 
-  describe '#calculate_line_item_sales_tax' do
-    let(:sales_tax_double) { double(amount_to_collect: 1.16) }
-    before do
-      allow(GravityService).to receive(:get_artwork).with('gravity_artwork_1').and_return(gravity_v1_artwork)
-    end
-    it 'fetches the artwork on the line item' do
-      SalesTaxService.calculate_line_item_sales_tax(line_items[0], partner_location, shipping_address, shipping_total_cents, fulfillment_type)
-      expect(GravityService).to have_received(:get_artwork).with(line_items[0].artwork_id)
-    end
-    context 'with an order to be picked up' do
-      it 'sets the destination address to the origin address and calls fetch_sale_tax' do
-        allow(SalesTaxService).to receive(:fetch_sales_tax).with(line_items[0].price_cents, partner_location, artwork_location, artwork_location, shipping_total_cents).and_return(sales_tax_double)
-        SalesTaxService.calculate_line_item_sales_tax(line_items[0], partner_location, shipping_address, shipping_total_cents, Order::PICKUP)
-        expect(SalesTaxService).to have_received(:fetch_sales_tax).with(line_items[0].price_cents, partner_location, artwork_location, artwork_location, shipping_total_cents)
+  describe '#origin_address' do
+    context 'with a fulfillment_type of SHIP' do
+      it 'returns the seller address' do
+        expect(@service_ship).to receive(:seller_address).and_return(partner_location)
+        expect(@service_ship.send(:origin_address)).to eq partner_location
       end
     end
-    context 'with an order to be shipped' do
-      it 'sets the destination address to the shipping address and calls fetch_sales_tax' do
-        allow(SalesTaxService).to receive(:fetch_sales_tax).with(line_items[0].price_cents, partner_location, artwork_location, shipping_address, shipping_total_cents).and_return(sales_tax_double)
-        SalesTaxService.calculate_line_item_sales_tax(line_items[0], partner_location, shipping_address, shipping_total_cents, Order::SHIP)
-        expect(SalesTaxService).to have_received(:fetch_sales_tax).with(line_items[0].price_cents, partner_location, artwork_location, shipping_address, shipping_total_cents)
+    context 'with a fulfillment_type of PICKUP' do
+      it 'returns the artwork location' do
+        expect(@service_pickup).to receive(:artwork_location).and_return(artwork_location)
+        expect(@service_pickup.send(:origin_address)).to eq artwork_location
       end
     end
-    it 'returns the amount of sales tax to be collected in cents' do
-      line_item_sales_tax = SalesTaxService.calculate_line_item_sales_tax(line_items[0], partner_location, shipping_address, shipping_total_cents, fulfillment_type)
-      expect(line_item_sales_tax).to eq 116
+  end
+
+  describe '#destination_address' do
+    context 'with a fulfillment_type of SHIP' do
+      it 'returns the shipping address' do
+        expect(@service_ship.send(:destination_address)).to eq shipping_address
+      end
+    end
+    context 'with a fulfillment_type of PICKUP' do
+      it 'returns the origin address' do
+        expect(@service_pickup).to receive(:origin_address).and_return(artwork_location)
+        expect(@service_pickup.send(:destination_address)).to eq artwork_location
+      end
+    end
+  end
+
+  describe '#artwork_location' do
+    it 'returns the artwork location' do
+      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
+      expect(@service_ship.send(:artwork_location)).to eq artwork_location
     end
   end
 
   describe '#fetch_sales_tax' do
-    let(:taxjar_client) { double }
     let(:params) do
       {
-        amount: UnitConverter.convert_cents_to_dollars(line_items[0].price_cents),
-        from_country: artwork_location[:country],
-        from_zip: artwork_location[:postal_code],
-        from_state: artwork_location[:state],
-        from_city: artwork_location[:city],
-        from_street: artwork_location[:address],
+        amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
+        from_country: partner_location[:country],
+        from_zip: partner_location[:postal_code],
+        from_state: partner_location[:state],
+        from_city: partner_location[:city],
+        from_street: partner_location[:address],
         to_country: shipping_address[:country],
         to_zip: shipping_address[:postal_code],
         to_state: shipping_address[:state],
         to_city: shipping_address[:city],
         to_street: shipping_address[:address],
-        nexus_addresses: [
-          {
-            country: partner_location[:country],
-            zip: partner_location[:postal_code],
-            state: partner_location[:state],
-            city: partner_location[:city],
-            street: partner_location[:address]
-          }
-        ],
         shipping: UnitConverter.convert_cents_to_dollars(shipping_total_cents)
       }
     end
-    before do
-      allow(Taxjar::Client).to receive(:new).with(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key']).and_return(taxjar_client)
-    end
     it 'calls the Taxjar API with the correct parameters' do
+      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
       allow(taxjar_client).to receive(:tax_for_order).with(params)
-      SalesTaxService.fetch_sales_tax(line_items[0].price_cents, partner_location, artwork_location, shipping_address, shipping_total_cents)
+      @service_ship.send(:fetch_sales_tax)
       expect(taxjar_client).to have_received(:tax_for_order).with(params)
+    end
+  end
+
+  describe '#record_tax_collected' do
+    context 'when Artsy needs to remit taxes' do
+      it 'calls post_transaction' do
+        expect(@service_ship).to receive(:artsy_should_remit_taxes?).and_return(true)
+        expect(@service_ship).to receive(:post_transaction)
+        @service_ship.record_tax_collected
+      end
+    end
+    context 'when Artsy does not need to remit taxes' do
+      it 'does nothing' do
+        expect(@service_ship).to receive(:artsy_should_remit_taxes?).and_return(false)
+        expect(@service_ship).to_not receive(:post_transaction)
+        @service_ship.record_tax_collected
+      end
+    end
+  end
+
+  describe '#post_transaction' do
+  end
+
+  describe '#artsy_should_remit_taxes?' do
+    context 'with an order that has a US-based destination address' do
+      context 'with a state of WA, NJ or PA' do
+        it 'returns true' do
+          %w[wa nj pa].each do |state|
+            shipping[:region] = state
+            service = SalesTaxService.new(line_item, Order::SHIP, shipping, shipping_total_cents)
+            expect(service.send(:artsy_should_remit_taxes?)).to be true
+          end
+        end
+      end
+      context 'with a state other than WA, NJ or PA' do
+        it 'returns false' do
+          expect(@service_ship.send(:artsy_should_remit_taxes?)).to be false
+        end
+      end
+    end
+    context 'with an order that has a non-US destination address' do
+      it 'returns false' do
+        shipping[:country] = 'FR'
+        service = SalesTaxService.new(line_item, Order::SHIP, shipping, shipping_total_cents)
+        expect(service.send(:artsy_should_remit_taxes?)).to be false
+      end
     end
   end
 end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -12,7 +12,7 @@ describe SalesTaxService, type: :services do
       postal_code: 10013,
       region: 'NY',
       city: 'New York',
-      address_line_1: '123 Fake St'
+      address_line1: '123 Fake St'
     }
   end
   let(:shipping_address) do
@@ -21,7 +21,7 @@ describe SalesTaxService, type: :services do
       postal_code: shipping[:postal_code],
       state: shipping[:region],
       city: shipping[:city],
-      address: shipping[:address_line_1]
+      address: shipping[:address_line1]
     }
   end
   let(:partner_location) do

--- a/spec/services/shipping_service_spec.rb
+++ b/spec/services/shipping_service_spec.rb
@@ -18,6 +18,7 @@ describe ShippingService, type: :services do
   end
   let(:artwork) { gravity_v1_artwork(artwork_shipping_setting) }
   describe '#calculate_shipping' do
+    let(:artwork) { gravity_v1_artwork }
     let(:line_item) { Fabricate(:line_item, artwork_id: 'gravity-id') }
     context 'with successful artwork fetch call' do
       before do
@@ -25,37 +26,18 @@ describe ShippingService, type: :services do
       end
       context 'with pickup fulfillment type' do
         it 'returns 0' do
-          expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::PICKUP, shipping_country: 'US')).to eq 0
+          expect(ShippingService.calculate_shipping(artwork: artwork, fulfillment_type: Order::PICKUP, shipping_country: 'US')).to eq 0
         end
       end
       context 'with domestic address' do
         it 'returns domestic cost' do
-          expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'US')).to eq 100_00
+          expect(ShippingService.calculate_shipping(artwork: artwork, fulfillment_type: Order::SHIP, shipping_country: 'US')).to eq 100_00
         end
       end
-      context 'with internaitonal address' do
+      context 'with international address' do
         it 'returns international cost' do
-          expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'Iran')).to eq 500_00
+          expect(ShippingService.calculate_shipping(artwork: artwork, fulfillment_type: Order::SHIP, shipping_country: 'Iran')).to eq 500_00
         end
-      end
-      context 'without artwork location' do
-        let(:artwork_location) { nil }
-        it 'raises Errors::OrderError' do
-          expect do
-            expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'US'))
-          end.to raise_error(Errors::OrderError, 'Cannot calculate shipping, missing artwork location')
-        end
-      end
-    end
-
-    context 'with failed artwork fetch call' do
-      before do
-        allow(Adapters::GravityV1).to receive(:get).with('/artwork/gravity-id').and_raise(Adapters::GravityError.new('unknown artwork'))
-      end
-      it 'raises Errors::OrderError' do
-        expect do
-          expect(ShippingService.calculate_shipping(line_item, fulfillment_type: Order::SHIP, shipping_country: 'US'))
-        end.to raise_error(Errors::OrderError, 'Cannot calculate shipping, unknown artwork')
       end
     end
   end


### PR DESCRIPTION
### Problem
We need to collect and remit taxes for orders shipping to or being picked up in NJ, WA or PA.

### Solution
On order approval (and after charge capture) for NJ, WA or PA orders, post a transaction to TaxJar for each line item in the order that records the amount of sales tax we collected.

We post a transaction for each _line item_ and not for the whole order because it's possible for line items to be taxed differently. An order for pickup is taxed based on the location of the artwork, and if there are multiple line items in different locations then each line item will be taxed differently.

### What Changed
- Follows up on https://github.com/artsy/exchange/pull/91#discussion_r212501874 and reorganizes code as a class centered on the line item instead of a module centered on the order. Updates all corresponding specs.
- Adds `record_tax_collected` and `post_transaction` methods to `SalesTaxService` that post a transaction to TaxJar recording our collection of sales tax if we need to remit taxes. We only post transactions for line items that ship to or are picked up in NJ, WA or PA.
- Adds `sales_tax_cents` to `LineItems`. Updates `sales_tax_cents` on tax estimation.
- Adds `RecordSalesTaxJob` that runs `SalesTaxService.record_tax_collected` after successful order approval.
- Modifies sales tax logic to match our latest understanding of what the right thing to do is -- namely, tax for orders that are _shipped_ will only use the primary business address while orders that are _picked up_ will only use the artwork location.
- Fetches artwork data before setting shipping costs and sales tax to avoid duplicate requests

### Future work
- Mark TaxJar transaction as refunded if a captured charge is refunded.