### PR TITLE
Add ability to refund transactions from TaxJar

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -46,6 +46,7 @@ module Errors
       refund_failed
       tax_recording_failure
       tax_calculator_failure
+      tax_refund_failure
     ],
     internal: %i[
       generic

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -36,7 +36,7 @@ class SalesTaxService
   end
 
   def refund_transaction(refund_date)
-    @transaction = get_transaction(transaction_id) if @transaction.blank?
+    @transaction = get_transaction(transaction_id)
     @refund = post_refund(refund_date) if @transaction.present?
   rescue Taxjar::Error => e
     raise Errors::ProcessingError.new(:tax_refund_failure, message: e.message)
@@ -74,7 +74,7 @@ class SalesTaxService
   def post_refund(refund_date)
     @tax_client.create_refund(
       construct_tax_params(
-        transaction_id: "#{transaction_id}_refund",
+        transaction_id: "refund_#{transaction_id}",
         transaction_date: refund_date.iso8601,
         transaction_reference_id: transaction_id,
         sales_tax: UnitConverter.convert_cents_to_dollars(@line_item.sales_tax_cents)
@@ -112,6 +112,6 @@ class SalesTaxService
   end
 
   def transaction_id
-    "#{@line_item.order.code}-#{@line_item.id[0..4]}"
+    "#{@line_item.order.id}__#{@line_item.id}"
   end
 end

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -20,6 +20,7 @@ class SalesTaxService
     @shipping_address = shipping_address
     @shipping_total_cents = artsy_should_remit_taxes? ? shipping_total_cents : 0
     @transaction = nil
+    @refund = nil
   end
 
   def sales_tax
@@ -34,6 +35,13 @@ class SalesTaxService
     raise Errors::ProcessingError.new(:tax_recording_failure, message: e.message)
   end
 
+  def refund_transaction(refund_date)
+    @transaction = get_transaction(transaction_id) if @transaction.blank?
+    @refund = post_refund(refund_date) if @transaction.present?
+  rescue Taxjar::Error => e
+    raise Errors::ProcessingError.new(:tax_refund_failure, message: e.message)
+  end
+
   def artsy_should_remit_taxes?
     return false unless destination_address.country == Carmen::Country.coded('US').code
 
@@ -42,28 +50,40 @@ class SalesTaxService
 
   private
 
+  def get_transaction(id)
+    @tax_client.show_order(id)
+  rescue Taxjar::Error::NotFound
+    nil
+  end
+
   def fetch_sales_tax
-    @tax_client.tax_for_order(
-      amount: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents),
-      from_country: origin_address.country,
-      from_zip: origin_address.postal_code,
-      from_state: origin_address.region,
-      from_city: origin_address.city,
-      from_street: origin_address.street_line1,
-      to_country: destination_address.country,
-      to_zip: destination_address.postal_code,
-      to_state: destination_address.region,
-      to_city: destination_address.city,
-      to_street: destination_address.street_line1,
-      shipping: UnitConverter.convert_cents_to_dollars(@shipping_total_cents)
-    )
+    @tax_client.tax_for_order(construct_tax_params)
   end
 
   def post_transaction
     transaction_date = @line_item.order.last_approved_at.iso8601
     @tax_client.create_order(
-      transaction_id: "#{@line_item.order_id}-#{@line_item.id}",
-      transaction_date: transaction_date,
+      construct_tax_params(
+        transaction_id: transaction_id,
+        transaction_date: transaction_date,
+        sales_tax: UnitConverter.convert_cents_to_dollars(@line_item.sales_tax_cents)
+      )
+    )
+  end
+
+  def post_refund(refund_date)
+    @tax_client.create_refund(
+      construct_tax_params(
+        transaction_id: "#{transaction_id}_refund",
+        transaction_date: refund_date.iso8601,
+        transaction_reference_id: transaction_id,
+        sales_tax: UnitConverter.convert_cents_to_dollars(@line_item.sales_tax_cents)
+      )
+    )
+  end
+
+  def construct_tax_params(args = {})
+    {
       amount: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents),
       from_country: origin_address.country,
       from_zip: origin_address.postal_code,
@@ -75,9 +95,8 @@ class SalesTaxService
       to_state: destination_address.region,
       to_city: destination_address.city,
       to_street: destination_address.street_line1,
-      sales_tax: UnitConverter.convert_cents_to_dollars(@line_item.sales_tax_cents),
       shipping: UnitConverter.convert_cents_to_dollars(@shipping_total_cents)
-    )
+    }.merge(args)
   end
 
   def origin_address
@@ -90,5 +109,9 @@ class SalesTaxService
 
   def seller_address
     @seller_address ||= GravityService.fetch_partner_location(@line_item.order.seller_id)
+  end
+
+  def transaction_id
+    "#{@line_item.order.code}-#{@line_item.id[0..4]}"
   end
 end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -3,9 +3,10 @@ require 'support/gravity_helper'
 
 describe SalesTaxService, type: :services do
   let(:taxjar_client) { double }
-  let(:order) { Fabricate(:order) }
-  let!(:line_item) { Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
+  let(:order) { Fabricate(:order, id: 1) }
+  let!(:line_item) { Fabricate(:line_item, id: 1, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
   let(:shipping_total_cents) { 2222 }
+  let(:transaction_id) { "#{line_item.order.code}-#{line_item.id[0..4]}" }
   let(:shipping) do
     {
       country: 'US',
@@ -27,6 +28,22 @@ describe SalesTaxService, type: :services do
   end
   let(:partner_address) { Address.new(partner_location) }
   let(:artwork_location) { Address.new(gravity_v1_artwork[:location]) }
+  let(:base_tax_params) do
+    {
+      amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
+      from_country: partner_location[:country],
+      from_zip: partner_location[:postal_code],
+      from_state: partner_location[:state],
+      from_city: partner_location[:city],
+      from_street: partner_location[:address],
+      to_country: shipping_address.country,
+      to_zip: shipping_address.postal_code,
+      to_state: shipping_address.region,
+      to_city: shipping_address.city,
+      to_street: shipping_address.street_line1,
+      shipping: 0
+    }
+  end
 
   before do
     silence_warnings do
@@ -59,10 +76,22 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#sales_tax' do
+    before do
+      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
+    end
     it 'calls fetch_sales_tax and returns the sales tax in cents' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_location)
       expect(@service_ship).to receive(:fetch_sales_tax).and_return(double(amount_to_collect: 1.00))
       expect(@service_ship.sales_tax).to eq 100
+    end
+    context 'with an error from TaxJar' do
+      it 'raises a ProcessingError with a code of tax_calculator_failure' do
+        expect(taxjar_client).to receive(:tax_for_order).and_raise(Taxjar::Error)
+        expect { @service_ship.sales_tax }.to raise_error do |error|
+          expect(error).to be_a Errors::ProcessingError
+          expect(error.type).to eq :processing
+          expect(error.code).to eq :tax_calculator_failure
+        end
+      end
     end
   end
 
@@ -101,37 +130,38 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#fetch_sales_tax' do
-    let(:params) do
-      {
-        amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
-        from_country: partner_location[:country],
-        from_zip: partner_location[:postal_code],
-        from_state: partner_location[:state],
-        from_city: partner_location[:city],
-        from_street: partner_location[:address],
-        to_country: shipping_address.country,
-        to_zip: shipping_address.postal_code,
-        to_state: shipping_address.region,
-        to_city: shipping_address.city,
-        to_street: shipping_address.street_line1,
-        shipping: 0
-      }
-    end
     it 'calls the Taxjar API with the correct parameters' do
       allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
-      allow(taxjar_client).to receive(:tax_for_order).with(params)
+      allow(taxjar_client).to receive(:tax_for_order).with(base_tax_params)
       @service_ship.send(:fetch_sales_tax)
-      expect(taxjar_client).to have_received(:tax_for_order).with(params)
+      expect(taxjar_client).to have_received(:tax_for_order).with(base_tax_params)
     end
   end
 
   describe '#record_tax_collected' do
     context 'when Artsy needs to remit taxes and line item has sales tax' do
-      it 'calls post_transaction and saves the result to @transaction' do
+      before do
         expect(@service_ship).to receive(:artsy_should_remit_taxes?).and_return(true)
+      end
+      it 'calls post_transaction and saves the result to @transaction' do
         expect(@service_ship).to receive(:post_transaction).and_return(double(transaction_id: '123'))
         @service_ship.record_tax_collected
         expect(@service_ship.transaction).to_not be_nil
+      end
+      context 'with an error from TaxJar' do
+        before do
+          order.submit!
+          order.approve!
+          allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
+        end
+        it 'raises a ProcessingError with a code of tax_recording_failure' do
+          expect(taxjar_client).to receive(:create_order).and_raise(Taxjar::Error)
+          expect { @service_ship.record_tax_collected }.to raise_error do |error|
+            expect(error).to be_a Errors::ProcessingError
+            expect(error.type).to eq :processing
+            expect(error.code).to eq :tax_recording_failure
+          end
+        end
       end
     end
     context 'when Artsy does not need to remit taxes' do
@@ -155,23 +185,11 @@ describe SalesTaxService, type: :services do
 
   describe '#post_transaction' do
     let(:params) do
-      {
-        transaction_id: "#{line_item.order_id}-#{line_item.id}",
+      base_tax_params.merge(
+        transaction_id: transaction_id,
         transaction_date: line_item.order.last_approved_at.iso8601,
-        amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
-        from_country: partner_location[:country],
-        from_zip: partner_location[:postal_code],
-        from_state: partner_location[:state],
-        from_city: partner_location[:city],
-        from_street: partner_location[:address],
-        to_country: shipping_address.country,
-        to_zip: shipping_address.postal_code,
-        to_state: shipping_address.region,
-        to_city: shipping_address.city,
-        to_street: shipping_address.street_line1,
-        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents),
-        shipping: 0
-      }
+        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents)
+      )
     end
     before do
       # We need to trigger the state actions to generate the state history
@@ -209,6 +227,70 @@ describe SalesTaxService, type: :services do
         service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location)
         expect(service.send(:artsy_should_remit_taxes?)).to be false
       end
+    end
+  end
+
+  describe '#refund_transaction' do
+    context 'with an existing transaction in Taxjar' do
+      it 'refunds the transaction' do
+        expect(taxjar_client).to receive(:show_order).with(transaction_id).and_return(double)
+        expect(@service_ship).to receive(:post_refund)
+        @service_ship.refund_transaction(Time.new(2018, 1, 1))
+      end
+    end
+    context 'without an existing transaction in Taxjar' do
+      it 'does nothing' do
+        expect(taxjar_client).to receive(:show_order).with(transaction_id).and_return(nil)
+        expect(@service_ship).to_not receive(:post_refund)
+        @service_ship.refund_transaction(Time.new(2018, 1, 1))
+      end
+    end
+    context 'with an error from TaxJar' do
+      it 'raises a ProcessingError with a code of tax_refund_failure' do
+        expect(taxjar_client).to receive(:show_order).and_raise(Taxjar::Error)
+        expect { @service_ship.refund_transaction(Time.new(2018, 1, 1)) }.to raise_error do |error|
+          expect(error).to be_a Errors::ProcessingError
+          expect(error.type).to eq :processing
+          expect(error.code).to eq :tax_refund_failure
+        end
+      end
+    end
+  end
+
+  describe '#get_transaction' do
+    it "returns nil if TaxJar can't find the associated record" do
+      expect(taxjar_client).to receive(:show_order).and_raise(Taxjar::Error::NotFound)
+      expect(@service_ship.send(:get_transaction, 'tx_id')).to be_nil
+    end
+  end
+
+  describe '#post_refund' do
+    let(:transaction_date) { Time.new(2018, 1, 1) }
+    let(:params) do
+      base_tax_params.merge(
+        transaction_id: "#{transaction_id}_refund",
+        transaction_date: transaction_date.iso8601,
+        transaction_reference_id: transaction_id,
+        sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents)
+      )
+    end
+    it 'calls the TaxJar API with the correct parameters' do
+      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
+      expect(taxjar_client).to receive(:create_refund).with(params)
+      @service_ship.send(:post_refund, transaction_date)
+    end
+  end
+
+  describe '#construct_tax_params' do
+    before do
+      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
+    end
+    it 'returns the parameters shared by all API calls to TaxJar' do
+      expect(@service_ship.send(:construct_tax_params)).to eq base_tax_params
+    end
+    it 'merges in additional data' do
+      additional_data = { foo: 'bar' }
+      expect(@service_ship.send(:construct_tax_params, additional_data)).to eq base_tax_params.merge(additional_data)
     end
   end
 end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -6,7 +6,7 @@ describe SalesTaxService, type: :services do
   let(:order) { Fabricate(:order, id: 1) }
   let!(:line_item) { Fabricate(:line_item, id: 1, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
   let(:shipping_total_cents) { 2222 }
-  let(:transaction_id) { "#{line_item.order.code}-#{line_item.id[0..4]}" }
+  let(:transaction_id) { "#{line_item.order.id}__#{line_item.id}" }
   let(:shipping) do
     {
       country: 'US',
@@ -268,7 +268,7 @@ describe SalesTaxService, type: :services do
     let(:transaction_date) { Time.new(2018, 1, 1) }
     let(:params) do
       base_tax_params.merge(
-        transaction_id: "#{transaction_id}_refund",
+        transaction_id: "refund_#{transaction_id}",
         transaction_date: transaction_date.iso8601,
         transaction_reference_id: transaction_id,
         sales_tax: UnitConverter.convert_cents_to_dollars(line_item.sales_tax_cents)


### PR DESCRIPTION
### Problem
When we refund a captured charge we need to send a reversed transaction to TaxJar to record the refund if we previously collected sales tax and planned to remit it.

### Solution
Add capability to create refund transactions in TaxJar. This will eventually be implemented in an async job in `OrderCancellationService`, but since we're not currently posting transactions to TaxJar I'm leaving it out for now. 

### What Changed
- Adds methods to handle creating refunds in TaxJar
- Refactors shared parameters for TaxJar API calls into a single method `construct_tax_params`
- Adds tests to ensure that we properly handle errors from TaxJar