### PR TITLE
Add commission_fee_cents to LineItem

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -132,6 +132,7 @@ type FulfillmentEdge {
 # A Line Item
 type LineItem {
   artworkId: String!
+  commissionFeeCents: Int
   createdAt: DateTime!
   editionSetId: String
   fulfillments(

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -50,7 +50,8 @@ class OrderEvent < Events::BaseEvent
       price_cents: line_item.price_cents,
       artwork_id: line_item.artwork_id,
       edition_set_id: line_item.edition_set_id,
-      quantity: line_item.quantity
+      quantity: line_item.quantity,
+      commission_fee_cents: line_item.commission_fee_cents
     }
   end
 end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -8,6 +8,7 @@ class Types::BaseField < GraphQL::Schema::Field
   def authorized?(obj, ctx)
     case obj
     when Order then order_field_authorized?(obj, ctx[:current_user])
+    when LineItem then order_field_authorized?(obj.order, ctx[:current_user])
     else
       super
     end

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -7,6 +7,7 @@ class Types::LineItemType < Types::BaseObject
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true
   field :quantity, Integer, null: false
+  field :commission_fee_cents, Integer, null: true, seller_only: true
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :fulfillments, Types::FulfillmentType.connection_type, null: true

--- a/db/migrate/20181003191806_add_commission_cents_to_line_items.rb
+++ b/db/migrate/20181003191806_add_commission_cents_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddCommissionCentsToLineItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :line_items, :commission_fee_cents, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_01_172826) do
+ActiveRecord::Schema.define(version: 2018_10_03_191806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2018_10_01_172826) do
     t.string "artwork_version_id"
     t.boolean "should_remit_sales_tax"
     t.string "sales_tax_transaction_id"
+    t.integer "commission_fee_cents"
     t.index ["order_id"], name: "index_line_items_on_order_id"
   end
 

--- a/spec/controllers/api/requests/order_field_permissions_spec.rb
+++ b/spec/controllers/api/requests/order_field_permissions_spec.rb
@@ -19,6 +19,7 @@ describe Api::GraphqlController, type: :request do
         seller_total_cents: 1050_00
       )
     end
+    let!(:line_item) { Fabricate(:line_item, price_cents: 100_00, quantity: 2, commission_fee_cents: 40_00, order: order) }
     context 'as buyer' do
       let(:jwt_partner_ids) { [] }
       let(:jwt_user_id) { user_id }
@@ -31,6 +32,16 @@ describe Api::GraphqlController, type: :request do
               transactionFeeCents
               sellerTotalCents
               buyerTotalCents
+              lineItems {
+                edges {
+                  node {
+                    id
+                    priceCents
+                    quantity
+                    commissionFeeCents
+                  }
+                }
+              }
             }
           }
         GRAPHQL
@@ -41,6 +52,8 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.transaction_fee_cents).to be_nil
         expect(result.data.order.seller_total_cents).to be_nil
         expect(result.data.order.buyer_total_cents).to eq 1100_00
+        expect(result.data.order.line_items.edges.first.node.commission_fee_cents).to be_nil
+        expect(result.data.order.line_items.edges.first.node.price_cents).to eq 100_00
       end
     end
 
@@ -55,6 +68,16 @@ describe Api::GraphqlController, type: :request do
               buyerTotalCents
               commissionFeeCents
               sellerTotalCents
+              lineItems {
+                edges {
+                  node {
+                    id
+                    priceCents
+                    quantity
+                    commissionFeeCents
+                  }
+                }
+              }
             }
           }
         GRAPHQL
@@ -64,6 +87,8 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.buyer_total_cents).to eq 1100_00
         expect(result.data.order.seller_total_cents).to eq 1050_00
         expect(result.data.order.commission_fee_cents).to eq 30_00
+        expect(result.data.order.line_items.edges.first.node.commission_fee_cents).to eq 40_00
+        expect(result.data.order.line_items.edges.first.node.price_cents).to eq 100_00
       end
     end
 

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -31,10 +31,25 @@ describe OrderEvent, type: :events do
               buyer_total_cents: 380,
               **shipping_info)
   end
-  let!(:line_items) do
+  let(:line_item1) { Fabricate(:line_item, price_cents: 200, order: order, commission_fee_cents: 40) }
+  let(:line_item2) { Fabricate(:line_item, price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
+  let!(:line_items) { [line_item1, line_item2] }
+  let(:line_item_properties) do
     [
-      Fabricate(:line_item, price_cents: 200, order: order),
-      Fabricate(:line_item, price_cents: 100, order: order)
+      {
+        price_cents: 200,
+        artwork_id: line_item1.artwork_id,
+        edition_set_id: line_item1.edition_set_id,
+        quantity: 1,
+        commission_fee_cents: 40
+      },
+      {
+        price_cents: 100,
+        artwork_id: line_item2.artwork_id,
+        edition_set_id: line_item2.edition_set_id,
+        quantity: 2,
+        commission_fee_cents: 20
+      }
     ]
   end
   let(:event) { OrderEvent.new(user: user_id, action: Order::SUBMITTED, model: order) }
@@ -76,6 +91,7 @@ describe OrderEvent, type: :events do
       expect(event.properties[:updated_at]).not_to be_nil
       expect(event.properties[:created_at]).not_to be_nil
       expect(event.properties[:line_items].count).to eq 2
+      expect(event.properties[:line_items]).to match_array(line_item_properties)
       expect(event.properties[:shipping_name]).to eq 'Fname Lname'
       expect(event.properties[:shipping_address_line1]).to eq '123 Main St'
       expect(event.properties[:shipping_address_line2]).to eq 'Apt 2'

--- a/spec/services/create_order_service_spec.rb
+++ b/spec/services/create_order_service_spec.rb
@@ -29,11 +29,11 @@ describe CreateOrderService, type: :services do
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
         it 'sets state_expires_at for newly pending order' do
-          Timecop.freeze(Time.now.utc) do
+          Timecop.freeze(Time.now.beginning_of_day) do
             service.process!
             order = service.order
             expect(order.state).to eq Order::PENDING
-            expect(order.state_updated_at).to eq Time.now.utc
+            expect(order.state_updated_at).to eq Time.now.beginning_of_day
             expect(order.state_expires_at).to eq 2.days.from_now
           end
         end

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -14,7 +14,9 @@ describe OrderTotalUpdaterService, type: :service do
       end
     end
     context 'with line items' do
-      let!(:line_items) { [Fabricate(:line_item, order: order, price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true), Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false)] }
+      let(:line_item1) { Fabricate(:line_item, order: order, price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
+      let(:line_item2) { Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
+      let!(:line_items) { [line_item1, line_item2] }
       context 'with shipping and tax' do
         let(:shipping_total_cents) { 50_00 }
         let(:tax_total_cents) { 60_00 }
@@ -48,6 +50,11 @@ describe OrderTotalUpdaterService, type: :service do
             expect(order.transaction_fee_cents).to eq 17_99
             expect(order.commission_fee_cents).to eq 200_00
             expect(order.seller_total_cents).to eq(610_00 - (17_99 + 200_00 + 500))
+          end
+          it 'sets correct commission on each line item' do
+            OrderTotalUpdaterService.new(order, 0.40).update_totals!
+            expect(line_item1.reload.commission_fee_cents).to eq 40_00
+            expect(line_item2.reload.commission_fee_cents).to eq 160_00
           end
         end
       end


### PR DESCRIPTION
# Problem
When creating `purchase` for each approved order in Gravity, we want to know the commission fee for each artwork sold. Currently `commission_fee_cents` is only stored on `Order`, this makes it hard for us to calculate the commission per artwork.

In general, it seems like a good idea to store `commission_fee_cents` on `LineItem` and also store the total on `Order` so we can go back and track what was the commission at the time of that order.

# Solution
- Added `commission_fee_cents` to `LineItem`
- Updated `OrderTotalUpdater` to first set `commission_fee_cents` on `LineItem` and then set the total on `Order` based on `line_items`.
  - For ☝️ , ended up locking the order to make sure totals are all set together now that updating line items is also involved.
- Updated `OrderEvent` to include `commission_fee_cents` in the event posted
- Updated Schema to include `commission_fee_cents` as `seller_only`, `null: true` field on `LineItem`.
  - For ☝️ to work, had to update `seller_only` definition to understand how to handle `LineItem` fields

# Is this a breaking change?
No, we added a field to `LineItem`, if new field is not used by clients, they don't have to update schema.