### PR TITLE
Catch all

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -1,6 +1,10 @@
 module ErrorHandler
   def self.included(clazz)
     clazz.class_eval do
+      rescue_from StandardError do |exception|
+        render json: { errors: [Types::ApplicationErrorType.from_exception(exception)] }, status: :internal_server_error
+      end
+
       rescue_from ActionController::ParameterMissing do |exception|
         render json: { errors: [exception.param => 'is required'] }, status: :bad_request
       end
@@ -9,7 +13,7 @@ module ErrorHandler
         render json: { errors: ['not found' => exception.to_s] }, status: :not_found
       end
 
-      rescue_from ::Errors::AuthError do |exception|
+      rescue_from Errors::AuthError do |exception|
         render json: { errors: [Types::ApplicationErrorType.from_application(exception)] }, status: :unauthorized
       end
 

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -6,11 +6,11 @@ module ErrorHandler
       end
 
       rescue_from ActionController::ParameterMissing do |exception|
-        render json: { errors: [exception.param => 'is required'] }, status: :bad_request
+        render json: { errors: [Types::ApplicationErrorType.error_type(type: :validation, code: :missing_param, data: { field: exception.param })] }, status: :bad_request
       end
 
       rescue_from ActiveRecord::RecordNotFound do |exception|
-        render json: { errors: ['not found' => exception.to_s] }, status: :not_found
+        render json: { errors: [Types::ApplicationErrorType.error_type(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
       rescue_from Errors::AuthError do |exception|

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -6,11 +6,11 @@ module ErrorHandler
       end
 
       rescue_from ActionController::ParameterMissing do |exception|
-        render json: { errors: [Types::ApplicationErrorType.error_type(type: :validation, code: :missing_param, data: { field: exception.param })] }, status: :bad_request
+        render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :missing_param, data: { field: exception.param })] }, status: :bad_request
       end
 
       rescue_from ActiveRecord::RecordNotFound do |exception|
-        render json: { errors: [Types::ApplicationErrorType.error_type(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
+        render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
       rescue_from Errors::AuthError do |exception|

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -2,7 +2,7 @@ module ErrorHandler
   def self.included(clazz)
     clazz.class_eval do
       rescue_from StandardError do |exception|
-        render json: { errors: [Types::ApplicationErrorType.from_exception(exception)] }, status: :internal_server_error
+        render json: { errors: [Types::ApplicationErrorType.from_generic_exception(exception)] }, status: :internal_server_error
       end
 
       rescue_from ActionController::ParameterMissing do |exception|

--- a/app/controllers/errors/application_error.rb
+++ b/app/controllers/errors/application_error.rb
@@ -1,7 +1,7 @@
 module Errors
   class ApplicationError < StandardError
     attr_reader :type, :code, :data
-    def initialize(type, code, data = {})
+    def initialize(type, code, data = nil)
       @type = type
       @code = code
       @data = data

--- a/app/controllers/errors/processing_error.rb
+++ b/app/controllers/errors/processing_error.rb
@@ -1,6 +1,6 @@
 module Errors
   class ProcessingError < ApplicationError
-    def initialize(code, data = {})
+    def initialize(code, data = nil)
       super(:processing, code, data)
     end
   end

--- a/app/controllers/errors/validation_error.rb
+++ b/app/controllers/errors/validation_error.rb
@@ -1,6 +1,6 @@
 module Errors
   class ValidationError < ApplicationError
-    def initialize(code, data = {})
+    def initialize(code, data = nil)
       super(:validation, code, data)
     end
   end

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -14,7 +14,7 @@ class Types::ApplicationErrorType < Types::BaseObject
     error_type(type: :internal, code: :server, data: { message: err.message })
   end
 
-  def self.error_type(type:, code:, data: {})
+  def self.error_type(type:, code:, data: nil)
     {
       code: code,
       data: data,

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -7,18 +7,18 @@ class Types::ApplicationErrorType < Types::BaseObject
   field :type, String, null: false, description: 'Type of this error'
 
   def self.from_application(err)
-    {
-      code: err.code,
-      data: err.data.to_json,
-      type: err.type.to_s
-    }
+    error_type(type: err.type, code: err.code, data: err.data)
   end
 
   def self.from_exception(err)
+    error_type(type: :internal, code: :server, data: { message: err.message })
+  end
+
+  def self.error_type(type:, code:, data: {})
     {
-      code: :server,
-      data: { message: err.message },
-      type: :internal
+      code: code,
+      data: data,
+      type: type
     }
   end
 end

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -10,8 +10,8 @@ class Types::ApplicationErrorType < Types::BaseObject
     format_error_type(type: err.type, code: err.code, data: err.data)
   end
 
-  def self.from_exception(err)
-    format_error_type(type: :internal, code: :server, data: { message: err.message })
+  def self.from_generic_exception(err)
+    format_error_type(type: :internal, code: :generic, data: { message: err.message })
   end
 
   def self.format_error_type(type:, code:, data: nil)

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -13,4 +13,12 @@ class Types::ApplicationErrorType < Types::BaseObject
       type: err.type.to_s
     }
   end
+
+  def self.from_exception(err)
+    {
+      code: :server,
+      data: { message: err.message }.to_json,
+      type: :internal
+    }
+  end
 end

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -17,7 +17,7 @@ class Types::ApplicationErrorType < Types::BaseObject
   def self.from_exception(err)
     {
       code: :server,
-      data: { message: err.message }.to_json,
+      data: { message: err.message },
       type: :internal
     }
   end

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -7,14 +7,14 @@ class Types::ApplicationErrorType < Types::BaseObject
   field :type, String, null: false, description: 'Type of this error'
 
   def self.from_application(err)
-    error_type(type: err.type, code: err.code, data: err.data)
+    format_error_type(type: err.type, code: err.code, data: err.data)
   end
 
   def self.from_exception(err)
-    error_type(type: :internal, code: :server, data: { message: err.message })
+    format_error_type(type: :internal, code: :server, data: { message: err.message })
   end
 
-  def self.error_type(type:, code:, data: nil)
+  def self.format_error_type(type:, code:, data: nil)
     {
       code: code,
       data: data,

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ default: &default
 
 development:
   <<: *default
-  database: exchange_development
+  database: <%= ENV['DATABASE_NAME'] || 'exchange_development' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -64,7 +64,7 @@ describe Api::GraphqlController, type: :request do
         allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActiveRecord::RecordNotFound, 'cannot find')
         post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
       end
-      it 'returns 500' do
+      it 'returns 404' do
         expect(response.status).to eq 404
       end
       it 'returns formatted the error' do
@@ -82,7 +82,7 @@ describe Api::GraphqlController, type: :request do
         allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActionController::ParameterMissing, 'id')
         post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
       end
-      it 'returns 500' do
+      it 'returns 400' do
         expect(response.status).to eq 400
       end
       it 'returns formatted the error' do

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -54,7 +54,7 @@ describe Api::GraphqlController, type: :request do
         expect(result['errors']).not_to be_nil
         error = result['errors'].first
         expect(error['type']).to eq 'internal'
-        expect(error['code']).to eq 'server'
+        expect(error['code']).to eq 'generic'
         expect(error['data']['message']).to eq 'something went wrong'
       end
     end

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'StandardError' do
+    let(:auth_headers) { jwt_headers(user_id: 'user-id', partner_ids: ['p1'], roles: nil) }
+    let(:mutation_input) do
+      {
+        artworkId: 'test'
+      }
+    end
+    let(:mutation) do
+      <<-GRAPHQL
+        mutation($input: CreateOrderWithArtworkInput!) {
+          createOrderWithArtwork(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  id
+                  buyer {
+                    ... on Partner {
+                      id
+                    }
+                  }
+                  seller {
+                    ... on User {
+                      id
+                    }
+                  }
+                }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  code
+                  data
+                  type
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+    before do
+      allow(CreateOrderService).to receive(:with_artwork!).and_raise('something went wrong')
+      post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
+    end
+    it 'returns 500' do
+      expect(response.status).to eq 500
+    end
+    it 'returns formatted the error' do
+      result = JSON.parse(response.body)
+      expect(result['errors']).not_to be_nil
+      error = result['errors'].first
+      expect(error['type']).to eq 'internal'
+      expect(error['code']).to eq 'server'
+      expect(error['data']['message']).to eq 'something went wrong'
+    end
+  end
+end

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Api::GraphqlController, type: :request do
-  describe 'StandardError' do
+  describe 'ErrorType' do
     let(:auth_headers) { jwt_headers(user_id: 'user-id', partner_ids: ['p1'], roles: nil) }
     let(:mutation_input) do
       {
@@ -40,20 +40,59 @@ describe Api::GraphqlController, type: :request do
         }
       GRAPHQL
     end
-    before do
-      allow(CreateOrderService).to receive(:with_artwork!).and_raise('something went wrong')
-      post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
+
+    context 'StandardError' do
+      before do
+        allow(CreateOrderService).to receive(:with_artwork!).and_raise('something went wrong')
+        post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
+      end
+      it 'returns 500' do
+        expect(response.status).to eq 500
+      end
+      it 'returns formatted the error' do
+        result = JSON.parse(response.body)
+        expect(result['errors']).not_to be_nil
+        error = result['errors'].first
+        expect(error['type']).to eq 'internal'
+        expect(error['code']).to eq 'server'
+        expect(error['data']['message']).to eq 'something went wrong'
+      end
     end
-    it 'returns 500' do
-      expect(response.status).to eq 500
+
+    context 'ActiveRecord::RecordNotFound' do
+      before do
+        allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActiveRecord::RecordNotFound, 'cannot find')
+        post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
+      end
+      it 'returns 500' do
+        expect(response.status).to eq 404
+      end
+      it 'returns formatted the error' do
+        result = JSON.parse(response.body)
+        expect(result['errors']).not_to be_nil
+        error = result['errors'].first
+        expect(error['type']).to eq 'validation'
+        expect(error['code']).to eq 'not_found'
+        expect(error['data']['message']).to eq 'cannot find'
+      end
     end
-    it 'returns formatted the error' do
-      result = JSON.parse(response.body)
-      expect(result['errors']).not_to be_nil
-      error = result['errors'].first
-      expect(error['type']).to eq 'internal'
-      expect(error['code']).to eq 'server'
-      expect(error['data']['message']).to eq 'something went wrong'
+
+    context 'ActionController::ParameterMissing' do
+      before do
+        allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActionController::ParameterMissing, 'id')
+        post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
+      end
+      it 'returns 500' do
+        expect(response.status).to eq 400
+      end
+      it 'returns formatted the error' do
+        result = JSON.parse(response.body)
+        expect(result['errors']).not_to be_nil
+        error = result['errors'].first
+        expect(error['type']).to eq 'validation'
+        expect(error['code']).to eq 'missing_param'
+        expect(error['data']['field']).to eq 'id'
+      end
     end
   end
 end


### PR DESCRIPTION
# Problem
Currently `RuntimeError`s and any other error that's not rescued results in a non-json response which leads to MP returning a useless `unexpected end of JSON` error.

# Solution
Add a `rescue_from StandardError` as a catch all option which returns `500` as http status code and returns a json error with type `internal` and code `server` with data being `message: exception.message`.

![](https://media.giphy.com/media/3o85xET02JdV8TQuwU/giphy-downsized.gif)

# Other changes
Made sure existing `rescue_from`s also return `ApplicationErrorType` with `code`, `type` and `data`.


# Example Response
```json
{
  "errors": [
    {
      "code": "server",
      "data": {
        "message": "undefined method `[]' for nil:NilClass"
      },
      "type": "internal"
    }
  ]
}

```