### PR TITLE
Stop using seller lapse for realZ

### DIFF
--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -9,7 +9,7 @@ class OrderCancellationService
     @order.seller_lapse! do
       refund
     end
-    PostNotificationJob.perform_later(@order.id, Order::SELLER_LAPSED)
+    PostNotificationJob.perform_later(@order.id, Order::CANCELED)
   ensure
     @order.transactions << @transaction if @transaction.present?
   end

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -31,6 +31,62 @@ describe OrderCancellationService, type: :services do
       end
       it 'updates the order state' do
         expect(order.state).to eq Order::CANCELED
+        expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_rejected]
+      end
+      it 'queues notification job' do
+        expect(PostNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED, user_id)
+      end
+    end
+    context 'with an unsuccessful refund' do
+      before do
+        artwork_inventory_undeduct_request
+        edition_set_inventory_undeduct_request
+        allow(Stripe::Refund).to receive(:create)
+          .with(hash_including(charge: captured_charge.id))
+          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+        expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
+      end
+      it 'raises a ProcessingError and records the transaction' do
+        expect(order.transactions.last.external_id).to eq captured_charge.id
+        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        expect(order.transactions.last.status).to eq Transaction::FAILURE
+      end
+      it 'does not undeduct inventory' do
+        expect(artwork_inventory_undeduct_request).not_to have_been_requested
+        expect(edition_set_inventory_undeduct_request).not_to have_been_requested
+      end
+    end
+  end
+
+  describe '#seller_lapse!' do
+    let(:artwork_inventory_deduct_request_status) { 200 }
+    let(:edition_set_inventory_deduct_request_status) { 200 }
+    let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
+    let(:edition_set_inventory_undeduct_request) do
+      stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json)
+    end
+    context 'with a successful refund' do
+      before do
+        artwork_inventory_undeduct_request
+        edition_set_inventory_undeduct_request
+        service.seller_lapse!
+      end
+      it 'calls to undeduct inventory' do
+        expect(artwork_inventory_undeduct_request).to have_been_requested
+        expect(edition_set_inventory_undeduct_request).to have_been_requested
+      end
+      it 'records the transaction' do
+        expect(order.transactions.last.external_id).to_not eq nil
+        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        expect(order.transactions.last.status).to eq Transaction::SUCCESS
+      end
+      it 'updates the order state' do
+        expect(order.state).to eq Order::CANCELED
+        expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
+      end
+
+      it 'queues notification job' do
+        expect(PostNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
       end
     end
     context 'with an unsuccessful refund' do


### PR DESCRIPTION
# Problem
We were still using `Order::SELLER_LAPSE` as event's action when calling post notification. That state was removed in previous PRs and was replaced with `Order::CANCELED`.

# Solution
Switch to `Order::CANCELED` and add missing specs.