### PR TITLE
👋 Memcache and Cache

### DIFF
--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -1,8 +1,6 @@
 module GravityService
   def self.fetch_partner(partner_id)
-    Rails.cache.fetch("gravity_partner_#{partner_id}", expire_in: Rails.application.config_for(:gravity)['partner_cache_in_seconds']) do
-      Adapters::GravityV1.get("/partner/#{partner_id}/all")
-    end
+    Adapters::GravityV1.get("/partner/#{partner_id}/all")
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_partner, partner_id: partner_id)
   rescue Adapters::GravityError, StandardError => e
@@ -36,9 +34,7 @@ module GravityService
 
   def self.fetch_partner_location(partner_id)
     partner = fetch_partner(partner_id)
-    location = Rails.cache.fetch("gravity_partner_location_#{partner[:billing_location_id]}", expire_in: Rails.application.config_for(:gravity)['partner_cache_in_seconds']) do
-      Adapters::GravityV1.get("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
-    end
+    location = Adapters::GravityV1.get("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
     location.slice(:address, :address_2, :city, :state, :country, :postal_code)
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store, ENV['MEMCACHE_HOST']
+  # config.cache_store = :mem_cache_store, ENV['MEMCACHE_HOST']
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,5 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.before(:each) do
-    Rails.cache.clear
-  end
-
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end


### PR DESCRIPTION
# Problem
Originally we decided to cache Partner and Artwork data, but as we started testing, looks like caching mostly causes issue and leads to us using stalled data. We want to make sure we are using latest version of all these models when calling our main API.

# Solution
Remove caching.

# Followup
De-provision Memache instances assigned to Exchange.