### PR TITLE
Sort by state updated at

### DIFF
--- a/app/graphql/types/order_connection_sort_enum.rb
+++ b/app/graphql/types/order_connection_sort_enum.rb
@@ -2,6 +2,8 @@ class Types::OrderConnectionSortEnum < Types::BaseEnum
   description 'Fields to sort by'
   graphql_name 'OrderConnectionSortEnum'
 
-  value 'UPDATED_AT_ASC', 'Sort by latest timestamp order was updated in ascending order'
-  value 'UPDATED_AT_DESC', 'Sort by latest timestamp order was updated in descending order'
+  value 'UPDATED_AT_ASC', 'Sort by timestamp order was last updated in ascending order'
+  value 'UPDATED_AT_DESC', 'Sort by timestamp order was last updated in descending order'
+  value 'STATE_UPDATED_AT_ASC', 'Sort by timestamp state of order was last updated in ascending order'
+  value 'STATE_UPDATED_AT_DESC', 'Sort by timestamp state of order was last updated in descending order'
 end

--- a/app/graphql/types/order_connection_sort_enum.rb
+++ b/app/graphql/types/order_connection_sort_enum.rb
@@ -2,8 +2,8 @@ class Types::OrderConnectionSortEnum < Types::BaseEnum
   description 'Fields to sort by'
   graphql_name 'OrderConnectionSortEnum'
 
-  value 'UPDATED_AT_ASC', 'Sort by timestamp order was last updated in ascending order'
-  value 'UPDATED_AT_DESC', 'Sort by timestamp order was last updated in descending order'
-  value 'STATE_UPDATED_AT_ASC', 'Sort by timestamp state of order was last updated in ascending order'
-  value 'STATE_UPDATED_AT_DESC', 'Sort by timestamp state of order was last updated in descending order'
+  value 'UPDATED_AT_ASC', 'Sort by the timestamp the order was last updated in ascending order'
+  value 'UPDATED_AT_DESC', 'Sort by the timestamp the order was last updated in descending order'
+  value 'STATE_UPDATED_AT_ASC', 'Sort by the timestamp the state of order was last updated in ascending order'
+  value 'STATE_UPDATED_AT_DESC', 'Sort by the timestamp the state of order was last updated in descending order'
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,6 +33,10 @@ class Types::QueryType < Types::BaseObject
       query.order(updated_at: :asc)
     when 'UPDATED_AT_DESC'
       query.order(updated_at: :desc)
+    when 'STATE_UPDATED_AT_ASC'
+      query.order(state_updated_at: :asc)
+    when 'STATE_UPDATED_AT_DESC'
+      query.order(state_updated_at: :desc)
     else
       query
     end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -94,6 +94,20 @@ describe Api::GraphqlController, type: :request do
         ids = ids_from_result_data(result)
         expect(ids).to eq([user1_order2.id, user1_order1.id])
       end
+
+      it 'sorts by state_updated_at in ascending order' do
+        user1_order1.update!(state_updated_at: Time.now)
+        result = client.execute(query, buyerId: user_id, sort: 'STATE_UPDATED_AT_ASC')
+        ids = ids_from_result_data(result)
+        expect(ids).to eq([user1_order2.id, user1_order1.id])
+      end
+
+      it 'sorts by state_updated_at in descending order' do
+        user1_order1.update!(state_updated_at: Time.now)
+        result = client.execute(query, buyerId: user_id, sort: 'STATE_UPDATED_AT_DESC')
+        ids = ids_from_result_data(result)
+        expect(ids).to eq([user1_order1.id, user1_order2.id])
+      end
     end
 
     context 'trusted user rules' do


### PR DESCRIPTION
This PR adds the ability to sort the orders list by the `state_updated_at` timestamp. I started by adding it to the `Types::OrderConnectionSortEnum` and getting a red test. From there I added the code to get back to green which was just adding to the case statement that I found in `Types::QueryType#orders`, but it occurred to me that with a little extract method, I'd be able to support future sorting options that follow the format of `[attribute_name]_[direction]` so I did that with a894e3e. Along the way I also did some work on making the specs a little more consistent by extracting a helper to work with ids in the response data so that comparing them to the ids of fabricated data is easier.

I'm not sure if this is enough - I guess I need to update the schema and propagate that change to MP? Not really sure how to do that so I'd love some direction on that front! ❤️ 