### PR TITLE
Use Address object in RecordSalesTaxJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,7 @@ Style/AsciiComments:
 
 Style/NumericLiterals:
   Enabled: false
+
+Lint/UselessComparison:
+  Exclude:
+    - 'spec/lib/address_spec.rb'

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -4,13 +4,14 @@ class RecordSalesTaxJob < ApplicationJob
   def perform(line_item_id)
     line_item = LineItem.find(line_item_id)
     artwork = GravityService.get_artwork(line_item.artwork_id)
-    shipping = {
+    artwork_address = Address.new(artwork[:location])
+    shipping_address = Address.new(
       country: line_item.order.shipping_country,
       postal_code: line_item.order.shipping_postal_code,
       region: line_item.order.shipping_region,
       city: line_item.order.shipping_city,
       address_line1: line_item.order.shipping_address_line1
-    }
-    SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping, line_item.order.shipping_total_cents, artwork[:location]).record_tax_collected
+    )
+    SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address).record_tax_collected
   end
 end

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -12,6 +12,15 @@ class Address
     @postal_code = @address[:postal_code]
   end
 
+  def ==(other)
+    @country == other.country && \
+      @region == other.region && \
+      @city == other.city && \
+      @street_line1 == other.street_line1 && \
+      @street_line2 == other.street_line2 && \
+      @postal_code == other.postal_code
+  end
+
   private
 
   def parse(address)

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 describe RecordSalesTaxJob, type: :job do
   let(:order) { Fabricate(:order, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
-  let(:shipping) do
-    {
+  let(:shipping_address) do
+    Address.new(
       country: order.shipping_country,
       postal_code: order.shipping_postal_code,
       region: order.shipping_region,
       city: order.shipping_city,
       address_line1: order.shipping_address_line1
-    }
+    )
   end
   let!(:line_item) { Fabricate(:line_item, order: order) }
-  let(:artwork_location) { gravity_v1_artwork[:location] }
+  let(:artwork_address) { Address.new(gravity_v1_artwork[:location]) }
   describe '#perform' do
     it 'instantiates a new SalesTaxService and calls record_tax_collected' do
       sales_tax_instance = double
-      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping, order.shipping_total_cents, artwork_location).and_return(sales_tax_instance)
+      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping_address, order.shipping_total_cents, artwork_address).and_return(sales_tax_instance)
       expect(sales_tax_instance).to receive(:record_tax_collected)
       expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
       RecordSalesTaxJob.perform_now(line_item.id)

--- a/spec/lib/address_spec.rb
+++ b/spec/lib/address_spec.rb
@@ -107,4 +107,30 @@ describe Address do
       end
     end
   end
+  describe '#==' do
+    context 'with an address that has the same address attributes' do
+      context 'with an empty address' do
+        it 'returns true' do
+          expect(Address.new({}) == Address.new({})).to be true
+        end
+      end
+      it 'returns true' do
+        expect(Address.new(address_params) == Address.new(address_params)).to be true
+      end
+    end
+    context 'with an address that does not have the same address attributes' do
+      let(:mismatched_address_params) do
+        {
+          country: 'US',
+          region: 'NY',
+          city: 'New York',
+          address_line1: 'SOMEWHERE ELSE',
+          postal_code: '10013'
+        }
+      end
+      it 'returns false' do
+        expect(Address.new(address_params) == Address.new(mismatched_address_params)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Problem
https://github.com/artsy/exchange/issues/185

### Solution
Pass an `Address` object to `SalesTaxService` in `RecordSalesTaxJob`

### What changed
- Updates `RecordSalesTaxJob` and specs to use `Address` object as required by `SalesTaxService`
- Overrides `Address.==` to consider two `Address` objects to be equal if their corresponding address attributes are equal. This was mostly done so that we can compare address objects in testing.
