### PR TITLE
Randomize order codes

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -90,7 +90,7 @@ class Order < ApplicationRecord
 
   def update_code(attempts = 10)
     while attempts.positive?
-      code = SecureRandom.rand(100000000..999999999)
+      code = format('%09d', SecureRandom.rand(999999999))
       unless Order.where(code: code).exists?
         update!(code: code)
         break

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -89,7 +89,15 @@ class Order < ApplicationRecord
   private
 
   def set_code
-    update!(code: format('B%06d', id))
+    update!(code: generate_code)
+  end
+
+  def generate_code(size = 8, num_chars = 3)
+    nums = %w{ 2 3 4 6 7 9 }
+    chars = %w{ A C D E F G H J K M N P Q R T V W X Y Z}
+    random_nums = (0..(size - num_chars - 1)).map { nums.to_a[rand(nums.size)] }.join
+    random_chars = (0..(num_chars - 1)).map { chars.to_a[rand(chars.size)] }.join
+    random_nums + random_chars
   end
 
   def update_state_timestamps

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -90,7 +90,7 @@ class Order < ApplicationRecord
 
   def update_code(attempts = 10)
     while attempts.positive?
-      code = generate_code
+      code = SecureRandom.rand(100000000..999999999)
       unless Order.where(code: code).exists?
         update!(code: code)
         break
@@ -98,14 +98,6 @@ class Order < ApplicationRecord
       attempts -= 1
     end
     raise Errors::OrderError, 'Failed to set order code' if attempts.zero?
-  end
-
-  def generate_code(size = 8, num_chars = 3)
-    nums = %w[2 3 4 6 7 9]
-    chars = %w[A C D E F G H J K M N P Q R T V W X Y Z]
-    random_nums = Array.new(size - num_chars).map { nums.sample }.join
-    random_chars = Array.new(num_chars).map { chars.sample }.join
-    random_nums + random_chars
   end
 
   def update_state_timestamps

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -60,8 +60,9 @@ RSpec.describe Order, type: :model do
       end.to raise_error(Errors::OrderError, 'Failed to set order code')
     end
 
-    it 'sets code on order creation' do
-      expect(order.code).not_to be_nil
+    it 'sets a 0-padded 9 digit number for the code on order creation' do
+      expect(order.code.length).to eq 9
+      expect(order.code).to eq format('%09d', order.code.to_i)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -53,9 +53,15 @@ RSpec.describe Order, type: :model do
     end
   end
 
-  describe '#code' do
-    it 'sets code in proper format' do
-      expect(order.code).to match(/^B\d{6}$/)
+  describe '#update_code' do
+    it 'raises an error if it is unable to set a code within specified attempts' do
+      expect do
+        order.send(:update_code, 0)
+      end.to raise_error(Errors::OrderError, 'Failed to set order code')
+    end
+
+    it 'sets code on order creation' do
+      expect(order.code).not_to be_nil
     end
   end
 


### PR DESCRIPTION
### Problem
Our human-readable order code is currently sequential and based on the order id, which gives away information about our orders.

### Solution
Generate a randomized human-readable order code.

### What changed
- The code is now a 0-padded 9-digit integer.
- `update_code` checks the database to ensure the code is unique and will attempt to set the code 10 times before giving up and throwing an error. 