### PR TITLE
More edition set handling

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -19,6 +19,7 @@ module Errors
       missing_country
       missing_currency
       missing_domestic_shipping_fee
+      missing_edition_set_id
       missing_international_shipping_fee
       missing_merchant_account
       missing_params

--- a/app/graphql/mutations/create_order_with_artwork.rb
+++ b/app/graphql/mutations/create_order_with_artwork.rb
@@ -8,8 +8,10 @@ class Mutations::CreateOrderWithArtwork < Mutations::BaseMutation
   field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
   def resolve(artwork_id:, edition_set_id: nil, quantity: 1)
+    service = CreateOrderService.new(user_id: context[:current_user][:id], artwork_id: artwork_id, edition_set_id: edition_set_id, quantity: quantity)
+    service.process!
     {
-      order_or_error: { order: CreateOrderService.with_artwork!(user_id: context[:current_user][:id], artwork_id: artwork_id, edition_set_id: edition_set_id, quantity: quantity) }
+      order_or_error: { order: service.order }
     }
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -45,6 +45,7 @@ class CreateOrderService
     raise Errors::ValidationError.new(:unknown_artwork, artwork_id: @artwork_id) if @artwork.nil?
     raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: @artwork_id) unless @artwork[:published]
     raise Errors::ValidationError.new(:not_acquireable, artwork_id: @artwork_id) unless @artwork[:acquireable]
+
     find_verify_edition_set
   end
 
@@ -53,7 +54,7 @@ class CreateOrderService
   end
 
   def artwork_price
-    item = @edition_set.present? ? @edition_set : @artwork
+    item = @edition_set.presence || @artwork
     raise Errors::ValidationError, :missing_price unless item[:price_listed]&.positive?
 
     raise Errors::ValidationError, :missing_currency if item[:price_currency].blank?
@@ -73,7 +74,8 @@ class CreateOrderService
       # if there is one we are going to assume thats the one buyer meant to buy
       # TODO: ☝ is a temporary logic till Eigen starts supporting editionset artworks
       return unless @artwork[:edition_sets]&.count
-      raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork[:id]) if @artwork[:edition_sets]&.count > 1
+      raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork_id) if @artwork[:edition_sets].present? && @artwork[:edition_sets].count > 1
+
       @edition_set = @artwork[:edition_sets].first
       @edition_set_id = @edition_set[:id]
     end

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -73,6 +73,7 @@ class CreateOrderService
       # if there are more than one EditionSet we'll raise error
       # if there is one we are going to assume thats the one buyer meant to buy
       # TODO: ☝ is a temporary logic till Eigen starts supporting editionset artworks
+      # https://artsyproduct.atlassian.net/browse/PURCHASE-505
       return unless @artwork[:edition_sets]&.count
       raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork_id) if @artwork[:edition_sets].count > 1
 

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -74,7 +74,7 @@ class CreateOrderService
       # if there is one we are going to assume thats the one buyer meant to buy
       # TODO: ☝ is a temporary logic till Eigen starts supporting editionset artworks
       return unless @artwork[:edition_sets]&.count
-      raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork_id) if @artwork[:edition_sets].present? && @artwork[:edition_sets].count > 1
+      raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork_id) if @artwork[:edition_sets].count > 1
 
       @edition_set = @artwork[:edition_sets].first
       @edition_set_id = @edition_set[:id]

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -129,24 +129,24 @@ describe Api::GraphqlController, type: :request do
               sold: false,
               price: '$4200',
               price_listed: 4200.42,
-              price_currency: "USD",
+              price_currency: 'USD',
               acquireable: false,
-              dimensions: {in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm'},
+              dimensions: { in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm' },
               editions: 'Edition of 15',
               display_price_currency: 'USD (United States Dollar)',
-              availability: 'for sale',
-            },{
+              availability: 'for sale'
+            }, {
               id: 'edition-set-id2',
               forsale: true,
               sold: false,
               price: '$4400',
               price_listed: 4200.42,
-              price_currency: "USD",
+              price_currency: 'USD',
               acquireable: false,
-              dimensions: {in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm'},
+              dimensions: { in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm' },
               editions: 'Edition of 15',
               display_price_currency: 'USD (United States Dollar)',
-              availability: 'for sale',
+              availability: 'for sale'
             }]
           end
           let(:artwork) { gravity_v1_artwork(edition_sets: edition_sets) }
@@ -154,7 +154,7 @@ describe Api::GraphqlController, type: :request do
           context 'without setting edition_set_id' do
             it 'raises error' do
               expect do
-                response = client.execute(mutation, input: mutation_input.except(:editionSetId))
+                client.execute(mutation, input: mutation_input.except(:editionSetId))
               end.to change(Order, :count).by(0).and change(LineItem, :count).by(0)
             end
           end

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -77,10 +77,110 @@ describe Api::GraphqlController, type: :request do
       end
 
       context 'with successful artwork fetch' do
+        let(:artwork) { gravity_v1_artwork }
         before do
-          expect(GravityService).to receive(:get_artwork).with(artwork_id).and_return(gravity_v1_artwork)
+          expect(GravityService).to receive(:get_artwork).with(artwork_id).and_return(artwork)
         end
-        context 'without editionSetId' do
+        context 'artwork with one edition set' do
+          context 'without passing edition_set_id' do
+            it 'uses artworks edition set' do
+              expect do
+                response = client.execute(mutation, input: mutation_input.except(:editionSetId))
+                expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
+                order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
+                expect(order.currency_code).to eq 'USD'
+                expect(order.buyer_id).to eq jwt_user_id
+                expect(order.seller_id).to eq partner_id
+                expect(order.line_items.count).to eq 1
+                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+                expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+                expect(order.line_items.first.quantity).to eq 2
+              end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+            end
+          end
+          context 'with passing edition set id' do
+            it 'creates order with edition_set price' do
+              expect do
+                response = client.execute(mutation, input: mutation_input)
+                expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
+
+                order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
+                expect(order.currency_code).to eq 'USD'
+                expect(order.buyer_id).to eq jwt_user_id
+                expect(order.seller_id).to eq partner_id
+                expect(order.line_items.count).to eq 1
+                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+                expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+                expect(order.line_items.first.quantity).to eq 2
+              end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+            end
+          end
+        end
+
+        context 'artwork with more than one edition set' do
+          let(:edition_sets) do
+            [{
+              id: 'edition-set-id',
+              forsale: true,
+              sold: false,
+              price: '$4200',
+              price_listed: 4200.42,
+              price_currency: "USD",
+              acquireable: false,
+              dimensions: {in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm'},
+              editions: 'Edition of 15',
+              display_price_currency: 'USD (United States Dollar)',
+              availability: 'for sale',
+            },{
+              id: 'edition-set-id2',
+              forsale: true,
+              sold: false,
+              price: '$4400',
+              price_listed: 4200.42,
+              price_currency: "USD",
+              acquireable: false,
+              dimensions: {in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm'},
+              editions: 'Edition of 15',
+              display_price_currency: 'USD (United States Dollar)',
+              availability: 'for sale',
+            }]
+          end
+          let(:artwork) { gravity_v1_artwork(edition_sets: edition_sets) }
+
+          context 'without setting edition_set_id' do
+            it 'raises error' do
+              expect do
+                response = client.execute(mutation, input: mutation_input.except(:editionSetId))
+              end.to change(Order, :count).by(0).and change(LineItem, :count).by(0)
+            end
+          end
+          context 'with editionSetId' do
+            it 'creates order with edition_set price' do
+              expect do
+                response = client.execute(mutation, input: mutation_input)
+                expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
+
+                order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
+                expect(order.currency_code).to eq 'USD'
+                expect(order.buyer_id).to eq jwt_user_id
+                expect(order.seller_id).to eq partner_id
+                expect(order.line_items.count).to eq 1
+                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+                expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+                expect(order.line_items.first.quantity).to eq 2
+              end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+            end
+          end
+        end
+
+        context 'artwork without edition set' do
+          let(:artwork) { gravity_v1_artwork(edition_sets: nil) }
           it 'creates order with artwork price' do
             expect do
               response = client.execute(mutation, input: mutation_input.except(:editionSetId))
@@ -97,68 +197,46 @@ describe Api::GraphqlController, type: :request do
               expect(order.line_items.first.quantity).to eq 2
             end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
           end
-        end
+          context 'without quantity' do
+            it 'defaults to 1' do
+              expect do
+                response = client.execute(mutation, input: { artworkId: artwork_id })
+                expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
 
-        context 'with editionSetId' do
-          it 'creates order with edition_set price' do
-            expect do
-              response = client.execute(mutation, input: mutation_input)
-              expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
-              expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
-
-              order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
-              expect(order.currency_code).to eq 'USD'
-              expect(order.buyer_id).to eq jwt_user_id
-              expect(order.seller_id).to eq partner_id
-              expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
-              expect(order.line_items.first.artwork_id).to eq 'artwork-id'
-              expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
-              expect(order.line_items.first.quantity).to eq 2
-            end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+                order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
+                expect(order.currency_code).to eq 'USD'
+                expect(order.buyer_id).to eq jwt_user_id
+                expect(order.seller_id).to eq partner_id
+                expect(order.line_items.count).to eq 1
+                expect(order.line_items.first.price_cents).to eq 5400_12
+                expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+                expect(order.line_items.first.edition_set_id).to be_nil
+                expect(order.line_items.first.quantity).to eq 1
+              end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+            end
           end
-        end
-
-        context 'without quantity' do
-          it 'defaults to 1' do
-            expect do
-              response = client.execute(mutation, input: { artworkId: artwork_id })
-              expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
-              expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
-
-              order = Order.find(response.data.create_order_with_artwork.order_or_error.order.id)
-              expect(order.currency_code).to eq 'USD'
-              expect(order.buyer_id).to eq jwt_user_id
-              expect(order.seller_id).to eq partner_id
-              expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 5400_12
-              expect(order.line_items.first.artwork_id).to eq 'artwork-id'
-              expect(order.line_items.first.edition_set_id).to be_nil
-              expect(order.line_items.first.quantity).to eq 1
-            end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
-          end
-        end
-
-        context 'with existing pending order for artwork' do
-          let!(:order) do
-            order = Fabricate(:order, buyer_id: jwt_user_id, state: Order::PENDING)
-            order.line_items = [Fabricate(:line_item, artwork_id: artwork_id)]
-            order
-          end
-          it 'creates a new order' do
-            expect do
-              response = client.execute(mutation, input: mutation_input)
-              expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
-              expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
-              expect(order.reload.state).to eq Order::PENDING
-            end.to change(Order, :count).by(1)
+          context 'with existing pending order for artwork' do
+            let!(:order) do
+              order = Fabricate(:order, buyer_id: jwt_user_id, state: Order::PENDING)
+              order.line_items = [Fabricate(:line_item, artwork_id: artwork_id)]
+              order
+            end
+            it 'creates a new order' do
+              expect do
+                response = client.execute(mutation, input: { artworkId: artwork_id })
+                expect(response.data.create_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_order_with_artwork.order_or_error).not_to respond_to(:error)
+                expect(order.reload.state).to eq Order::PENDING
+              end.to change(Order, :count).by(1)
+            end
           end
         end
       end
 
       context 'with artwork price in unsupported currency' do
         before do
-          expect(GravityService).to receive(:get_artwork).with(artwork_id).and_return(gravity_v1_artwork(price_currency: 'RIA'))
+          expect(GravityService).to receive(:get_artwork).with(artwork_id).and_return(gravity_v1_artwork(edition_sets: nil, price_currency: 'RIA'))
         end
         it 'returns error' do
           expect do

--- a/spec/controllers/api/requests/error_handling_request_spec.rb
+++ b/spec/controllers/api/requests/error_handling_request_spec.rb
@@ -43,7 +43,7 @@ describe Api::GraphqlController, type: :request do
 
     context 'StandardError' do
       before do
-        allow(CreateOrderService).to receive(:with_artwork!).and_raise('something went wrong')
+        expect_any_instance_of(CreateOrderService).to receive(:process!).and_raise('something went wrong')
         post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
       end
       it 'returns 500' do
@@ -62,7 +62,7 @@ describe Api::GraphqlController, type: :request do
 
     context 'ActiveRecord::RecordNotFound' do
       before do
-        allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActiveRecord::RecordNotFound, 'cannot find')
+        expect_any_instance_of(CreateOrderService).to receive(:process!).and_raise(ActiveRecord::RecordNotFound, 'cannot find')
         post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
       end
       it 'returns 404' do
@@ -81,7 +81,7 @@ describe Api::GraphqlController, type: :request do
 
     context 'ActionController::ParameterMissing' do
       before do
-        allow(CreateOrderService).to receive(:with_artwork!).and_raise(ActionController::ParameterMissing, 'id')
+        expect_any_instance_of(CreateOrderService).to receive(:process!).and_raise(ActionController::ParameterMissing, 'id')
         post '/api/graphql', params: { query: mutation, variables: { input: mutation_input } }, headers: auth_headers
       end
       it 'returns 400' do

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -2,16 +2,20 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe CreateOrderService, type: :services do
-  describe '#with_artwork!' do
+  describe '#process!' do
     let(:user_id) { 'user-id' }
-    context 'with known artwork' do
+    let(:artwork) { gravity_v1_artwork }
+    context 'known artwork' do
       before do
-        expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork)
+        expect(Adapters::GravityV1).to receive(:get).and_return(artwork)
       end
       context 'without edition set' do
+        let(:artwork) { gravity_v1_artwork(edition_sets: nil) }
+        let(:service) { CreateOrderService.new(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: nil, quantity: 2) }
         it 'create order with proper data' do
           expect do
-            order = CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: nil, quantity: 2)
+            service.process!
+            order = service.order
             expect(order.currency_code).to eq 'USD'
             expect(order.buyer_id).to eq user_id
             expect(order.seller_id).to eq 'gravity-partner-id'
@@ -26,32 +30,129 @@ describe CreateOrderService, type: :services do
         end
         it 'sets state_expires_at for newly pending order' do
           Timecop.freeze(Time.now.utc) do
-            order = CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: nil, quantity: 2)
+            service.process!
+            order = service.order
             expect(order.state).to eq Order::PENDING
             expect(order.state_updated_at).to eq Time.now.utc
             expect(order.state_expires_at).to eq 2.days.from_now
           end
         end
       end
-      context 'with edition set' do
-        it 'creates order with proper data' do
-          expect do
-            order = CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: 'edition-set-id', quantity: 2)
-            expect(order.currency_code).to eq 'USD'
-            expect(order.buyer_id).to eq user_id
-            expect(order.seller_id).to eq 'gravity-partner-id'
-            expect(order.line_items.count).to eq 1
-            expect(order.line_items.first.price_cents).to eq 4200_42
-            expect(order.line_items.first.artwork_id).to eq 'artwork-id'
-            expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
-            expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
-            expect(order.line_items.first.quantity).to eq 2
-            job = ActiveJob::Base.queue_adapter.enqueued_jobs.detect { |j| j[:job] == OrderFollowUpJob }
-            expect(job).to_not be_nil
-            expect(job[:at].to_i).to eq order.reload.state_expires_at.to_i
-            expect(job[:args][0]).to eq order.id
-            expect(job[:args][1]).to eq Order::PENDING
-          end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+
+      context 'artwork with one edition set' do
+        let(:artwork) { gravity_v1_artwork }
+        context 'with passing edition_set_id' do
+          let(:service) { CreateOrderService.new(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: 'edition-set-id', quantity: 2) }
+          it 'creates order' do
+            expect do
+              service.process!
+              order = service.order
+              expect(order.currency_code).to eq 'USD'
+              expect(order.buyer_id).to eq user_id
+              expect(order.seller_id).to eq 'gravity-partner-id'
+              expect(order.line_items.count).to eq 1
+              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+              expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
+              expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+              expect(order.line_items.first.quantity).to eq 2
+              job = ActiveJob::Base.queue_adapter.enqueued_jobs.detect { |j| j[:job] == OrderFollowUpJob }
+              expect(job).to_not be_nil
+              expect(job[:at].to_i).to eq order.reload.state_expires_at.to_i
+              expect(job[:args][0]).to eq order.id
+              expect(job[:args][1]).to eq Order::PENDING
+            end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+          end
+        end
+        context 'without passing edition_set_id' do
+          let(:service) { CreateOrderService.new(user_id: user_id, artwork_id: 'artwork-id', quantity: 2) }
+          it 'creates order with artworks edition set' do
+            expect do
+              service.process!
+              order = service.order
+              expect(order.currency_code).to eq 'USD'
+              expect(order.buyer_id).to eq user_id
+              expect(order.seller_id).to eq 'gravity-partner-id'
+              expect(order.line_items.count).to eq 1
+              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+              expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
+              expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+              expect(order.line_items.first.quantity).to eq 2
+              job = ActiveJob::Base.queue_adapter.enqueued_jobs.detect { |j| j[:job] == OrderFollowUpJob }
+              expect(job).to_not be_nil
+              expect(job[:at].to_i).to eq order.reload.state_expires_at.to_i
+              expect(job[:args][0]).to eq order.id
+              expect(job[:args][1]).to eq Order::PENDING
+            end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+          end
+        end
+      end
+
+      context 'artwork with multiple edition sets' do
+        let(:edition_sets) do
+          [{
+            id: 'edition-set-id',
+            forsale: true,
+            sold: false,
+            price: '$4200',
+            price_listed: 4200.42,
+            price_currency: 'USD',
+            acquireable: false,
+            dimensions: { in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm' },
+            editions: 'Edition of 15',
+            display_price_currency: 'USD (United States Dollar)',
+            availability: 'for sale'
+          }, {
+            id: 'edition-set-id2',
+            forsale: true,
+            sold: false,
+            price: '$4400',
+            price_listed: 4200.42,
+            price_currency: 'USD',
+            acquireable: false,
+            dimensions: { in: '44 × 30 1/2 in', cm: '111.8 × 77.5 cm' },
+            editions: 'Edition of 15',
+            display_price_currency: 'USD (United States Dollar)',
+            availability: 'for sale'
+          }]
+        end
+        let(:artwork) { gravity_v1_artwork(edition_sets: edition_sets) }
+        context 'without passing edition set' do
+          let(:service) { CreateOrderService.new(user_id: user_id, artwork_id: 'artwork-id', quantity: 2) }
+          it 'raises error' do
+            expect do
+              service.process!
+            end.to raise_error do |error|
+              expect(error).to be_a Errors::ValidationError
+              expect(error.type).to eq :validation
+              expect(error.code).to eq :missing_edition_set_id
+              expect(error.data).to match(artwork_id: 'artwork-id')
+            end
+          end
+        end
+        context 'with passing edition set' do
+          let(:service) { CreateOrderService.new(user_id: user_id, artwork_id: 'artwork-id', edition_set_id: 'edition-set-id', quantity: 2) }
+          it 'creates order with proper data' do
+            expect do
+              service.process!
+              order = service.order
+              expect(order.currency_code).to eq 'USD'
+              expect(order.buyer_id).to eq user_id
+              expect(order.seller_id).to eq 'gravity-partner-id'
+              expect(order.line_items.count).to eq 1
+              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.artwork_id).to eq 'artwork-id'
+              expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
+              expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
+              expect(order.line_items.first.quantity).to eq 2
+              job = ActiveJob::Base.queue_adapter.enqueued_jobs.detect { |j| j[:job] == OrderFollowUpJob }
+              expect(job).to_not be_nil
+              expect(job[:at].to_i).to eq order.reload.state_expires_at.to_i
+              expect(job[:args][0]).to eq order.id
+              expect(job[:args][1]).to eq Order::PENDING
+            end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
+          end
         end
       end
     end
@@ -60,7 +161,7 @@ describe CreateOrderService, type: :services do
         expect(Adapters::GravityV1).to receive(:get).and_raise(Adapters::GravityError.new('unknown artwork'))
       end
       it 'raises error' do
-        expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
+        expect { CreateOrderService.new(user_id: user_id, artwork_id: 'random-artwork', quantity: 2).process! }.to raise_error do |error|
           expect(error).to be_a(Errors::ValidationError)
           expect(error.code).to eq :unknown_artwork
           expect(error.type).to eq :validation
@@ -72,7 +173,7 @@ describe CreateOrderService, type: :services do
         expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(published: false))
       end
       it 'raises error' do
-        expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
+        expect { CreateOrderService.new(user_id: user_id, artwork_id: 'random-artwork', quantity: 2).process! }.to raise_error do |error|
           expect(error).to be_a(Errors::ValidationError)
           expect(error.code).to eq :unpublished_artwork
           expect(error.type).to eq :validation
@@ -84,32 +185,10 @@ describe CreateOrderService, type: :services do
         expect(Adapters::GravityV1).to receive(:get).and_return(gravity_v1_artwork(acquireable: false))
       end
       it 'raises error' do
-        expect { CreateOrderService.with_artwork!(user_id: user_id, artwork_id: 'random-artwork', quantity: 2) }.to raise_error do |error|
+        expect { CreateOrderService.new(user_id: user_id, artwork_id: 'random-artwork', quantity: 2).process! }.to raise_error do |error|
           expect(error).to be_a(Errors::ValidationError)
           expect(error.code).to eq :not_acquireable
           expect(error.type).to eq :validation
-        end
-      end
-    end
-  end
-
-  describe '#artwork_price' do
-    context 'for artwork' do
-      it 'returns artwork price' do
-        expect(CreateOrderService.artwork_price(gravity_v1_artwork)).to eq 5400_12
-      end
-    end
-    context 'for edition set' do
-      it 'returns edition_set_price for known edition set id' do
-        expect(CreateOrderService.artwork_price(gravity_v1_artwork, edition_set_id: 'edition-set-id')).to eq 4200_42
-      end
-      it 'raises error for unknown edition set id' do
-        expect do
-          CreateOrderService.artwork_price(gravity_v1_artwork, edition_set_id: 'random-id')
-        end.to raise_error do |error|
-          expect(error).to be_a Errors::ValidationError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :unknown_edition_set
         end
       end
     end


### PR DESCRIPTION
# Problem
Currently Eigen doesn't pass `edition_set_id` to `createOrderWithArtwork` mutation when there is one edition set. We need Exchange to check if artwork has only one edition set, assume that was the one that buyer meant to pick. In case there are more than one edition sets and `edition_set_id` was not passed, we now raise a new `validation` error with code `missing_edition_set_id`.

# Changes
`CreateOrderService` was getting more complicated with these changes and as part of this change we did a little refactoring there where followed our new style. We now create a new instance of `CreateOrderService` and we call `process!` on it. We also expose created `order` with `attr_reader` on that class.
New edition set logic is:
- If `edition_set_id` was passed to the service
  - we check if edition set exists on artwork we use that, otherwise we raise error
- else
  - we check if artwork has edition sets
     - if artwork has more than one edition set, we raise error since we don't know which one buyer meant to buy
     - if artwork has one edition set, we make assumption that buyer meant to buy that one 

# New Error
- type: `validation`, code: `missing_edition_set_id`, data: `artwork_id`: happens when artwork has more than one edition sets and we don't provide which one we want during order creation.


# TODO
Once Eigen starts sending edition set id in these cases we can eventually deprecate the logic above that assumes edition set.  