### PR TITLE
Fix calling account on charge.destination

### DIFF
--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -13,7 +13,7 @@ module PaymentService
       metadata: metadata,
       capture: false
     )
-    Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination.account, amount_cents: charge.amount, transaction_type: Transaction::HOLD, status: Transaction::SUCCESS)
+    Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::HOLD, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
     transaction = generate_transaction_from_exception(e, Transaction::HOLD, credit_card: credit_card, merchant_account: merchant_account, buyer_amount: buyer_amount)
     raise Errors::PaymentError.new(e.message, transaction)


### PR DESCRIPTION
# Problem
Getting 👇 when trying to submit an order
```
F, [2018-09-06T13:22:52.404226 #6] FATAL -- : [f40da4e0-b1d7-11e8-84cb-e9e6b0b75015] NoMethodError (undefined method `account' for "acct_14FIYS4fSw9JrcJy":String):
F, [2018-09-06T13:22:52.404353 #6] FATAL -- : [f40da4e0-b1d7-11e8-84cb-e9e6b0b75015]
F, [2018-09-06T13:22:52.404436 #6] FATAL -- : [f40da4e0-b1d7-11e8-84cb-e9e6b0b75015] app/services/payment_service.rb:16:in `authorize_charge'
```
# Cause
When writing tests, noticed we can get destination account using `charge.destination.account` but it seems that doesn't work in real world and we can get that basically from `destination.account` which is the account id.