### PR TITLE
Add capability to refund sales tax transactions

### DIFF
--- a/app/jobs/post_sales_tax_refund_job.rb
+++ b/app/jobs/post_sales_tax_refund_job.rb
@@ -1,0 +1,16 @@
+class PostSalesTaxRefundJob < ApplicationJob
+  queue_as :default
+
+  def perform(line_item_id, refund_date)
+    line_item = LineItem.find(line_item_id)
+    artwork = GravityService.get_artwork(line_item.artwork_id)
+    shipping = {
+      country: line_item.order.shipping_country,
+      postal_code: line_item.order.shipping_postal_code,
+      region: line_item.order.shipping_region,
+      city: line_item.order.shipping_city,
+      address_line1: line_item.order.shipping_address_line1
+    }
+    SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping, line_item.order.shipping_total_cents, artwork[:location]).refund_transaction(refund_date)
+  end
+end

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -47,7 +47,7 @@ class SalesTaxService
   end
 
   def artsy_should_remit_taxes?
-    return false unless destination_address[:country] == 'US'
+    return false unless destination_address[:country] == Carmen::Country.coded('US').code
     REMITTING_STATES.include? destination_address[:state].downcase
   end
 

--- a/spec/jobs/post_sales_tax_refund_job_spec.rb
+++ b/spec/jobs/post_sales_tax_refund_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe PostSalesTaxRefundJob, type: :job do
+  let(:order) { Fabricate(:order, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
+  let(:shipping) do
+    {
+      country: order.shipping_country,
+      postal_code: order.shipping_postal_code,
+      region: order.shipping_region,
+      city: order.shipping_city,
+      address_line1: order.shipping_address_line1
+    }
+  end
+  let!(:line_item) { Fabricate(:line_item, order: order) }
+  let(:artwork_location) { gravity_v1_artwork[:location] }
+  let(:refund_date) { Time.new(2018, 1, 1) }
+  describe '#perform' do
+    it 'instantiates a new SalesTaxService and calls refund_transaction' do
+      sales_tax_instance = double
+      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork_location).and_return(sales_tax_instance)
+      expect(sales_tax_instance).to receive(:refund_transaction).with(refund_date)
+      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
+      PostSalesTaxRefundJob.perform_now(line_item.id, refund_date)
+    end
+  end
+end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -3,8 +3,8 @@ require 'support/gravity_helper'
 
 describe SalesTaxService, type: :services do
   let(:taxjar_client) { double }
-  let(:order) { Fabricate(:order) }
-  let!(:line_item) { Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
+  let(:order) { Fabricate(:order, id: 1) }
+  let!(:line_item) { Fabricate(:line_item, id: 1, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
   let(:shipping_total_cents) { 2222 }
   let(:shipping) do
     {
@@ -34,9 +34,26 @@ describe SalesTaxService, type: :services do
     }
   end
   let(:artwork_location) { gravity_v1_artwork[:location] }
+  let(:base_tax_params) do
+    {
+      amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
+      from_country: partner_location[:country],
+      from_zip: partner_location[:postal_code],
+      from_state: partner_location[:state],
+      from_city: partner_location[:city],
+      from_street: partner_location[:address],
+      to_country: shipping_address[:country],
+      to_zip: shipping_address[:postal_code],
+      to_state: shipping_address[:state],
+      to_city: shipping_address[:city],
+      to_street: shipping_address[:address],
+      shipping: 0
+    }
+  end
 
   before do
     allow(Taxjar::Client).to receive(:new).with(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key'], api_url: nil).and_return(taxjar_client)
+    allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
     @service_ship = SalesTaxService.new(line_item, Order::SHIP, shipping, shipping_total_cents, artwork_location)
     @service_pickup = SalesTaxService.new(line_item, Order::PICKUP, shipping, shipping_total_cents, artwork_location)
   end
@@ -58,7 +75,6 @@ describe SalesTaxService, type: :services do
 
   describe '#sales_tax' do
     it 'calls fetch_sales_tax and returns the sales tax in cents' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
       expect(@service_ship).to receive(:fetch_sales_tax).and_return(double(amount_to_collect: 1.00))
       expect(@service_ship.sales_tax).to eq 100
     end
@@ -99,27 +115,9 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#fetch_sales_tax' do
-    let(:params) do
-      {
-        amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
-        from_country: partner_location[:country],
-        from_zip: partner_location[:postal_code],
-        from_state: partner_location[:state],
-        from_city: partner_location[:city],
-        from_street: partner_location[:address],
-        to_country: shipping_address[:country],
-        to_zip: shipping_address[:postal_code],
-        to_state: shipping_address[:state],
-        to_city: shipping_address[:city],
-        to_street: shipping_address[:address],
-        shipping: 0
-      }
-    end
     it 'calls the Taxjar API with the correct parameters' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
-      allow(taxjar_client).to receive(:tax_for_order).with(params)
+      expect(taxjar_client).to receive(:tax_for_order).with(base_tax_params)
       @service_ship.send(:fetch_sales_tax)
-      expect(taxjar_client).to have_received(:tax_for_order).with(params)
     end
   end
 
@@ -152,23 +150,11 @@ describe SalesTaxService, type: :services do
 
   describe '#post_transaction' do
     let(:params) do
-      {
+      base_tax_params.merge(
         transaction_id: "#{line_item.order_id}-#{line_item.id}",
         transaction_date: line_item.order.last_approved_at.iso8601,
-        amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
-        from_country: partner_location[:country],
-        from_zip: partner_location[:postal_code],
-        from_state: partner_location[:state],
-        from_city: partner_location[:city],
-        from_street: partner_location[:address],
-        to_country: shipping_address[:country],
-        to_zip: shipping_address[:postal_code],
-        to_state: shipping_address[:state],
-        to_city: shipping_address[:city],
-        to_street: shipping_address[:address],
-        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents),
-        shipping: 0
-      }
+        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents)
+      )
     end
     before do
       # We need to trigger the state actions to generate the state history
@@ -177,7 +163,6 @@ describe SalesTaxService, type: :services do
       order.approve!
     end
     it 'calls the Taxjar API with the correct parameters' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
       expect(taxjar_client).to receive(:create_order).with(params)
       @service_ship.send(:post_transaction)
     end
@@ -206,6 +191,56 @@ describe SalesTaxService, type: :services do
         service = SalesTaxService.new(line_item, Order::SHIP, shipping, shipping_total_cents, artwork_location)
         expect(service.send(:artsy_should_remit_taxes?)).to be false
       end
+    end
+  end
+
+  describe '#refund_transaction' do
+    context 'with an existing transaction in Taxjar' do
+      it 'refunds the transaction' do
+        expect(taxjar_client).to receive(:show_order).with('1-1').and_return(double)
+        expect(@service_ship).to receive(:post_refund)
+        @service_ship.refund_transaction(Time.new(2018, 1, 1))
+      end
+    end
+    context 'without an existing transaction in Taxjar' do
+      it 'does nothing' do
+        expect(taxjar_client).to receive(:show_order).with('1-1').and_return(nil)
+        expect(@service_ship).to_not receive(:post_refund)
+        @service_ship.refund_transaction(Time.new(2018, 1, 1))
+      end
+    end
+  end
+
+  describe '#get_transaction' do
+    it "returns nil if TaxJar can't find the associated record" do
+      expect(taxjar_client).to receive(:show_order).and_raise(Taxjar::Error::NotFound)
+      expect(@service_ship.send(:get_transaction, 'tx_id')).to be_nil
+    end
+  end
+
+  describe '#post_refund' do
+    let(:transaction_date) { Time.new(2018, 1, 1) }
+    let(:params) do
+      base_tax_params.merge(
+        transaction_id: "#{line_item.order_id}-#{line_item.id}_refund",
+        transaction_date: transaction_date.iso8601,
+        transaction_reference_id: "#{line_item.order_id}-#{line_item.id}",
+        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents)
+      )
+    end
+    it 'calls the TaxJar API with the correct parameters' do
+      expect(taxjar_client).to receive(:create_refund).with(params)
+      @service_ship.send(:post_refund, transaction_date)
+    end
+  end
+
+  describe '#construct_tax_params' do
+    it 'returns the parameters shared by all API calls to TaxJar' do
+      expect(@service_ship.send(:construct_tax_params)).to eq base_tax_params
+    end
+    it 'merges in additional data' do
+      additional_data = { foo: 'bar' }
+      expect(@service_ship.send(:construct_tax_params, additional_data)).to eq base_tax_params.merge(additional_data)
     end
   end
 end


### PR DESCRIPTION
### Problem
When we refund a _captured charge_ we need to send a reversed transaction to TaxJar to record the refund.

### Solution
Add capability to create refund transactions. This will eventually be implemented by using `PostSalesTaxRefundJob` in `OrderCancellationService`. However, since we're not currently refunding captured charges this is just the code to create refund transactions in TaxJar.

### What Changed
- Adds methods to handle creating refunds in TaxJar
- Creates `PostSalesTaxRefundJob` to process the refund job in the background
- Refactors shared parameters for TaxJar API calls into a single method `construct_tax_params`
- Compares country codes for `artsy_should_remit_taxes?` using Carmen's country code instead of a hard-coded string