### PR TITLE
Enforce domestic shipping only validation on adding address to order

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -35,6 +35,7 @@ module Errors
       unknown_edition_set
       unknown_partner
       unpublished_artwork
+      unsupported_shipping_location
       wrong_fulfillment_type
     ],
     processing: %i[
@@ -44,6 +45,7 @@ module Errors
       insufficient_inventory
       refund_failed
       tax_recording_failure
+      tax_calculator_failure
     ],
     internal: %i[
       generic

--- a/app/graphql/types/application_error_type.rb
+++ b/app/graphql/types/application_error_type.rb
@@ -7,7 +7,7 @@ class Types::ApplicationErrorType < Types::BaseObject
   field :type, String, null: false, description: 'Type of this error'
 
   def self.from_application(err)
-    format_error_type(type: err.type, code: err.code, data: err.data)
+    format_error_type(type: err.type, code: err.code, data: err.data.to_json)
   end
 
   def self.format_error_type(type:, code:, data: nil)

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -10,6 +10,8 @@ class OrderShippingService
   def process!
     raise Errors::ValidationError.new(:invalid_state, state: @order.state) unless @order.state == Order::PENDING
 
+    validate_shipping_location!
+
     Order.transaction do
       attrs = {
         shipping_total_cents: shipping_total_cents,
@@ -58,6 +60,14 @@ class OrderShippingService
     raise Errors::ValidationError, :missing_artwork_location if artwork[:location].blank?
   end
 
+  def validate_shipping_location!
+    domestic_shipping_only = artworks.any? do |(_, artwork)|
+      artwork[:international_shipping_fee_cents].nil? && international_shipping?(artwork[:location])
+    end
+
+    raise Errors::ValidationError.new(:unsupported_shipping_location, failure_code: :domestic_shipping_only) if domestic_shipping_only
+  end
+
   def shipping_total_cents
     @shipping_total_cents ||= @order.line_items.map { |li| artwork_shipping_fee(artworks[li.artwork_id]) }.sum
   end
@@ -65,15 +75,20 @@ class OrderShippingService
   def artwork_shipping_fee(artwork)
     if @fulfillment_type == Order::PICKUP
       0
-    elsif domestic?(artwork[:location])
+    elsif domestic_shipping?(artwork[:location])
       calculate_domestic_shipping_fee(artwork)
     else
       calculate_international_shipping_fee(artwork)
     end
   end
 
-  def domestic?(artwork_location)
-    artwork_location[:country].casecmp(@shipping_address.country).zero?
+  def domestic_shipping?(artwork_location)
+    artwork_location[:country].casecmp(@shipping_address.country).zero? &&
+      (@shipping_address.country != Carmen::Country.coded('US').code || @shipping_address.continental_us?)
+  end
+
+  def international_shipping?(artwork_location)
+    !domestic_shipping?(artwork_location)
   end
 
   def calculate_domestic_shipping_fee(artwork)

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -21,6 +21,14 @@ class Address
       @postal_code == other.postal_code
   end
 
+  # The "continental United States" is defined as any US state that isn't Alaska or Hawaii.
+  def continental_us?
+    us = Carmen::Country.coded('US')
+    @country == us.code &&
+      @region != us.subregions.coded('HI').code &&
+      @region != us.subregions.coded('AK').code
+  end
+
   private
 
   def parse(address)

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -20,6 +20,11 @@ describe RecordSalesTaxJob, type: :job do
         SalesTaxService.const_set('REMITTING_STATES', ['ny'])
       end
     end
+    after do
+      silence_warnings do
+        SalesTaxService.const_set('REMITTING_STATES', [])
+      end
+    end
     context 'with an order that has sales tax to remit' do
       it 'posts a transaction to TaxJar and saves the transaction id' do
         expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -37,6 +37,12 @@ describe SalesTaxService, type: :services do
     @service_pickup = SalesTaxService.new(line_item, Order::PICKUP, Address.new({}), shipping_total_cents, artwork_location)
   end
 
+  after do
+    silence_warnings do
+      SalesTaxService.const_set('REMITTING_STATES', [])
+    end
+  end
+
   describe '#initialize' do
     context 'with a destination address in a remitting state' do
       it 'sets shipping_total_cents to the passed in value' do


### PR DESCRIPTION
As part of [PURCHASE-371](https://artsyproduct.atlassian.net/browse/PURCHASE-371), we want to validate against adding a non-continental US shipping address to an artwork with a nil `international_shipping_fee_cents` i.e. the work ships to continental us only. Exchange will return an error of type `invalid_shipping_address`, which reaction will use to display an appropriate modal. Reaction already disables the country field from being changed in this case, so this validation logic should only trigger when a user attempts to enter an address in Alaska or Hawaii.

This is the first time I've written Ruby in a while, so feel free to nit anything and everything.