### PR TITLE
Fix setShipping to pickup issue

### DIFF
--- a/app/graphql/types/requested_fulfillment_union_type.rb
+++ b/app/graphql/types/requested_fulfillment_union_type.rb
@@ -14,6 +14,7 @@ end
 
 class Types::Pickup < Types::BaseObject
   field :fulfillment_type, String, null: false
+
   def fulfillment_type
     Order::PICKUP
   end

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -2,7 +2,7 @@ class OrderShippingService
   def initialize(order, fulfillment_type:, shipping:)
     @order = order
     @fulfillment_type = fulfillment_type
-    @shipping_address = Address.new(shipping)
+    @shipping_address = Address.new(shipping) if @fulfillment_type == Order::SHIP
     @buyer_name = shipping[:name]
     @buyer_phone_number = shipping[:phone_number]
   end
@@ -19,12 +19,12 @@ class OrderShippingService
           fulfillment_type: @fulfillment_type,
           buyer_phone_number: @buyer_phone_number,
           shipping_name: @buyer_name,
-          shipping_address_line1: @shipping_address.street_line1,
-          shipping_address_line2: @shipping_address.street_line2,
-          shipping_city: @shipping_address.city,
-          shipping_region: @shipping_address.region,
-          shipping_country: @shipping_address.country,
-          shipping_postal_code: @shipping_address.postal_code
+          shipping_address_line1: @shipping_address&.street_line1,
+          shipping_address_line2: @shipping_address&.street_line2,
+          shipping_city: @shipping_address&.city,
+          shipping_region: @shipping_address&.region,
+          shipping_country: @shipping_address&.country,
+          shipping_postal_code: @shipping_address&.postal_code
         )
       )
       OrderTotalUpdaterService.new(@order).update_totals!

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -35,6 +35,9 @@ describe Api::GraphqlController, type: :request do
                     ... on Ship {
                       addressLine1
                     }
+                    ... on Pickup {
+                      fulfillmentType
+                    }
                   }
                   buyer {
                     ... on Partner {
@@ -60,21 +63,24 @@ describe Api::GraphqlController, type: :request do
         }
       GRAPHQL
     end
+    let(:shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: shipping_country,
+        city: 'Tehran',
+        region: shipping_region,
+        postalCode: shipping_postal_code,
+        phoneNumber: phone_number,
+        addressLine1: 'Vanak',
+        addressLine2: 'P 80'
+      }
+    end
     let(:set_shipping_input) do
       {
         input: {
           id: order.id.to_s,
           fulfillmentType: fulfillment_type,
-          shipping: {
-            name: 'Fname Lname',
-            country: shipping_country,
-            city: 'Tehran',
-            region: shipping_region,
-            postalCode: shipping_postal_code,
-            phoneNumber: phone_number,
-            addressLine1: 'Vanak',
-            addressLine2: 'P 80'
-          }
+          shipping: shipping_address
         }.compact
       }
     end
@@ -106,153 +112,182 @@ describe Api::GraphqlController, type: :request do
         end
       end
 
-      context 'without passing phone number' do
-        let(:phone_number) { nil }
-        it 'fails' do
-          expect do
-            client.execute(mutation, set_shipping_input)
-          end.to raise_error(/phoneNumber: Expected value to not be null/)
-        end
-      end
-
-      context 'with a shipping address with an unrecognized country' do
-        let(:shipping_country) { 'ASDF' }
-        it 'returns proper error' do
-          response = client.execute(mutation, set_shipping_input)
-          expect(response.data.set_shipping.order_or_error).to respond_to(:error)
-          expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-          expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_country'
-        end
-      end
-
-      context 'with a US-based shipping address' do
-        let(:shipping_country) { 'US' }
-        context 'without a state' do
-          let(:shipping_region) { nil }
-          it 'returns proper error' do
-            response = client.execute(mutation, set_shipping_input)
-            expect(response.data.set_shipping.order_or_error).to respond_to(:error)
-            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
-          end
-        end
-        context 'without a postal code' do
-          let(:shipping_region) { 'FL' }
-          let(:shipping_postal_code) { nil }
-          it 'returns proper error' do
-            response = client.execute(mutation, set_shipping_input)
-            expect(response.data.set_shipping.order_or_error).to respond_to(:error)
-            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_postal_code'
-          end
-        end
-      end
-
-      context 'with a Canada based shipping address' do
-        let(:shipping_country) { 'CA' }
-        context 'without a province or territory' do
-          let(:shipping_region) { nil }
-          it 'returns proper error' do
-            response = client.execute(mutation, set_shipping_input)
-            expect(response.data.set_shipping.order_or_error).to respond_to(:error)
-            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
-          end
-        end
-      end
-
-      context 'with artwork with missing location' do
-        it 'returns an error' do
-          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
-          response = client.execute(mutation, set_shipping_input)
-          expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-          expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_artwork_location'
-        end
-      end
-
-      context 'with failed artwork fetch call' do
-        it 'returns an error' do
-          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
-          response = client.execute(mutation, set_shipping_input)
-          expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-          expect(response.data.set_shipping.order_or_error.error.code).to eq 'unknown_artwork'
-        end
-      end
-
-      it 'sets shipping info and sales tax on the order' do
-        allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-        allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-        allow(GravityService).to receive(:fetch_partner).and_return(partner)
-        allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
-        response = client.execute(mutation, set_shipping_input)
-        expect(response.data.set_shipping.order_or_error.order.id).to eq order.id.to_s
-        expect(response.data.set_shipping.order_or_error.order.state).to eq 'PENDING'
-        expect(response.data.set_shipping.order_or_error).not_to respond_to(:error)
-        expect(response.data.set_shipping.order_or_error.order.requested_fulfillment.address_line1).to eq 'Vanak'
-        expect(order.reload.fulfillment_type).to eq Order::SHIP
-        expect(order.state).to eq Order::PENDING
-        expect(order.shipping_country).to eq 'IR'
-        expect(order.shipping_city).to eq 'Tehran'
-        expect(order.shipping_region).to eq 'Tehran'
-        expect(order.shipping_postal_code).to eq '02198912'
-        expect(order.buyer_phone_number).to eq '00123456789'
-        expect(order.shipping_name).to eq 'Fname Lname'
-        expect(order.shipping_address_line1).to eq 'Vanak'
-        expect(order.shipping_address_line2).to eq 'P 80'
-        expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
-        expect(line_items[0].reload.sales_tax_cents).to eq 116
-        expect(line_items[1].reload.sales_tax_cents).to eq 116
-        expect(line_items[0].reload.should_remit_sales_tax).to eq false
-        expect(line_items[1].reload.should_remit_sales_tax).to eq false
-        expect(order.tax_total_cents).to eq 232
-      end
-
-      describe '#shipping_total_cents' do
+      context 'Pickup Order' do
+        let(:shipping_address) { nil }
+        let(:fulfillment_type) { 'PICKUP' }
         before do
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
           allow(GravityService).to receive(:fetch_partner).and_return(partner)
           allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
+          @response = client.execute(mutation, set_shipping_input)
         end
-        context 'with PICKUP as fulfillment type' do
-          before do
-            expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
+        it 'sets fulfillment_type on the order' do
+          expect(@response.data.set_shipping.order_or_error.order.requested_fulfillment.__typename).to eq 'Pickup'
+          expect(@response.data.set_shipping.order_or_error.order.requested_fulfillment.fulfillment_type).to eq Order::PICKUP
+          expect(order.reload.fulfillment_type).to eq Order::PICKUP
+        end
+        it 'calculates tax' do
+          expect(line_items[0].reload.sales_tax_cents).to eq 116
+          expect(line_items[1].reload.sales_tax_cents).to eq 116
+          expect(line_items[0].reload.should_remit_sales_tax).to eq false
+          expect(line_items[1].reload.should_remit_sales_tax).to eq false
+          expect(order.reload.tax_total_cents).to eq 232
+        end
+        it 'sets shipping to 0' do
+          expect(@response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 0
+          expect(order.reload.shipping_total_cents).to eq 0
+        end
+      end
+      context 'Ship Order' do
+        context 'without passing phone number' do
+          let(:phone_number) { nil }
+          it 'fails' do
+            expect do
+              client.execute(mutation, set_shipping_input)
+            end.to raise_error(/phoneNumber: Expected value to not be null/)
           end
-          let(:fulfillment_type) { 'PICKUP' }
-          it 'sets total shipping cents to 0' do
+        end
+
+        context 'with a shipping address with an unrecognized country' do
+          let(:shipping_country) { 'ASDF' }
+          it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
-            expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 0
-            expect(order.reload.shipping_total_cents).to eq 0
+            expect(response.data.set_shipping.order_or_error).to respond_to(:error)
+            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_country'
           end
         end
-        context 'with SHIP as fulfillment type' do
+
+        context 'with a US-based shipping address' do
+          let(:shipping_country) { 'US' }
+          context 'without a state' do
+            let(:shipping_region) { nil }
+            it 'returns proper error' do
+              response = client.execute(mutation, set_shipping_input)
+              expect(response.data.set_shipping.order_or_error).to respond_to(:error)
+              expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+              expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
+            end
+          end
+          context 'without a postal code' do
+            let(:shipping_region) { 'FL' }
+            let(:shipping_postal_code) { nil }
+            it 'returns proper error' do
+              response = client.execute(mutation, set_shipping_input)
+              expect(response.data.set_shipping.order_or_error).to respond_to(:error)
+              expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+              expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_postal_code'
+            end
+          end
+        end
+
+        context 'with a Canada based shipping address' do
+          let(:shipping_country) { 'CA' }
+          context 'without a province or territory' do
+            let(:shipping_region) { nil }
+            it 'returns proper error' do
+              response = client.execute(mutation, set_shipping_input)
+              expect(response.data.set_shipping.order_or_error).to respond_to(:error)
+              expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+              expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
+            end
+          end
+        end
+
+        context 'with artwork with missing location' do
+          it 'returns an error' do
+            allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
+            response = client.execute(mutation, set_shipping_input)
+            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_artwork_location'
+          end
+        end
+
+        context 'with failed artwork fetch call' do
+          it 'returns an error' do
+            allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
+            response = client.execute(mutation, set_shipping_input)
+            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_shipping.order_or_error.error.code).to eq 'unknown_artwork'
+          end
+        end
+
+        it 'sets shipping info and sales tax on the order' do
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+          allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
+          allow(GravityService).to receive(:fetch_partner).and_return(partner)
+          allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
+          response = client.execute(mutation, set_shipping_input)
+          expect(response.data.set_shipping.order_or_error.order.id).to eq order.id.to_s
+          expect(response.data.set_shipping.order_or_error.order.state).to eq 'PENDING'
+          expect(response.data.set_shipping.order_or_error).not_to respond_to(:error)
+          expect(response.data.set_shipping.order_or_error.order.requested_fulfillment.address_line1).to eq 'Vanak'
+          expect(order.reload.fulfillment_type).to eq Order::SHIP
+          expect(order.state).to eq Order::PENDING
+          expect(order.shipping_country).to eq 'IR'
+          expect(order.shipping_city).to eq 'Tehran'
+          expect(order.shipping_region).to eq 'Tehran'
+          expect(order.shipping_postal_code).to eq '02198912'
+          expect(order.buyer_phone_number).to eq '00123456789'
+          expect(order.shipping_name).to eq 'Fname Lname'
+          expect(order.shipping_address_line1).to eq 'Vanak'
+          expect(order.shipping_address_line2).to eq 'P 80'
+          expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+          expect(line_items[0].reload.sales_tax_cents).to eq 116
+          expect(line_items[1].reload.sales_tax_cents).to eq 116
+          expect(line_items[0].reload.should_remit_sales_tax).to eq false
+          expect(line_items[1].reload.should_remit_sales_tax).to eq false
+          expect(order.tax_total_cents).to eq 232
+        end
+
+        describe '#shipping_total_cents' do
           before do
-            expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-1').and_return(artwork1)
-            expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-2').and_return(artwork2)
+            allow(GravityService).to receive(:fetch_partner).and_return(partner)
+            allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
           end
-          context 'with international shipping' do
-            it 'sets total shipping cents properly' do
+          context 'with PICKUP as fulfillment type' do
+            before do
+              expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+              expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
+            end
+            let(:fulfillment_type) { 'PICKUP' }
+            it 'sets total shipping cents to 0' do
               response = client.execute(mutation, set_shipping_input)
-              expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 800_00
-              expect(order.reload.shipping_total_cents).to eq 800_00
+              expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 0
+              expect(order.reload.shipping_total_cents).to eq 0
             end
           end
-
-          context 'with domestic shipping' do
-            let(:shipping_country) { 'US' }
-            let(:shipping_region) { 'NY' }
-            it 'sets total shipping cents properly' do
-              response = client.execute(mutation, set_shipping_input)
-              expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 600_00
-              expect(order.reload.shipping_total_cents).to eq 600_00
+          context 'with SHIP as fulfillment type' do
+            before do
+              expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-1').and_return(artwork1)
+              expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-2').and_return(artwork2)
             end
-          end
+            context 'with international shipping' do
+              it 'sets total shipping cents properly' do
+                response = client.execute(mutation, set_shipping_input)
+                expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 800_00
+                expect(order.reload.shipping_total_cents).to eq 800_00
+              end
+            end
 
-          context 'with one free shipping artwork' do
-            let(:artwork1) { gravity_v1_artwork(_id: 'a-1', domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 0) }
-            it 'sets total shipping cents only based on non-free shipping artwork' do
-              response = client.execute(mutation, set_shipping_input)
-              expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 500_00
-              expect(order.reload.shipping_total_cents).to eq 500_00
+            context 'with domestic shipping' do
+              let(:shipping_country) { 'US' }
+              let(:shipping_region) { 'NY' }
+              it 'sets total shipping cents properly' do
+                response = client.execute(mutation, set_shipping_input)
+                expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 600_00
+                expect(order.reload.shipping_total_cents).to eq 600_00
+              end
+            end
+
+            context 'with one free shipping artwork' do
+              let(:artwork1) { gravity_v1_artwork(_id: 'a-1', domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 0) }
+              it 'sets total shipping cents only based on non-free shipping artwork' do
+                response = client.execute(mutation, set_shipping_input)
+                expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 500_00
+                expect(order.reload.shipping_total_cents).to eq 500_00
+              end
             end
           end
         end


### PR DESCRIPTION
# Problem
Currently setting order requested fulfillment to Pickup on staging fails with address validation. Follow up on #175 

# Cause
We are validating `shipping` input even if type is pickup, clients are currently sending `region: ''` and that fails checking region requirements.

# Solution
Don't set/validate shipping address for pickup orders.