### PR TITLE
chore: log error message and stacktrace

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -2,24 +2,38 @@ module ErrorHandler
   def self.included(clazz)
     clazz.class_eval do
       rescue_from StandardError do |exception|
+        capture_exception(exception)
+        log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.root_level_error_from_exception(exception)] }, status: :internal_server_error
       end
 
       rescue_from ActionController::ParameterMissing do |exception|
+        log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.format_error_type(type: :validation, code: :missing_param, data: { field: exception.param })] }, status: :bad_request
       end
 
       rescue_from ActiveRecord::RecordNotFound do |exception|
+        log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.format_root_level_error(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
       rescue_from Errors::AuthError do |exception|
+        log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :unauthorized
       end
 
       rescue_from Errors::ValidationError do |exception|
+        log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :bad_request
       end
     end
+  end
+
+  private
+
+  def log_exception(exception)
+    Rails.logger.error(exception.message)
+    trace = exception.backtrace.join("\n")
+    Rails.logger.error(trace)
   end
 end


### PR DESCRIPTION
As discussed in [this thread](https://artsy.slack.com/archives/CB110C6LE/p1538157819000100), we're adding exception logging to the `ErrorHandler` used to ensure GraphQL responses are returned.

<details>
<summary>Example logs from introducing an undefined variable and executing a request from MP</summary>

```
Started POST "/api/graphql" for 127.0.0.1 at 2018-09-28 15:15:39 -0400
   (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
  ↳ /Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/log_subscriber.rb:98
Processing by Api::GraphqlController#execute as */*
  Parameters: {"operationName"=>"createOrderWithArtwork", "variables"=>{"artworkId"=>"5bad103ff748ad00074b475a", "quantity"=>1}, "query"=>"mutation createOrderWithArtwork($artworkId: String!, $editionSetId: String, $quantity: Int) {\n  createOrderWithArtwork(input: {artworkId: $artworkId, editionSetId: $editionSetId, quantity: $quantity}) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          id\n          buyerTotalCents\n          buyerPhoneNumber\n          code\n          commissionFeeCents\n          createdAt\n          currencyCode\n          itemsTotalCents\n          seller {\n            __typename\n            ... on Partner {\n              id\n            }\n            ... on User {\n              id\n            }\n          }\n          buyer {\n            __typename\n            ... on User {\n              id\n            }\n            ... on Partner {\n              id\n            }\n          }\n          sellerTotalCents\n          requestedFulfillment {\n            __typename\n            ... on Ship {\n              name\n              addressLine1\n              addressLine2\n              city\n              region\n              country\n              postalCode\n              phoneNumber\n            }\n            ... on Pickup {\n              fulfillmentType\n            }\n          }\n          shippingTotalCents\n          state\n          stateReason\n          stateExpiresAt\n          stateUpdatedAt\n          taxTotalCents\n          transactionFeeCents\n          updatedAt\n          lastApprovedAt\n          lastSubmittedAt\n          lineItems {\n            edges {\n              node {\n                id\n                priceCents\n                artworkId\n                editionSetId\n                quantity\n              }\n            }\n          }\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n", "graphql"=>{"operationName"=>"createOrderWithArtwork", "variables"=>{"artworkId"=>"5bad103ff748ad00074b475a", "quantity"=>1}, "query"=>"mutation createOrderWithArtwork($artworkId: String!, $editionSetId: String, $quantity: Int) {\n  createOrderWithArtwork(input: {artworkId: $artworkId, editionSetId: $editionSetId, quantity: $quantity}) {\n    orderOrError {\n      __typename\n      ... on OrderWithMutationSuccess {\n        order {\n          id\n          buyerTotalCents\n          buyerPhoneNumber\n          code\n          commissionFeeCents\n          createdAt\n          currencyCode\n          itemsTotalCents\n          seller {\n            __typename\n            ... on Partner {\n              id\n            }\n            ... on User {\n              id\n            }\n          }\n          buyer {\n            __typename\n            ... on User {\n              id\n            }\n            ... on Partner {\n              id\n            }\n          }\n          sellerTotalCents\n          requestedFulfillment {\n            __typename\n            ... on Ship {\n              name\n              addressLine1\n              addressLine2\n              city\n              region\n              country\n              postalCode\n              phoneNumber\n            }\n            ... on Pickup {\n              fulfillmentType\n            }\n          }\n          shippingTotalCents\n          state\n          stateReason\n          stateExpiresAt\n          stateUpdatedAt\n          taxTotalCents\n          transactionFeeCents\n          updatedAt\n          lastApprovedAt\n          lastSubmittedAt\n          lineItems {\n            edges {\n              node {\n                id\n                priceCents\n                artworkId\n                editionSetId\n                quantity\n              }\n            }\n          }\n        }\n      }\n      ... on OrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"}}
Can't verify CSRF token authenticity.
undefined local variable or method `foobar' for CreateOrderService:Module
/Users/danielramirez/Documents/artsy/exchange/app/services/create_order_service.rb:8:in `with_artwork!'
/Users/danielramirez/Documents/artsy/exchange/app/graphql/mutations/create_order_with_artwork.rb:12:in `resolve'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/resolver.rb:89:in `public_send'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/resolver.rb:89:in `block (3 levels) in resolve_with_support'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:1013:in `after_lazy'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/resolver.rb:77:in `block (2 levels) in resolve_with_support'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:1013:in `after_lazy'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/resolver.rb:70:in `block in resolve_with_support'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:1013:in `after_lazy'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/resolver.rb:59:in `resolve_with_support'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/relay_classic_mutation.rb:33:in `resolve_with_support'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/field.rb:453:in `public_send'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/field.rb:453:in `public_send_field'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/field.rb:349:in `block in resolve_field'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:1013:in `after_lazy'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/field.rb:338:in `resolve_field'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/relay/mutation/resolve.rb:19:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/relay/mutation/resolve.rb:19:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/member/instrumentation.rb:74:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/field.rb:248:in `resolve'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:295:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/middleware_chain.rb:49:in `invoke_core'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema/middleware_chain.rb:38:in `invoke'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:108:in `block in resolve_field'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `block in trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:76:in `call_tracers'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:107:in `resolve_field'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:71:in `block in resolve_selection'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:64:in `each'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:64:in `resolve_selection'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:36:in `block in resolve_root_selection'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `block in trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:76:in `call_tracers'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/execute.rb:32:in `resolve_root_selection'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:108:in `begin_query'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:81:in `block in run_as_multiplex'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:80:in `map'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:80:in `run_as_multiplex'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:69:in `block (2 levels) in run_queries'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:174:in `block in instrument_and_analyze'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:29:in `block (2 levels) in apply_instrumenters'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:41:in `each_query_call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:70:in `call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:70:in `call_hooks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:166:in `instrument_and_analyze'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:68:in `block in run_queries'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `block in trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:76:in `call_tracers'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/tracing.rb:62:in `trace'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:58:in `run_queries'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/execution/multiplex.rb:48:in `run_all'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:342:in `block in multiplex'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:1079:in `with_definition_error_check'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:341:in `multiplex'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/graphql-1.8.10/lib/graphql/schema.rb:318:in `execute'
/Users/danielramirez/Documents/artsy/exchange/app/controllers/api/graphql_controller.rb:11:in `execute'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/abstract_controller/base.rb:194:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/rendering.rb:30:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sentry-raven-2.7.4/lib/raven/integrations/rails/controller_transaction.rb:7:in `block in included'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:118:in `instance_exec'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:136:in `run_callbacks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/abstract_controller/callbacks.rb:41:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/rescue.rb:22:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/notifications.rb:168:in `block in instrument'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/notifications.rb:168:in `instrument'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/abstract_controller/base.rb:134:in `process'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionview-5.2.1/lib/action_view/rendering.rb:32:in `process'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal.rb:191:in `dispatch'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_controller/metal.rb:252:in `dispatch'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/routing/route_set.rb:34:in `serve'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/journey/router.rb:35:in `each'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/journey/router.rb:35:in `serve'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/routing/route_set.rb:840:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/tempfile_reaper.rb:15:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/etag.rb:25:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/conditional_get.rb:38:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/head.rb:12:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/session/abstract/id.rb:232:in `context'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/session/abstract/id.rb:226:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/cookies.rb:670:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-5.2.1/lib/active_record/migration.rb:559:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:98:in `run_callbacks'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-5.2.1/lib/rails/rack/logger.rb:38:in `call_app'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-5.2.1/lib/rails/rack/logger.rb:26:in `block in call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/tagged_logging.rb:28:in `tagged'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/tagged_logging.rb:71:in `tagged'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-5.2.1/lib/rails/rack/logger.rb:26:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/request_store-1.4.1/lib/request_store/middleware.rb:19:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/request_id.rb:27:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/method_override.rb:22:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/runtime.rb:22:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.2.1/lib/action_dispatch/middleware/static.rb:127:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/sendfile.rb:111:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sentry-raven-2.7.4/lib/raven/integrations/rack.rb:51:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-5.2.1/lib/rails/engine.rb:524:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puma-3.12.0/lib/puma/configuration.rb:225:in `call'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puma-3.12.0/lib/puma/server.rb:658:in `handle_request'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puma-3.12.0/lib/puma/server.rb:472:in `process_client'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puma-3.12.0/lib/puma/server.rb:332:in `block in run'
/Users/danielramirez/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puma-3.12.0/lib/puma/thread_pool.rb:133:in `block in spawn_thread'
Completed 500 Internal Server Error in 228ms (Views: 0.4ms | ActiveRecord: 0.0ms)
```
</details>