### PR TITLE
More CreateOrder errors Raise error

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -8,7 +8,6 @@ module Errors
       credit_card_missing_customer
       credit_card_missing_external_id
       credit_card_not_found
-      disabled_ecommerce
       failed_order_code_generation
       invalid_artwork_address
       invalid_commission_rate
@@ -28,6 +27,7 @@ module Errors
       missing_price
       missing_region
       missing_required_info
+      not_acquireable
       not_found
       unknown_artwork
       unknown_edition_set

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -8,14 +8,14 @@ module Errors
       credit_card_missing_customer
       credit_card_missing_external_id
       credit_card_not_found
+      disabled_ecommerce
       failed_order_code_generation
       invalid_artwork_address
       invalid_commission_rate
+      invalid_order
       invalid_seller_address
       invalid_state
-      invalid_order
       missing_artwork_location
-      missing_partner_location
       missing_commission_rate
       missing_country
       missing_currency
@@ -23,6 +23,7 @@ module Errors
       missing_international_shipping_fee
       missing_merchant_account
       missing_params
+      missing_partner_location
       missing_postal_code
       missing_price
       missing_region
@@ -31,6 +32,7 @@ module Errors
       unknown_artwork
       unknown_edition_set
       unknown_partner
+      unpublished_artwork
     ],
     processing: %i[
       capture_failed

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -2,6 +2,8 @@ module CreateOrderService
   def self.with_artwork!(user_id:, artwork_id:, edition_set_id: nil, quantity:)
     artwork = GravityService.get_artwork(artwork_id)
     raise Errors::ValidationError.new(:unknown_artwork, artwork_id: artwork_id) if artwork.nil? || (edition_set_id && !find_edition_set(artwork, edition_set_id))
+    raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: artwork_id) unless artwork[:published]
+    raise Errors::ValidationError.new(:disabled_ecommerce, artwork_id: artwork_id) unless artwork[:ecommerce]
 
     Order.transaction do
       order = Order.create!(

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -3,7 +3,7 @@ module CreateOrderService
     artwork = GravityService.get_artwork(artwork_id)
     raise Errors::ValidationError.new(:unknown_artwork, artwork_id: artwork_id) if artwork.nil? || (edition_set_id && !find_edition_set(artwork, edition_set_id))
     raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: artwork_id) unless artwork[:published]
-    raise Errors::ValidationError.new(:disabled_ecommerce, artwork_id: artwork_id) unless artwork[:ecommerce]
+    raise Errors::ValidationError.new(:disabled_ecommerce, artwork_id: artwork_id) unless artwork[:acquireable]
 
     Order.transaction do
       order = Order.create!(

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -3,7 +3,7 @@ module CreateOrderService
     artwork = GravityService.get_artwork(artwork_id)
     raise Errors::ValidationError.new(:unknown_artwork, artwork_id: artwork_id) if artwork.nil? || (edition_set_id && !find_edition_set(artwork, edition_set_id))
     raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: artwork_id) unless artwork[:published]
-    raise Errors::ValidationError.new(:disabled_ecommerce, artwork_id: artwork_id) unless artwork[:acquireable]
+    raise Errors::ValidationError.new(:not_acquireable, artwork_id: artwork_id) unless artwork[:acquireable]
 
     Order.transaction do
       order = Order.create!(

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -86,7 +86,7 @@ describe CreateOrderService, type: :services do
       it 'raises error' do
         expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
           expect(error).to be_a(Errors::ValidationError)
-          expect(error.code).to eq :disabled_ecommerce
+          expect(error.code).to eq :not_acquireable
           expect(error.type).to eq :validation
         end
       end

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -81,7 +81,7 @@ describe CreateOrderService, type: :services do
     end
     context 'with disabled ecommerce artwork' do
       before do
-        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(ecommerce: false))
+        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(acquireable: false))
       end
       it 'raises error' do
         expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -67,6 +67,30 @@ describe CreateOrderService, type: :services do
         end
       end
     end
+    context 'with unpublished artwork' do
+      before do
+        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(published: false))
+      end
+      it 'raises error' do
+        expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ValidationError)
+          expect(error.code).to eq :unpublished_artwork
+          expect(error.type).to eq :validation
+        end
+      end
+    end
+    context 'with disabled ecommerce artwork' do
+      before do
+        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(ecommerce: false))
+      end
+      it 'raises error' do
+        expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ValidationError)
+          expect(error.code).to eq :disabled_ecommerce
+          expect(error.type).to eq :validation
+        end
+      end
+    end
   end
 
   describe '#artwork_price' do

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -153,7 +153,7 @@ def gravity_v1_artwork(options={})
     feature_eligible: false,
     price_currency: 'USD',
     inquireable: true,
-    acquireable: false,
+    acquireable: true,
     published_at: '2015-01-08T19:29:54+00:00',
     deleted_at: nil,
     publisher: nil,

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -132,7 +132,7 @@ def gravity_v1_artwork(options={})
     series: '',
     availability: 'for sale',
     availability_hidden: false,
-    ecommerce: nil,
+    ecommerce: true,
     tags: [],
     width: '30 1/2',
     height: '44',


### PR DESCRIPTION
# Change
Make sure we raise error when artwork was:
- unpublished
- disabled for ecommerce

Updated https://www.notion.so/artsy/Error-and-failure-states-for-Orders-b3dfcdef33bc4f2b9a1f912568cb3c8e with the changes