### PR TITLE
Refactor RecordSalesTaxJob

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -40,6 +40,7 @@ module Errors
       charge_authorization_failed
       insufficient_inventory
       refund_failed
+      tax_recording_failure
     ],
     internal: %i[
       generic

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -3,7 +3,7 @@ class RecordSalesTaxJob < ApplicationJob
 
   def perform(line_item_id)
     line_item = LineItem.find(line_item_id)
-    return unless line_item.should_remit_sales_tax
+    return unless line_item.should_remit_sales_tax?
 
     artwork = GravityService.get_artwork(line_item.artwork_id)
     artwork_address = Address.new(artwork[:location])

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -3,17 +3,12 @@ class RecordSalesTaxJob < ApplicationJob
 
   def perform(line_item_id)
     line_item = LineItem.find(line_item_id)
+    return unless line_item.should_remit_sales_tax
+
     artwork = GravityService.get_artwork(line_item.artwork_id)
     artwork_address = Address.new(artwork[:location])
-    shipping_address = Address.new(
-      country: line_item.order.shipping_country,
-      postal_code: line_item.order.shipping_postal_code,
-      region: line_item.order.shipping_region,
-      city: line_item.order.shipping_city,
-      address_line1: line_item.order.shipping_address_line1
-    )
-    service = SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address)
+    service = SalesTaxService.new(line_item, line_item.order.fulfillment_type, line_item.order.shipping_address, line_item.order.shipping_total_cents, artwork_address)
     service.record_tax_collected
-    line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id)
+    line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id) if service.transaction.present?
   end
 end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -12,7 +12,8 @@ class RecordSalesTaxJob < ApplicationJob
       city: line_item.order.shipping_city,
       address_line1: line_item.order.shipping_address_line1
     )
-    transaction = SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address).record_tax_collected
-    line_item.update!(sales_tax_transaction_id: transaction.transaction_id)
+    service = SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address)
+    service.record_tax_collected
+    line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id)
   end
 end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -12,6 +12,7 @@ class RecordSalesTaxJob < ApplicationJob
       city: line_item.order.shipping_city,
       address_line1: line_item.order.shipping_address_line1
     )
-    SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address).record_tax_collected
+    transaction = SalesTaxService.new(line_item, line_item.order.fulfillment_type, shipping_address, line_item.order.shipping_total_cents, artwork_address).record_tax_collected
+    line_item.update!(sales_tax_transaction_id: transaction.transaction_id)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -104,6 +104,19 @@ class Order < ApplicationRecord
     get_last_state_timestamp(Order::APPROVED)
   end
 
+  def shipping_address
+    return unless fulfillment_type == Order::SHIP
+
+    Address.new(
+      country: shipping_country,
+      postal_code: shipping_postal_code,
+      region: shipping_region,
+      city: shipping_city,
+      address_line1: shipping_address_line1,
+      address_line2: shipping_address_line2
+    )
+  end
+
   private
 
   def state_reason_inclusion

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,6 +1,6 @@
 class SalesTaxService
   REMITTING_STATES = %w[wa pa].freeze
-
+  attr_reader :transaction
   def initialize(
     line_item,
     fulfillment_type,
@@ -19,6 +19,7 @@ class SalesTaxService
     @artwork_location = artwork_location
     @shipping_address = shipping_address
     @shipping_total_cents = artsy_should_remit_taxes? ? shipping_total_cents : 0
+    @transaction = nil
   end
 
   def sales_tax
@@ -28,7 +29,7 @@ class SalesTaxService
   end
 
   def record_tax_collected
-    post_transaction if artsy_should_remit_taxes? && @line_item.sales_tax_cents&.positive?
+    @transaction = post_transaction if artsy_should_remit_taxes? && @line_item.sales_tax_cents&.positive?
   rescue Taxjar::Error => e
     raise Errors::ProcessingError.new(:tax_recording_failure, message: e.message)
   end

--- a/db/migrate/20180927142906_add_sales_tax_transaction_id_to_line_items.rb
+++ b/db/migrate/20180927142906_add_sales_tax_transaction_id_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddSalesTaxTransactionIdToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :sales_tax_transaction_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_19_205125) do
+ActiveRecord::Schema.define(version: 2018_09_27_142906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2018_09_19_205125) do
     t.integer "sales_tax_cents"
     t.string "artwork_version_id"
     t.boolean "should_remit_sales_tax"
+    t.string "sales_tax_transaction_id"
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -130,8 +130,8 @@ describe Api::GraphqlController, type: :request do
         it 'calculates tax' do
           expect(line_items[0].reload.sales_tax_cents).to eq 116
           expect(line_items[1].reload.sales_tax_cents).to eq 116
-          expect(line_items[0].reload.should_remit_sales_tax).to eq false
-          expect(line_items[1].reload.should_remit_sales_tax).to eq false
+          expect(line_items[0].reload.should_remit_sales_tax?).to eq false
+          expect(line_items[1].reload.should_remit_sales_tax?).to eq false
           expect(order.reload.tax_total_cents).to eq 232
         end
         it 'sets shipping to 0' do
@@ -264,8 +264,8 @@ describe Api::GraphqlController, type: :request do
           expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
           expect(line_items[0].reload.sales_tax_cents).to eq 116
           expect(line_items[1].reload.sales_tax_cents).to eq 116
-          expect(line_items[0].reload.should_remit_sales_tax).to eq false
-          expect(line_items[1].reload.should_remit_sales_tax).to eq false
+          expect(line_items[0].reload.should_remit_sales_tax?).to eq false
+          expect(line_items[1].reload.should_remit_sales_tax?).to eq false
           expect(order.tax_total_cents).to eq 232
         end
 

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -1,26 +1,27 @@
 require 'rails_helper'
+require 'support/taxjar_helper'
 
 describe RecordSalesTaxJob, type: :job do
-  let(:order) { Fabricate(:order, id: 1, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
-  let(:shipping_address) do
-    Address.new(
-      country: order.shipping_country,
-      postal_code: order.shipping_postal_code,
-      region: order.shipping_region,
-      city: order.shipping_city,
-      address_line1: order.shipping_address_line1
-    )
+  let(:order) { Fabricate(:order, fulfillment_type: Order::PICKUP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'WA', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100, state: Order::APPROVED) }
+  let!(:line_item) { Fabricate(:line_item, order: order, sales_tax_cents: 100_00) }
+  let(:artwork_location) do
+    {
+      country: 'US',
+      city: 'Seattle',
+      state: 'WA',
+      address: '22 Fake St',
+      postal_code: 10013
+    }
   end
-  let!(:line_item) { Fabricate(:line_item, id: 2, order: order) }
-  let(:artwork_address) { Address.new(gravity_v1_artwork[:location]) }
   describe '#perform' do
-    it 'instantiates a new SalesTaxService and calls record_tax_collected' do
-      sales_tax_instance = double
-      expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping_address, order.shipping_total_cents, artwork_address).and_return(sales_tax_instance)
-      expect(sales_tax_instance).to receive(:record_tax_collected).and_return(double(transaction_id: '1-2'))
-      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
+    before do
+      stub_tax_for_order
+    end
+
+    it 'posts a transaction to TaxJar and saves the transaction id' do
+      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
       RecordSalesTaxJob.perform_now(line_item.id)
-      expect(line_item.reload.sales_tax_transaction_id).to eq '1-2'
+      expect(line_item.reload.sales_tax_transaction_id).to eq '123'
     end
   end
 end

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -3,7 +3,7 @@ require 'support/taxjar_helper'
 
 describe RecordSalesTaxJob, type: :job do
   let(:order) { Fabricate(:order, fulfillment_type: Order::PICKUP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'WA', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100, state: Order::APPROVED) }
-  let!(:line_item) { Fabricate(:line_item, order: order, sales_tax_cents: 100_00) }
+  let!(:line_item) { Fabricate(:line_item, order: order, sales_tax_cents: 100_00, should_remit_sales_tax: true) }
   let(:artwork_location) do
     {
       country: 'US',
@@ -17,11 +17,23 @@ describe RecordSalesTaxJob, type: :job do
     before do
       stub_tax_for_order
     end
-
-    it 'posts a transaction to TaxJar and saves the transaction id' do
-      expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
-      RecordSalesTaxJob.perform_now(line_item.id)
-      expect(line_item.reload.sales_tax_transaction_id).to eq '123'
+    context 'with an order that has sales tax to remit' do
+      it 'posts a transaction to TaxJar and saves the transaction id' do
+        expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
+        expect(Address).to receive(:new).with(artwork_location).and_return(Address.new(artwork_location))
+        RecordSalesTaxJob.perform_now(line_item.id)
+        expect(line_item.reload.sales_tax_transaction_id).to eq '123'
+      end
+      context 'with an order that does not have sales tax to remit' do
+        before do
+          line_item.update!(should_remit_sales_tax: false)
+        end
+        it 'does nothing' do
+          expect(SalesTaxService).to_not receive(:new)
+          RecordSalesTaxJob.perform_now(line_item.id)
+          expect(line_item.reload.sales_tax_transaction_id).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe RecordSalesTaxJob, type: :job do
-  let(:order) { Fabricate(:order, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
+  let(:order) { Fabricate(:order, id: 1, fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100) }
   let(:shipping_address) do
     Address.new(
       country: order.shipping_country,
@@ -11,15 +11,16 @@ describe RecordSalesTaxJob, type: :job do
       address_line1: order.shipping_address_line1
     )
   end
-  let!(:line_item) { Fabricate(:line_item, order: order) }
+  let!(:line_item) { Fabricate(:line_item, id: 2, order: order) }
   let(:artwork_address) { Address.new(gravity_v1_artwork[:location]) }
   describe '#perform' do
     it 'instantiates a new SalesTaxService and calls record_tax_collected' do
       sales_tax_instance = double
       expect(SalesTaxService).to receive(:new).with(line_item, order.fulfillment_type, shipping_address, order.shipping_total_cents, artwork_address).and_return(sales_tax_instance)
-      expect(sales_tax_instance).to receive(:record_tax_collected)
+      expect(sales_tax_instance).to receive(:record_tax_collected).and_return(double(transaction_id: '1-2'))
       expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork)
       RecordSalesTaxJob.perform_now(line_item.id)
+      expect(line_item.reload.sales_tax_transaction_id).to eq '1-2'
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -186,4 +186,32 @@ RSpec.describe Order, type: :model do
       end
     end
   end
+
+  describe '#shipping_address' do
+    context 'with a fulfillment type of SHIP' do
+      it 'returns an address object with shipping parameters as attributes' do
+        order.update!(fulfillment_type: Order::SHIP, shipping_country: 'US', shipping_region: 'NY', shipping_postal_code: '10013', shipping_city: 'New York', shipping_address_line1: '401 Broadway')
+        expected_shipping_address = Address.new(
+          country: order.shipping_country,
+          postal_code: order.shipping_postal_code,
+          region: order.shipping_region,
+          city: order.shipping_city,
+          address_line1: order.shipping_address_line1,
+          address_line2: order.shipping_address_line2
+        )
+        expect(order.shipping_address).to eq expected_shipping_address
+      end
+    end
+    context 'with a fulfillment type of PICKUP' do
+      it 'returns nil' do
+        order.update!(fulfillment_type: Order::PICKUP)
+        expect(order.shipping_address).to be_nil
+      end
+      context 'with nil fulfillment type' do
+        it 'returns nil' do
+          expect(order.shipping_address).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -118,10 +118,11 @@ describe SalesTaxService, type: :services do
 
   describe '#record_tax_collected' do
     context 'when Artsy needs to remit taxes and line item has sales tax' do
-      it 'calls post_transaction' do
+      it 'calls post_transaction and saves the result to @transaction' do
         expect(@service_ship).to receive(:artsy_should_remit_taxes?).and_return(true)
-        expect(@service_ship).to receive(:post_transaction)
+        expect(@service_ship).to receive(:post_transaction).and_return(double(transaction_id: '123'))
         @service_ship.record_tax_collected
+        expect(@service_ship.transaction).to_not be_nil
       end
     end
     context 'when Artsy does not need to remit taxes' do

--- a/spec/support/taxjar_helper.rb
+++ b/spec/support/taxjar_helper.rb
@@ -4,6 +4,42 @@ require 'webmock/rspec'
 
 def stub_tax_for_order
   stub_request(:post, Taxjar::API::Request::DEFAULT_API_URL + '/v2/taxes').to_return(body: sales_tax_fixture.to_json, headers: { content_type: 'application/json; charset=utf-8' })
+  stub_request(:post, Taxjar::API::Request::DEFAULT_API_URL + '/v2/transactions/orders').to_return(body: order_fixture.to_json, headers: { content_type: 'application/json; charset=utf-8' })
+end
+
+def order_fixture
+  {
+    "order": {
+      "transaction_id": "123",
+      "user_id": 10649,
+      "transaction_date": "2015-05-14T00:00:00Z",
+      "from_country": "US",
+      "from_zip": "93107",
+      "from_state": "CA",
+      "from_city": "SANTA BARBARA",
+      "from_street": "1281 State St",
+      "to_country": "US",
+      "to_zip": "90002",
+      "to_state": "CA",
+      "to_city": "LOS ANGELES",
+      "to_street": "123 Palm Grove Ln",
+      "amount": "17.45",
+      "shipping": "1.5",
+      "sales_tax": "0.95",
+      "line_items": [
+        {
+          "id": "1",
+          "quantity": 1,
+          "product_identifier": "12-34243-9",
+          "description": "Fuzzy Widget",
+          "product_tax_code": "20010",
+          "unit_price": "15.0",
+          "discount": "0.0",
+          "sales_tax": "0.95"
+        }
+      ]
+    }
+  }
 end
 
 def sales_tax_fixture


### PR DESCRIPTION
### Problem
`RecordSalesTaxJob` was failing on pickup orders with unhelpful error messages.

### Solution
- Refactor `RecordSalesTaxJob` to not try to create an address for pickup orders
- Add `tax_recording_failure` code to error types
- Store the transaction ID that we get back upon creating a transaction in TaxJar so that we can reference it later

### What changed
- Adds string `sales_tax_transaction_id` to `line_items`
- Update `SalesTaxService` to store response from transaction POST request to TaxJar in `@transaction`
- Updates `line_item.sales_tax_transaction_id` after receiving transaction response from TaxJar
- Return early in `RecordSalesTaxJob` if sales tax does not need to be remitted
- Add method `shipping_address` to `Order` model that returns the shipping address wrapped in an `Address` object for shipped orders or `nil` otherwise.