### PR TITLE
Add Sidekiq check to our health endpoint

### DIFF
--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -1,9 +1,13 @@
 module Api
   class HealthController < Api::BaseApiController
     skip_before_action :authenticate_request!
+    SIDEKIQ_ALERT_THRESHOLD = 100
 
     def index
-      render json: { healthy: true }
+      render json: {
+        healthy: true,
+        worker_health: Sidekiq::Queue.new.size < SIDEKIQ_ALERT_THRESHOLD ? 'OK' : 'OY'
+      }
     end
   end
 end

--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -4,9 +4,11 @@ module Api
     SIDEKIQ_ALERT_THRESHOLD = 100
 
     def index
+      sidekiq_default_queue_size = Sidekiq::Queue.new.size
       render json: {
-        healthy: true,
-        worker_health: Sidekiq::Queue.new.size < SIDEKIQ_ALERT_THRESHOLD ? 'OK' : 'OY'
+        api_healthy: true,
+        worker_health:  sidekiq_default_queue_size < SIDEKIQ_ALERT_THRESHOLD ? 'OK' : 'OY',
+        worker_default_queue_size: sidekiq_default_queue_size
       }
     end
   end

--- a/spec/controllers/api/health_controller_spec.rb
+++ b/spec/controllers/api/health_controller_spec.rb
@@ -6,7 +6,10 @@ describe Api::HealthController, type: :request do
       it 'returns healthy: true' do
         get '/api/health'
         expect(response.status).to eq 200
-        expect(response.body).to eq({ healthy: true }.to_json)
+        result = JSON.parse(response.body)
+        expect(result['api_healthy']).to eq(true)
+        expect(result['worker_health']).to eq('OK')
+        expect(result['worker_default_queue_size']).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
Adding `worker_health` to our health endpoint response, based on our threshold it either returns `OK` or `OY` 