### PR TITLE
Missing error type for artwork version mismatch

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -17,7 +17,7 @@ module ErrorHandler
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :unauthorized
       end
 
-      rescue_from ::Errors::ValidationError do |exception|
+      rescue_from Errors::ValidationError do |exception|
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :bad_request
       end
     end

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -35,6 +35,7 @@ module Errors
       unpublished_artwork
     ],
     processing: %i[
+      artwork_version_mismatch
       capture_failed
       charge_authorization_failed
       insufficient_inventory

--- a/app/controllers/errors/inventory_error.rb
+++ b/app/controllers/errors/inventory_error.rb
@@ -1,9 +1,0 @@
-module Errors
-  class InventoryError < ApplicationError
-    attr_reader :message, :line_item
-    def initialize(message, line_item)
-      @message = message
-      @line_item = line_item
-    end
-  end
-end


### PR DESCRIPTION
# Problem
We are getting 500 when artwork version mismatch is raised.

# Cause
We were missing `artwork_version_mismatch` code in list of `error_types`  under `processing` errors.

# Solution
Add it and also add a spec for it.