### PR TITLE
Enable find Order by code

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -27,6 +27,7 @@ module Errors
       missing_price
       missing_region
       missing_required_info
+      missing_required_param
       not_acquireable
       not_found
       unknown_artwork

--- a/app/graphql/mutations/plain_mutation.rb
+++ b/app/graphql/mutations/plain_mutation.rb
@@ -1,2 +1,0 @@
-class Mutations::PlainMutation < GraphQL::Schema::Mutation
-end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,7 +4,8 @@ class Types::QueryType < Types::BaseObject
 
   field :order, Types::OrderType, null: true do
     description 'Find an order by ID'
-    argument :id, ID, required: true
+    argument :id, ID, required: false
+    argument :code, String, required: false
   end
 
   field :orders, Types::OrderConnectionWithTotalCountType, null: true, connection: true do
@@ -17,8 +18,10 @@ class Types::QueryType < Types::BaseObject
     argument :sort, Types::OrderConnectionSortEnum, required: false
   end
 
-  def order(id:)
-    order = Order.find(id)
+  def order(args)
+    raise Error::ValidationError.new(:missing_required_param, message: 'id or code is required') unless args[:id].present? || args[:code].present?
+
+    order = Order.find_by!(args)
     validate_order_request!(order)
     order
   end


### PR DESCRIPTION
# Problem

https://artsyproduct.atlassian.net/browse/PURCHASE-496
We want to be able to find orders by code.


# Solution
make `id` optional and add new `code` argument. Make sure one of them is required. 

# New Error
type: `validation`, code: `missing_required_param`, data: `message: id or code is required` 