### PR TITLE
Guard validate_shipping_location with fulfillment type check

### DIFF
--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -10,7 +10,7 @@ class OrderShippingService
   def process!
     raise Errors::ValidationError.new(:invalid_state, state: @order.state) unless @order.state == Order::PENDING
 
-    validate_shipping_location!
+    validate_shipping_location! if @fulfillment_type == Order::SHIP
 
     Order.transaction do
       attrs = {


### PR DESCRIPTION
Fixes this [`NoMethodError`](https://sentry.io/artsynet/exchange-staging/issues/711632454/?query=is:unresolved) by checking the `fulfillment_type` of the order before validating the shipping location.