### PR TITLE
Add `ConfirmPickup` mutation 

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -33,6 +33,7 @@ module Errors
       unknown_edition_set
       unknown_partner
       unpublished_artwork
+      wrong_fulfillment_type
     ],
     processing: %i[
       artwork_version_mismatch

--- a/app/graphql/mutations/confirm_pickup.rb
+++ b/app/graphql/mutations/confirm_pickup.rb
@@ -8,7 +8,6 @@ class Mutations::ConfirmPickup < Mutations::BaseMutation
   def resolve(id:)
     order = Order.find(id)
     validate_seller_request!(order)
-    # byebug
     OrderService.confirm_pickup!(order, context[:current_user][:id])
     {
       order_or_error: { order: order.reload }

--- a/app/graphql/mutations/confirm_pickup.rb
+++ b/app/graphql/mutations/confirm_pickup.rb
@@ -1,0 +1,19 @@
+class Mutations::ConfirmPickup < Mutations::BaseMutation
+  null true
+
+  argument :id, ID, required: true
+
+  field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
+
+  def resolve(id:)
+    order = Order.find(id)
+    validate_seller_request!(order)
+    # byebug
+    OrderService.confirm_pickup!(order, context[:current_user][:id])
+    {
+      order_or_error: { order: order.reload }
+    }
+  rescue Errors::ApplicationError => e
+    { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -6,4 +6,5 @@ class Types::MutationType < Types::BaseObject
   field :approve_order, mutation: Mutations::ApproveOrder
   field :reject_order, mutation: Mutations::RejectOrder
   field :fulfill_at_once, mutation: Mutations::FulfillAtOnce
+  field :confirm_pickup, mutation: Mutations::ConfirmPickup
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -17,6 +17,14 @@ module OrderService
     order
   end
 
+  def self.confirm_pickup!(order, by)
+    raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::PICKUP
+
+    order.fulfill!
+    PostNotificationJob.perform_later(order.id, Order::FULFILLED, by)
+    order
+  end
+
   def self.abandon!(order)
     order.abandon!
   end

--- a/spec/controllers/api/requests/confirm_pickup_request_spec.rb
+++ b/spec/controllers/api/requests/confirm_pickup_request_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'confirm_pickup mutation' do
+    include_context 'GraphQL Client'
+    let(:partner_id) { jwt_partner_ids.first }
+    let(:user_id) { jwt_user_id }
+    let(:credit_card_id) { 'cc-1' }
+    let(:order) { Fabricate(:order, seller_id: partner_id, buyer_id: user_id, fulfillment_type: Order::PICKUP) }
+
+    let(:mutation) do
+      <<-GRAPHQL
+        mutation($input: ConfirmPickupInput!) {
+          confirmPickup(input: $input) {
+            orderOrError {
+              ... on OrderWithMutationSuccess {
+                order {
+                  id
+                  state
+                  buyer {
+                    ... on Partner {
+                      id
+                    }
+                  }
+                  seller {
+                    ... on User {
+                      id
+                    }
+                  }
+                }
+              }
+              ... on OrderWithMutationFailure {
+                error {
+                  code
+                  data
+                  type
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:confirm_pickup_input) do
+      {
+        input: {
+          id: order.id.to_s
+        }
+      }
+    end
+
+    context 'with user without permission to this partner' do
+      let(:partner_id) { 'another-partner-id' }
+      it 'returns permission error' do
+        response = client.execute(mutation, confirm_pickup_input)
+        expect(response.data.confirm_pickup.order_or_error.error.type).to eq 'validation'
+        expect(response.data.confirm_pickup.order_or_error.error.code).to eq 'not_found'
+        expect(order.reload.state).to eq Order::PENDING
+      end
+    end
+
+    context 'with proper permission' do
+      Order::STATES.reject { |s| [Order::APPROVED, Order::CANCELED].include? s }.each do |state|
+        context "with order not in #{state} state" do
+          before do
+            order.update! state: state
+          end
+          it 'returns error' do
+            response = client.execute(mutation, confirm_pickup_input)
+            expect(response.data.confirm_pickup.order_or_error.error.type).to eq 'validation'
+            expect(response.data.confirm_pickup.order_or_error.error.code).to eq 'invalid_state'
+            expect(order.reload.state).to eq state
+          end
+        end
+      end
+
+      context 'order in approved state' do
+        before do
+          order.update! state: Order::APPROVED
+        end
+        context 'shipping order' do
+          before do
+            order.update! fulfillment_type: Order::SHIP
+          end
+          it 'returns error' do
+            response = client.execute(mutation, confirm_pickup_input)
+            expect(response.data.confirm_pickup.order_or_error.error.type).to eq 'validation'
+            expect(response.data.confirm_pickup.order_or_error.error.code).to eq 'wrong_fulfillment_type'
+            expect(order.reload.state).to eq Order::APPROVED
+          end
+        end
+
+        context 'pickup order' do
+          it 'approves the order' do
+            response = client.execute(mutation, confirm_pickup_input)
+            expect(response.data.confirm_pickup.order_or_error.order.id).to eq order.id.to_s
+            expect(response.data.confirm_pickup.order_or_error.order.state).to eq 'FULFILLED'
+            expect(response.data.confirm_pickup.order_or_error).not_to respond_to(:error)
+            expect(order.reload.state).to eq Order::FULFILLED
+            expect(order.state_expires_at).to be_nil
+          end
+
+          it 'queues a job for posting events' do
+            client.execute(mutation, confirm_pickup_input)
+            expect(PostNotificationJob).to have_been_enqueued
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Problem
For pickup orders sellers need to confirm the work was picked up by the buyer. `fulfillAtOnce` is very specific and works for `SHIP` orders but not for `PICKUP`.

# Solution
Added a new `ConfirmPickup` mutation which can be used only on pickup orders and all it does is it changes the order state to `fulfilled`.

```graphql
mutation($input: ConfirmPickupInput!) {
  confirmPickup(input: $input) {
    orderOrError {
      ... on OrderWithMutationSuccess {
        order {
          id
          state
          buyer {
            ... on Partner {
              id
            }
          }
          seller {
            ... on User {
              id
            }
          }
        }
      }
      ... on OrderWithMutationFailure {
        error {
          code
          data
          type
        }
      }
    }
  }
}
```

# Followup 
- [ ] Update MP
- [ ] Insomnia