### PR TITLE
Include sales tax when calculating `seller_total_cents`

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -108,9 +108,9 @@ module OrderService
 
   def self.calculate_total_tax_cents(order, fulfillment_type, shipping, shipping_total_cents, artworks)
     order.line_items.map do |li|
-      sales_tax = SalesTaxService.new(li, fulfillment_type, shipping, shipping_total_cents, artworks[li.artwork_id][:location]).sales_tax
-      li.update!(sales_tax_cents: sales_tax)
-      sales_tax
+      service = SalesTaxService.new(li, fulfillment_type, shipping, shipping_total_cents, artworks[li.artwork_id][:location])
+      li.update!(sales_tax_cents: service.sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
+      service.sales_tax
     end.sum
   end
 end

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -11,11 +11,15 @@ class OrderTotalUpdaterService
     @order.buyer_total_cents = @order.items_total_cents + @order.shipping_total_cents.to_i + @order.tax_total_cents.to_i
     @order.commission_fee_cents = calculate_commission_fee if @commission_rate.present?
     @order.transaction_fee_cents = calculate_transaction_fee
-    @order.seller_total_cents = @order.buyer_total_cents - @order.commission_fee_cents.to_i - @order.transaction_fee_cents.to_i
+    @order.seller_total_cents = @order.buyer_total_cents - @order.commission_fee_cents.to_i - @order.transaction_fee_cents.to_i - calculate_remittable_sales_tax
     @order.save!
   end
 
   private
+
+  def calculate_remittable_sales_tax
+    @order.line_items.select(&:should_remit_sales_tax).sum(&:sales_tax_cents)
+  end
 
   def calculate_commission_fee
     @order.items_total_cents * @commission_rate

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -28,6 +28,11 @@ class SalesTaxService
     raise Errors::OrderError, e.message
   end
 
+  def artsy_should_remit_taxes?
+    return false unless destination_address[:country] == 'US'
+    REMITTING_STATES.include? destination_address[:state].downcase
+  end
+
   private
 
   def fetch_sales_tax
@@ -78,10 +83,5 @@ class SalesTaxService
 
   def seller_address
     @seller_address ||= GravityService.fetch_partner_location(@line_item.order.seller_id)
-  end
-
-  def artsy_should_remit_taxes?
-    return false unless destination_address[:country] == 'US'
-    REMITTING_STATES.include? destination_address[:state].downcase
   end
 end

--- a/db/migrate/20180906205600_add_should_remit_sales_tax_to_line_items.rb
+++ b/db/migrate/20180906205600_add_should_remit_sales_tax_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddShouldRemitSalesTaxToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :should_remit_sales_tax, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_03_104007) do
+ActiveRecord::Schema.define(version: 2018_09_06_205600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2018_09_03_104007) do
     t.datetime "updated_at", null: false
     t.integer "quantity", default: 1, null: false
     t.integer "sales_tax_cents"
+    t.boolean "should_remit_sales_tax"
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -150,6 +150,8 @@ describe Api::GraphqlController, type: :request do
         expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
         expect(line_items[0].reload.sales_tax_cents).to eq 116
         expect(line_items[1].reload.sales_tax_cents).to eq 116
+        expect(line_items[0].reload.should_remit_sales_tax).to eq false
+        expect(line_items[1].reload.should_remit_sales_tax).to eq false
         expect(order.tax_total_cents).to eq 232
       end
 

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -14,7 +14,7 @@ describe OrderTotalUpdaterService, type: :service do
       end
     end
     context 'with line items' do
-      let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 100_00), Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2)] }
+      let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true), Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false)] }
       context 'with shipping and tax' do
         let(:shipping_total_cents) { 50_00 }
         let(:tax_total_cents) { 60_00 }
@@ -25,7 +25,7 @@ describe OrderTotalUpdaterService, type: :service do
             expect(order.buyer_total_cents).to eq(500_00 + 50_00 + 60_00)
             expect(order.transaction_fee_cents).to eq 17_99
             expect(order.commission_fee_cents).to be_nil
-            expect(order.seller_total_cents).to eq(610_00 - 17_99)
+            expect(order.seller_total_cents).to eq(610_00 - 17_99 - 500)
           end
         end
         context 'with commission rate' do
@@ -41,7 +41,7 @@ describe OrderTotalUpdaterService, type: :service do
             expect(order.buyer_total_cents).to eq(500_00 + 50_00 + 60_00)
             expect(order.transaction_fee_cents).to eq 17_99
             expect(order.commission_fee_cents).to eq 200_00
-            expect(order.seller_total_cents).to eq(610_00 - (17_99 + 200_00))
+            expect(order.seller_total_cents).to eq(610_00 - (17_99 + 200_00 + 500))
           end
         end
       end


### PR DESCRIPTION
### Problem
`order.seller_total_cents` currently doesn't subtract out taxes that Artsy is obligated to remit.

### Solution
In addition to the sales tax for each line item, keep track of whether or not Artsy needs to remit the sales tax. Include the remittable taxes when calculating `seller_total_cents`.

### What changed
- Adds a new Boolean field `should_remit_sales_tax` on `line_items` that's set by `SalesTaxService.artsy_should_remit_taxes?` when we calculate sales tax.
- Sums sales tax to be remitted and subtracts it out in `seller_total_cents`.