### PR TITLE
Adds Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jwt'
 gem 'micromachine'
 gem 'money' # Library for dealing with money and currency conversion
 gem 'paper_trail'
+gem 'sentry-raven'
 gem 'sidekiq'
 gem 'stripe'
 gem 'taxjar-ruby', require: 'taxjar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -349,6 +351,7 @@ DEPENDENCIES
   rails (= 5.2.0)
   rspec-rails
   rubocop
+  sentry-raven
   sidekiq
   stripe
   stripe-ruby-mock (~> 2.5.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,9 @@ class ApplicationController < ActionController::Base
 
   attr_reader :current_user
   before_action :set_paper_trail_whodunnit
+  before_action :set_current_user_for_error_reporting
+
+  def set_current_user_for_error_reporting
+    Raven.user_context(current_user: current_user) if current_user.present?
+  end
 end

--- a/config/initializers/sentry_raven.rb
+++ b/config/initializers/sentry_raven.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_DSN']
+end


### PR DESCRIPTION
This PR enables Sentry error reporting. I've already created [exchange-production](https://sentry.io/artsynet/exchange-production/) and [exchange-staging](https://sentry.io/artsynet/exchange-staging) projects in Sentry and set ENV variables (`ENV['SENTRY_DSN']`) to both staging and production. All we have to do is to just merge and deploy :)