### PR TITLE
OrderTotalUpdaterService

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -20,7 +20,7 @@ module CreateOrderService
         price_cents: artwork_price(artwork, edition_set_id: edition_set_id),
         quantity: quantity
       )
-      OrderTotalUpdaterService.update_totals!(order)
+      OrderTotalUpdaterService.new(order).update_totals!
       OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
       order
     end

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -20,7 +20,7 @@ module CreateOrderService
         price_cents: artwork_price(artwork, edition_set_id: edition_set_id),
         quantity: quantity
       )
-      OrderService.update_totals!(order)
+      OrderTotalUpdaterService.update_totals!(order)
       OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
       order
     end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -33,7 +33,7 @@ module OrderService
           shipping_postal_code: shipping[:postal_code]
         )
       )
-      OrderTotalUpdaterService.update_totals!(order)
+      OrderTotalUpdaterService.new(order).update_totals!
     end
     order
   end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -47,9 +47,7 @@ class OrderSubmitService
     assert_credit_card!
     @partner = GravityService.fetch_partner(@order.seller_id)
     @merchant_account = GravityService.get_merchant_account(@order.seller_id)
-    @order.commission_fee_cents = calculate_commission_fee
-    @order.transaction_fee_cents = calculate_transaction_fee
-    @order.save!
+    OrderTotalUpdaterService.update_totals!(@order, @partner[:effective_commission_rate])
   end
 
   def post_process!
@@ -79,15 +77,6 @@ class OrderSubmitService
 
   def can_submit?
     @order.shipping_info? && @order.payment_info?
-  end
-
-  def calculate_commission_fee
-    @order.items_total_cents * @partner[:effective_commission_rate]
-  end
-
-  def calculate_transaction_fee
-    # This is based on Stripe US fee, it will be different for other countries
-    (Money.new(@order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
   end
 
   def charge_description

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -47,7 +47,7 @@ class OrderSubmitService
     assert_credit_card!
     @partner = GravityService.fetch_partner(@order.seller_id)
     @merchant_account = GravityService.get_merchant_account(@order.seller_id)
-    OrderTotalUpdaterService.update_totals!(@order, @partner[:effective_commission_rate])
+    OrderTotalUpdaterService.new(@order, @partner[:effective_commission_rate]).update_totals!
   end
 
   def post_process!

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -16,6 +16,7 @@ class OrderTotalUpdaterService
   def self.calculate_transaction_fee(order)
     return 0 unless order.buyer_total_cents.positive?
     # This is based on Stripe US fee, it will be different for other countries
+    # https://stripe.com/us/pricing
     (Money.new(order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
   end
 end

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -1,4 +1,4 @@
-class OrderTotalUpdaterService
+module OrderTotalUpdaterService
   def self.update_totals!(order, commission_rate = nil)
     raise Errors::OrderError, 'Missing price info on line items' if order.line_items.any? { |li| li.price_cents.nil? }
     order.items_total_cents = order.line_items.map(&:total_amount_cents).sum

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -1,0 +1,21 @@
+class OrderTotalUpdaterService
+  def self.update_totals!(order, commission_rate = nil)
+    raise Errors::OrderError, 'Missing price info on line items' if order.line_items.any? { |li| li.price_cents.nil? }
+    order.items_total_cents = order.line_items.map(&:total_amount_cents).sum
+    order.buyer_total_cents = order.items_total_cents + order.shipping_total_cents.to_i + order.tax_total_cents.to_i
+    order.commission_fee_cents = calculate_commission_fee(order, commission_rate) if commission_rate.present?
+    order.transaction_fee_cents = calculate_transaction_fee(order)
+    order.seller_total_cents = order.buyer_total_cents - order.commission_fee_cents.to_i - order.transaction_fee_cents.to_i
+    order.save!
+  end
+
+  def self.calculate_commission_fee(order, commission_rate)
+    order.items_total_cents * commission_rate
+  end
+
+  def self.calculate_transaction_fee(order)
+    return 0 unless order.buyer_total_cents.positive?
+    # This is based on Stripe US fee, it will be different for other countries
+    (Money.new(order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
+  end
+end

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -1,22 +1,30 @@
-module OrderTotalUpdaterService
-  def self.update_totals!(order, commission_rate = nil)
-    raise Errors::OrderError, 'Missing price info on line items' if order.line_items.any? { |li| li.price_cents.nil? }
-    order.items_total_cents = order.line_items.map(&:total_amount_cents).sum
-    order.buyer_total_cents = order.items_total_cents + order.shipping_total_cents.to_i + order.tax_total_cents.to_i
-    order.commission_fee_cents = calculate_commission_fee(order, commission_rate) if commission_rate.present?
-    order.transaction_fee_cents = calculate_transaction_fee(order)
-    order.seller_total_cents = order.buyer_total_cents - order.commission_fee_cents.to_i - order.transaction_fee_cents.to_i
-    order.save!
+class OrderTotalUpdaterService
+  def initialize(order, commission_rate = nil)
+    @order = order
+    raise 'Commission rate should be a value between 0 and 1' if commission_rate.present? && (commission_rate > 1 || commission_rate.negative?)
+    @commission_rate = commission_rate
   end
 
-  def self.calculate_commission_fee(order, commission_rate)
-    order.items_total_cents * commission_rate
+  def update_totals!
+    raise Errors::OrderError, 'Missing price info on line items' if @order.line_items.any? { |li| li.price_cents.nil? }
+    @order.items_total_cents = @order.line_items.map(&:total_amount_cents).sum
+    @order.buyer_total_cents = @order.items_total_cents + @order.shipping_total_cents.to_i + @order.tax_total_cents.to_i
+    @order.commission_fee_cents = calculate_commission_fee if @commission_rate.present?
+    @order.transaction_fee_cents = calculate_transaction_fee
+    @order.seller_total_cents = @order.buyer_total_cents - @order.commission_fee_cents.to_i - @order.transaction_fee_cents.to_i
+    @order.save!
   end
 
-  def self.calculate_transaction_fee(order)
-    return 0 unless order.buyer_total_cents.positive?
+  private
+
+  def calculate_commission_fee
+    @order.items_total_cents * @commission_rate
+  end
+
+  def calculate_transaction_fee
+    return 0 unless @order.buyer_total_cents.positive?
     # This is based on Stripe US fee, it will be different for other countries
     # https://stripe.com/us/pricing
-    (Money.new(order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
+    (Money.new(@order.buyer_total_cents * 2.9 / 100, 'USD') + Money.new(30, 'USD')).cents
   end
 end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -70,34 +70,4 @@ describe OrderService, type: :services do
       end
     end
   end
-
-  describe '#update_totals!' do
-    before do
-      order.update!(tax_total_cents: 50_00, shipping_total_cents: 50_00, commission_fee_cents: 10_00, transaction_fee_cents: 10_00)
-      OrderService.update_totals!(order)
-    end
-    context 'with no line items' do
-      let!(:line_items) { nil }
-      it 'updates total fields' do
-        expect(order.items_total_cents).to eq 0
-        expect(order.buyer_total_cents).to eq 100_00
-        expect(order.seller_total_cents).to eq 80_00
-      end
-    end
-
-    context 'with one line item quantity of 2' do
-      it 'returns the sum of the prices of those line items' do
-        expect(order.items_total_cents).to eq 371_00
-        expect(order.buyer_total_cents).to eq 471_00
-        expect(order.seller_total_cents).to eq 451_00
-      end
-    end
-
-    context 'with a line item that has no price' do
-      it 'raises error' do
-        order.line_items << Fabricate(:line_item, price_cents: nil)
-        expect { OrderService.update_totals!(order) }.to raise_error(Errors::OrderError, 'Missing price info on line items')
-      end
-    end
-  end
 end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -7,7 +7,14 @@ describe OrderSubmitService, type: :services do
   let(:partner_id) { 'partner-1' }
   let(:credit_card_id) { 'cc-1' }
   let(:user_id) { 'dr-collector' }
-  let(:order) { Fabricate(:order, seller_id: partner_id, credit_card_id: credit_card_id, fulfillment_type: Order::PICKUP, items_total_cents: 10000_00, buyer_total_cents: 10000_00) }
+  let(:order) do
+    Fabricate(
+      :order,
+      seller_id: partner_id,
+      credit_card_id: credit_card_id,
+      fulfillment_type: Order::PICKUP
+    )
+  end
   let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: 'a-1', quantity: 1), Fabricate(:line_item, order: order, price_cents: 8000_00, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2)] }
   let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id }, deactivated_at: nil } }
   let(:merchant_account_id) { 'ma-1' }
@@ -112,11 +119,11 @@ describe OrderSubmitService, type: :services do
         end
 
         it 'sets commission_fee_cents' do
-          expect(order.commission_fee_cents).to eq 8000_00
+          expect(order.commission_fee_cents).to eq 14400_00
         end
 
         it 'sets transaction_fee_cents' do
-          expect(order.transaction_fee_cents).to eq 290_30
+          expect(order.transaction_fee_cents).to eq 522_30
         end
       end
 
@@ -129,11 +136,7 @@ describe OrderSubmitService, type: :services do
             fulfillment_type: Order::PICKUP,
             items_total_cents: 18000_00,
             tax_total_cents: 200_00,
-            shipping_total_cents: 100_00,
-            commission_fee_cents: 100_00,
-            transaction_fee_cents: 50_00,
-            buyer_total_cents: 18300_00,
-            seller_total_cents: 18150_00
+            shipping_total_cents: 100_00
           )
         end
         it 'calls stripe with expected params' do
@@ -153,7 +156,7 @@ describe OrderSubmitService, type: :services do
             },
             destination: {
               account: 'ma-1',
-              amount: 18150_00
+              amount: 3369_00
             },
             capture: false
           ).and_return(captured_charge)
@@ -207,19 +210,6 @@ describe OrderSubmitService, type: :services do
     it 'raises an error if the card is deactivated' do
       service.credit_card = { external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 2.days.ago }
       expect { service.send(:assert_credit_card!) }.to raise_error(Errors::OrderError, 'Credit card is deactivated')
-    end
-  end
-
-  describe '#calculate_commission_fee' do
-    it 'returns calculated commission fee' do
-      service.partner = gravity_v1_partner
-      expect(service.send(:calculate_commission_fee)).to eq 8000_00.0
-    end
-  end
-
-  describe '#calculate_transaction_fee' do
-    it 'returns proper transaction fee' do
-      expect(service.send(:calculate_transaction_fee)).to eq 290_30
     end
   end
 end

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe OrderTotalUpdaterService, type: :service do
+  let(:shipping_total_cents) { nil }
+  let(:tax_total_cents) { nil }
+  let(:order) { Fabricate(:order, shipping_total_cents: shipping_total_cents, tax_total_cents: tax_total_cents) }
+  describe '#update_order_totals!' do
+    context 'without line items' do
+      it 'returns 0 for everything' do
+        OrderTotalUpdaterService.update_totals!(order)
+        expect(order.reload.items_total_cents).to eq 0
+        expect(order.buyer_total_cents).to eq 0
+        expect(order.seller_total_cents).to eq 0
+      end
+    end
+    context 'with line items' do
+      let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 100_00), Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2)] }
+      context 'with shipping and tax' do
+        let(:shipping_total_cents) { 50_00 }
+        let(:tax_total_cents) { 60_00 }
+        context 'without commission rate' do
+          it 'sets correct totals on the order' do
+            OrderTotalUpdaterService.update_totals!(order)
+            expect(order.items_total_cents).to eq 500_00
+            expect(order.buyer_total_cents).to eq(500_00 + 50_00 + 60_00)
+            expect(order.transaction_fee_cents).to eq 17_99
+            expect(order.commission_fee_cents).to be_nil
+            expect(order.seller_total_cents).to eq(610_00 - 17_99)
+          end
+        end
+        context 'with commission rate' do
+          it 'sets correct totals on the order' do
+            OrderTotalUpdaterService.update_totals!(order, 0.40)
+            expect(order.items_total_cents).to eq 500_00
+            expect(order.buyer_total_cents).to eq(500_00 + 50_00 + 60_00)
+            expect(order.transaction_fee_cents).to eq 17_99
+            expect(order.commission_fee_cents).to eq 200_00
+            expect(order.seller_total_cents).to eq(610_00 - (17_99 + 200_00))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Problem
We were not calling update totals before submission, we were setting commission and transaction fees and were missing updating totals after that which would lead to calling stripe and not holding commission and transaction in our account.

# Solution
Totals were calculated in 2 different places, moved all of them into one service which can get commission rate as an input and based on that calculates all the totals of an order in one place! this makes things little more sane... hopefully.
