### PR TITLE
Fix empty array EditionSet issue

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -46,7 +46,7 @@ class CreateOrderService
     raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: @artwork_id) unless @artwork[:published]
     raise Errors::ValidationError.new(:not_acquireable, artwork_id: @artwork_id) unless @artwork[:acquireable]
 
-    find_verify_edition_set
+    find_verify_edition_set if @edition_set_id.present? || @artwork[:edition_sets].present?
   end
 
   def post_process
@@ -74,7 +74,6 @@ class CreateOrderService
       # if there is one we are going to assume thats the one buyer meant to buy
       # TODO: ☝ is a temporary logic till Eigen starts supporting editionset artworks
       # https://artsyproduct.atlassian.net/browse/PURCHASE-505
-      return unless @artwork[:edition_sets]&.count
       raise Errors::ValidationError.new(:missing_edition_set_id, artwork_id: @artwork_id) if @artwork[:edition_sets].count > 1
 
       @edition_set = @artwork[:edition_sets].first

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -46,7 +46,7 @@ class CreateOrderService
     raise Errors::ValidationError.new(:unpublished_artwork, artwork_id: @artwork_id) unless @artwork[:published]
     raise Errors::ValidationError.new(:not_acquireable, artwork_id: @artwork_id) unless @artwork[:acquireable]
 
-    find_verify_edition_set if @edition_set_id.present? || @artwork[:edition_sets].present?
+    find_verify_edition_set
   end
 
   def post_process
@@ -65,6 +65,8 @@ class CreateOrderService
   end
 
   def find_verify_edition_set
+    return unless @edition_set_id.present? || @artwork[:edition_sets].present?
+
     if @edition_set_id
       @edition_set = @artwork[:edition_sets]&.find { |e| e[:id] == @edition_set_id }
       raise Errors::ValidationError.new(:unknown_edition_set, artwork_id: @artwork[:id], edition_set_id: @edition_set_id) unless @edition_set


### PR DESCRIPTION
# Problem
https://sentry.io/artsynet/exchange-staging/issues/706978737/?query=is:unresolved
With current logic if artwork's `edition_sets` is empty array we try to fetch first edition set and call `[:id]` on it which raises runtime error.

https://github.com/artsy/exchange/pull/198#pullrequestreview-160285287

# Change
use `present?` and do it earlier before calling `find_verify_edition_set`.