### PR TITLE
Set stateUpdatedAt on newly created orders

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -11,7 +11,8 @@ module CreateOrderService
         seller_type: Order::PARTNER,
         currency_code: artwork[:price_currency],
         state: Order::PENDING,
-        state_expires_at: Order::STATE_EXPIRATIONS[Order::PENDING]
+        state_updated_at: Time.now.utc,
+        state_expires_at: Order::STATE_EXPIRATIONS[Order::PENDING].from_now
       )
       order.line_items.create!(
         artwork_id: artwork_id,

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -26,6 +26,7 @@ describe CreateOrderService, type: :services do
           Timecop.freeze(Time.now.utc) do
             order = CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: nil, quantity: 2)
             expect(order.state).to eq Order::PENDING
+            expect(order.state_updated_at).to eq Time.now.utc
             expect(order.state_expires_at).to eq 2.days.from_now
           end
         end


### PR DESCRIPTION
Still seeing issues with `pending` orders not having `state_expires_at` and `state_updated_at`, adding more spec around this and also possible fix.