### PR TITLE
Remove all states from list of states where we need to remit taxes

### DIFF
--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -1,5 +1,5 @@
 class SalesTaxService
-  REMITTING_STATES = %w[wa pa].freeze
+  REMITTING_STATES = [].freeze
   attr_reader :transaction
   def initialize(
     line_item,

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 require 'support/taxjar_helper'
 
 describe RecordSalesTaxJob, type: :job do
-  let(:order) { Fabricate(:order, fulfillment_type: Order::PICKUP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'WA', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100, state: Order::APPROVED) }
+  let(:order) { Fabricate(:order, fulfillment_type: Order::PICKUP, shipping_country: 'US', shipping_postal_code: '10013', shipping_region: 'NY', shipping_city: 'New York', shipping_address_line1: '401 Broadway', shipping_total_cents: 100, state: Order::APPROVED) }
   let!(:line_item) { Fabricate(:line_item, order: order, sales_tax_cents: 100_00, should_remit_sales_tax: true) }
   let(:artwork_location) do
     {
       country: 'US',
-      city: 'Seattle',
-      state: 'WA',
+      city: 'New York',
+      state: 'NY',
       address: '22 Fake St',
       postal_code: 10013
     }
@@ -16,6 +16,9 @@ describe RecordSalesTaxJob, type: :job do
   describe '#perform' do
     before do
       stub_tax_for_order
+      silence_warnings do
+        SalesTaxService.const_set('REMITTING_STATES', ['ny'])
+      end
     end
     context 'with an order that has sales tax to remit' do
       it 'posts a transaction to TaxJar and saves the transaction id' do


### PR DESCRIPTION
### Problem
Legal has determined that we should not be remitting taxes sellers to any states right now. This may change in the future as legislation evolves.

### Solution
Remove all states from `SalesTaxService::REMITTING_STATES` but keep code that allows us to remit sales tax to states.

### What Changed
 - Removed WA and PA from `SalesTaxService::REMITTING_STATES`
- Updated specs