### PR TITLE
Mo error handling less problems

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -13,6 +13,10 @@ module ErrorHandler
         render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
+      rescue_from ActiveRecord::RecordInvalid do |exception|
+        render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :invalid_order, data: { message: exception.message })] }
+      end
+
       rescue_from Errors::AuthError do |exception|
         render json: { errors: [Types::ApplicationErrorType.from_application(exception)] }, status: :unauthorized
       end

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -2,7 +2,7 @@ module ErrorHandler
   def self.included(clazz)
     clazz.class_eval do
       rescue_from StandardError do |exception|
-        render json: { errors: [Types::ApplicationErrorType.from_generic_exception(exception)] }, status: :internal_server_error
+        render json: { errors: [Types::ApplicationErrorType.root_level_error_from_exception(exception)] }, status: :internal_server_error
       end
 
       rescue_from ActionController::ParameterMissing do |exception|
@@ -10,19 +10,15 @@ module ErrorHandler
       end
 
       rescue_from ActiveRecord::RecordNotFound do |exception|
-        render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
-      end
-
-      rescue_from ActiveRecord::RecordInvalid do |exception|
-        render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :invalid_order, data: { message: exception.message })] }
+        render json: { errors: [Types::ApplicationErrorType.format_root_level_error(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
       rescue_from Errors::AuthError do |exception|
-        render json: { errors: [Types::ApplicationErrorType.from_application(exception)] }, status: :unauthorized
+        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :unauthorized
       end
 
       rescue_from ::Errors::ValidationError do |exception|
-        render json: { errors: [Types::ApplicationErrorType.from_application(exception)] }, status: :bad_request
+        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :bad_request
       end
     end
   end

--- a/app/controllers/errors/application_error.rb
+++ b/app/controllers/errors/application_error.rb
@@ -2,6 +2,7 @@ module Errors
   class ApplicationError < StandardError
     attr_reader :type, :code, :data
     def initialize(type, code, data = nil)
+      raise "Invalid type: #{type} or #{code}. Make sure to add/reuse codes in error_types.rb" unless ERROR_TYPES[type].include?(code)
       @type = type
       @code = code
       @data = data

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -15,6 +15,7 @@ module Errors
       invalid_state
       invalid_order
       missing_artwork_location
+      missing_partner_location
       missing_commission_rate
       missing_country
       missing_currency
@@ -33,7 +34,7 @@ module Errors
     ],
     processing: %i[
       capture_failed
-      failed_charge_authorization
+      charge_authorization_failed
       insufficient_inventory
       refund_failed
     ],

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -13,6 +13,7 @@ module Errors
       invalid_commission_rate
       invalid_seller_address
       invalid_state
+      invalid_order
       missing_artwork_location
       missing_commission_rate
       missing_country

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -1,0 +1,44 @@
+module Errors
+  ERROR_TYPES = {
+    auth: %i[
+      not_found
+    ],
+    validation: %i[
+      credit_card_deactivated
+      credit_card_missing_customer
+      credit_card_missing_external_id
+      credit_card_not_found
+      failed_order_code_generation
+      invalid_artwork_address
+      invalid_commission_rate
+      invalid_seller_address
+      invalid_state
+      missing_artwork_location
+      missing_commission_rate
+      missing_country
+      missing_currency
+      missing_domestic_shipping_fee
+      missing_international_shipping_fee
+      missing_merchant_account
+      missing_params
+      missing_postal_code
+      missing_price
+      missing_region
+      missing_required_info
+      not_found
+      unknown_artwork
+      unknown_edition_set
+      unknown_partner
+    ],
+    processing: %i[
+      capture_failed
+      failed_charge_authorization
+      insufficient_inventory
+      refund_failed
+    ],
+    internal: %i[
+      generic
+      gravity
+    ]
+  }.freeze
+end

--- a/app/controllers/errors/internal_error.rb
+++ b/app/controllers/errors/internal_error.rb
@@ -1,0 +1,7 @@
+module Errors
+  class InternalError < ApplicationError
+    def initialize(code, data = nil)
+      super(:internal, code, data)
+    end
+  end
+end

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -10,15 +10,28 @@ class Types::ApplicationErrorType < Types::BaseObject
     format_error_type(type: err.type, code: err.code, data: err.data)
   end
 
-  def self.from_generic_exception(err)
-    format_error_type(type: :internal, code: :generic, data: { message: err.message })
-  end
-
   def self.format_error_type(type:, code:, data: nil)
     {
       code: code,
       data: data,
       type: type
+    }
+  end
+
+  def self.root_level_from_application_error(err)
+    format_root_level_error(type: err.type, code: err.code, data: err.data)
+  end
+
+  def self.root_level_error_from_exception(err)
+    format_root_level_error(type: :internal, code: :generic, data: { message: err.message }, message: err.message)
+  end
+
+  # For root level errors expect a message key and our detail data should be under extension
+  def self.format_root_level_error(type:, code:, data: nil, message: nil)
+    message ||= "type: #{type}, code: #{code}, data: #{data}"
+    {
+      message: message,
+      extensions: format_error_type(type: type, code: code, data: data)
     }
   end
 end

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -25,6 +25,8 @@ module CreateOrderService
       OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
       order
     end
+  rescue ActiveRecord::RecordInvalid => e
+    raise Errors::ValidationError.new(:invalid_order, message: e.message)
   end
 
   def self.artwork_price(external_artwork, edition_set_id: nil)

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -4,7 +4,7 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_partner, partner_id: partner_id)
   rescue Adapters::GravityError, StandardError => e
-    raise Errors::ValidationError.new(:gravity_error, message: e.message)
+    raise Errors::InternalError.new(:gravity, message: e.message)
   end
 
   def self.get_merchant_account(partner_id)
@@ -14,7 +14,7 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:missing_merchant_account, partner_id: partner_id)
   rescue Adapters::GravityError, StandardError => e
-    raise Errors::ValidationError.new(:gravity_error, message: e.message)
+    raise Errors::InternalError.new(:gravity, message: e.message)
   end
 
   def self.get_credit_card(credit_card_id)
@@ -22,7 +22,7 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:credit_card_not_found, credit_card_id: credit_card_id)
   rescue Adapters::GravityError, StandardError => e
-    raise Errors::ValidationError.new(:gravity_error, message: e.message)
+    raise Errors::InternalError.new(:gravity, message: e.message)
   end
 
   def self.get_artwork(artwork_id)
@@ -49,7 +49,7 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_artwork, line_item_id: line_item.id)
   rescue Adapters::GravityError
-    raise Errors::ValidationError.new(:insufficient_inventory, line_item_id: line_item.id)
+    raise Errors::ProcessingError.new(:insufficient_inventory, line_item_id: line_item.id)
   end
 
   def self.undeduct_inventory(line_item)
@@ -61,6 +61,6 @@ module GravityService
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_artwork, line_item_id: line_item.id)
   rescue Adapters::GravityError
-    raise Errors::ValidationError.new(:insufficient_inventory, line_item_id: line_item.id)
+    raise Errors::ProcessingError.new(:insufficient_inventory, line_item_id: line_item.id)
   end
 end

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -34,10 +34,15 @@ module GravityService
 
   def self.fetch_partner_location(partner_id)
     partner = fetch_partner(partner_id)
+    raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if partner[:billing_location_id].blank?
     location = Adapters::GravityV1.get("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
     Address.new(location.slice(:address, :address_2, :city, :state, :country, :postal_code))
   rescue Errors::AddressError
     raise Errors::ValidationError.new(:invalid_seller_address, partner_id: partner_id)
+  rescue Adapters::GravityNotFoundError
+    raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id)
+  rescue Adapters::GravityError
+    raise Errors::InternalError.new(:gravity, message: e.message)
   end
 
   def self.deduct_inventory(line_item)

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -2,7 +2,7 @@ class OrderShippingService
   def initialize(order, fulfillment_type:, shipping:)
     @order = order
     @fulfillment_type = fulfillment_type
-    @shipping_address = Address.new(shipping)
+    @shipping_address = Address.new(shipping) if @fulfillment_type == Order::SHIP
     @buyer_name = shipping[:name]
     @buyer_phone_number = shipping[:phone_number]
   end

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -19,12 +19,12 @@ class OrderShippingService
           fulfillment_type: @fulfillment_type,
           buyer_phone_number: @buyer_phone_number,
           shipping_name: @buyer_name,
-          shipping_address_line1: @shipping_address.street_line1,
-          shipping_address_line2: @shipping_address.street_line2,
-          shipping_city: @shipping_address.city,
-          shipping_region: @shipping_address.region,
-          shipping_country: @shipping_address.country,
-          shipping_postal_code: @shipping_address.postal_code
+          shipping_address_line1: @shipping_address&.street_line1,
+          shipping_address_line2: @shipping_address&.street_line2,
+          shipping_city: @shipping_address&.city,
+          shipping_region: @shipping_address&.region,
+          shipping_country: @shipping_address&.country,
+          shipping_postal_code: @shipping_address&.postal_code
         )
       )
       OrderTotalUpdaterService.new(@order).update_totals!

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -23,7 +23,7 @@ class OrderSubmitService
         deducted_inventory << li
       end
       @transaction = PaymentService.authorize_charge(construct_charge_params)
-      raise Errors::ProcessingError.new(:failed_charge_authorization, @transaction) if @transaction.failed?
+      raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
     end
     @order.update!(external_charge_id: @transaction.external_id)
     post_process!

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -39,7 +39,7 @@ class OrderSubmitService
   private
 
   def pre_process!
-    raise Errors::ValidationError, :missing_info unless can_submit?
+    raise Errors::ValidationError, :missing_required_info unless can_submit?
     @credit_card = GravityService.get_credit_card(@order.credit_card_id)
     assert_credit_card!
     @partner = GravityService.fetch_partner(@order.seller_id)

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -53,9 +53,10 @@ describe Api::GraphqlController, type: :request do
         result = JSON.parse(response.body)
         expect(result['errors']).not_to be_nil
         error = result['errors'].first
-        expect(error['type']).to eq 'internal'
-        expect(error['code']).to eq 'generic'
-        expect(error['data']['message']).to eq 'something went wrong'
+        expect(error['message']).to eq 'something went wrong'
+        expect(error['extensions']['type']).to eq 'internal'
+        expect(error['extensions']['code']).to eq 'generic'
+        expect(error['extensions']['data']['message']).to eq 'something went wrong'
       end
     end
 
@@ -71,9 +72,10 @@ describe Api::GraphqlController, type: :request do
         result = JSON.parse(response.body)
         expect(result['errors']).not_to be_nil
         error = result['errors'].first
-        expect(error['type']).to eq 'validation'
-        expect(error['code']).to eq 'not_found'
-        expect(error['data']['message']).to eq 'cannot find'
+        expect(error['message']).to eq 'type: validation, code: not_found, data: {:message=>"cannot find"}'
+        expect(error['extensions']['type']).to eq 'validation'
+        expect(error['extensions']['code']).to eq 'not_found'
+        expect(error['extensions']['data']['message']).to eq 'cannot find'
       end
     end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -213,11 +213,11 @@ describe Api::GraphqlController, type: :request do
           allow(GravityService).to receive(:fetch_partner_location).and_return(partner_location)
         end
         context 'with PICKUP as fulfillment type' do
+          let(:fulfillment_type) { 'PICKUP' }
           before do
             expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
           end
-          let(:fulfillment_type) { 'PICKUP' }
           it 'sets total shipping cents to 0' do
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 0

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -101,7 +101,7 @@ describe Api::GraphqlController, type: :request do
         it 'returns error' do
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.order_or_error).not_to respond_to(:order)
-          expect(response.data.submit_order.order_or_error.error.code).to eq 'missing_info'
+          expect(response.data.submit_order.order_or_error.error.code).to eq 'missing_required_info'
           expect(response.data.submit_order.order_or_error.error.type).to eq 'validation'
           expect(order.reload.state).to eq Order::PENDING
         end
@@ -111,7 +111,7 @@ describe Api::GraphqlController, type: :request do
         it 'returns error' do
           response = client.execute(mutation, submit_order_input)
           expect(response.data.submit_order.order_or_error).not_to respond_to(:order)
-          expect(response.data.submit_order.order_or_error.error.code).to eq 'missing_info'
+          expect(response.data.submit_order.order_or_error.error.code).to eq 'missing_required_info'
           expect(response.data.submit_order.order_or_error.error.type).to eq 'validation'
           expect(order.reload.state).to eq Order::PENDING
         end

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -77,7 +77,11 @@ describe GravityService, type: :services do
 
     it 'raises an error if the partner does not have a merchant account' do
       allow(Adapters::GravityV1).to receive(:get).with('/merchant_accounts', params: { partner_id: partner_id }).and_return([])
-      expect { GravityService.get_merchant_account(partner_id) }.to raise_error(Errors::ValidationError)
+      expect { GravityService.get_merchant_account(partner_id) }.to raise_error do |error|
+        expect(error).to be_a(Errors::InternalError)
+        expect(error.type).to eq :internal
+        expect(error.code).to eq :gravity
+      end
     end
 
     context 'with failed gravity call' do

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -159,7 +159,7 @@ describe OrderSubmitService, type: :services do
           expect(OrderFollowUpJob).not_to receive(:perform_later)
           expect { service.process! }.to raise_error do |error|
             expect(error).to be_a(Errors::ProcessingError)
-            expect(error.code).to eq :failed_charge_authorization
+            expect(error.code).to eq :charge_authorization_failed
             expect(error.data[:failure_code]).to eq 'card_declined'
           end
         end


### PR DESCRIPTION
# Changes

## Errors::ERROR_TYPES
Added `Errors::ERROR_TYPES` as a Hash with keys being all current possible error `types` and each type has a list of possible `codes` for that type. On creating `ApplicationError` we check if type and code are valid. This way `Errors::ErrorTypes` should be our source of truth for all current errors.

## Root Level Errors
In this PR we also updated root level errors to match [GraphQL specs](http://facebook.github.io/graphql/June2018/#example-fce18) where we are required to provide a `message` and we can add our own specific fields under `extensions`.

## Errors::InternalError
Used `Errors::InternalError` for things like Gravity's generic errors.