### PR TITLE
Support Refunds by Admins

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -34,6 +34,55 @@ ActiveAdmin.register Order do
     end
   end
 
+  member_action :refund, method: :post do
+    OrderCancellationService.new(resource).refund!
+    redirect_to resource_path, notice: "Refunded!"
+  end
+
+  action_item :refund, only: :show do
+    link_to 'Refund', refund_admin_order_path(order), method: :post if [Order::APPROVED, Order::FULFILLED].include? order.state
+  end
+
+  sidebar :contact_info, only: :show do
+    #TODO: why doesn't this work?
+    link_to "artsy.net" do
+      button "View Artwork on Artsy"
+    end
+    panel "Buyer Information" do
+      attributes_table_for order do
+        #TODO: fill this in
+        row :name
+        row :shipping_address do
+          if order.shipping_info?
+            #TODO: shipping info
+            #table_for order.admin_notes
+          else
+            'None'
+          end
+        end
+        row :shipping_phone
+        row :email
+      end
+    end
+
+    panel "Seller Information" do
+      attributes_table_for order do
+        #TODO: fill this in
+        row :partner_name
+        row :address
+        row :phone
+        row :email
+        row :sales_contacts do
+          #TODO: add sales contacts
+          #table_for
+        end
+      end
+      link_to "artsy.net" do
+        button "View Partner in Admin-Partners"
+      end
+    end
+  end
+
   show do
 
     panel "Order Summary" do
@@ -65,7 +114,7 @@ ActiveAdmin.register Order do
     panel "Transaction" do
       #TODO: finish this payment summary
       para "Paid #{number_to_currency order.buyer_total_cents}"
-       
+
       attributes_table_for order do
         row "Artwork Price" do |order|
            number_to_currency order.items_total_cents
@@ -105,52 +154,4 @@ ActiveAdmin.register Order do
 
   end
 
-  sidebar :contact_info, only: :show do
-
-    #TODO: why doesn't this work?
-    link_to "artsy.net" do
-      button "View Artwork on Artsy"
-    end
-
-
-    panel "Buyer Information" do
-      attributes_table_for order do
-        #TODO: fill this in
-        row :name
-        row :shipping_address do
-          if order.shipping_info?
-            #TODO: shipping info
-            #table_for order.admin_notes
-          else
-            'None'
-          end
-        end
-        row :shipping_phone
-        row :email
-      end
-
-    end
-
-    panel "Seller Information" do
-      attributes_table_for order do
-        #TODO: fill this in
-        row :partner_name
-        row :address
-        row :phone
-        row :email
-        row :sales_contacts do
-          #TODO: add sales contacts
-          #table_for
-        end
-      end
-      link_to "artsy.net" do
-        button "View Partner in Admin-Partners"
-      end
-    end
-  end
-  
 end
-
-
-
-

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,8 +16,10 @@ class Order < ApplicationRecord
     APPROVED = 'approved'.freeze,
     # Items have been deemed unavailable and hold is voided.
     CANCELED = 'canceled'.freeze,
-    # Order is completly fulfilled by the seller
-    FULFILLED = 'fulfilled'.freeze
+    # Order is completely fulfilled by the seller
+    FULFILLED = 'fulfilled'.freeze.freeze,
+    # Order was refunded after approval/fulfillment
+    REFUNDED = 'refunded'.freeze
   ].freeze
 
   REASONS = {
@@ -38,7 +40,7 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  ACTIONS = %i[abandon submit approve reject fulfill seller_lapse].freeze
+  ACTIONS = %i[abandon submit approve reject fulfill seller_lapse refund].freeze
   ACTION_REASONS = {
     seller_lapse: REASONS[CANCELED][:seller_lapsed],
     reject: REASONS[CANCELED][:seller_rejected]
@@ -166,6 +168,7 @@ class Order < ApplicationRecord
     machine.when(:seller_lapse, SUBMITTED => CANCELED)
     machine.when(:cancel, SUBMITTED => CANCELED)
     machine.when(:fulfill, APPROVED => FULFILLED)
+    machine.when(:refund, APPROVED => REFUNDED, FULFILLED => REFUNDED)
     machine.on(:any) do
       self.state = machine.state
     end

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -23,6 +23,15 @@ class OrderCancellationService
     @order.transactions << @transaction if @transaction.present?
   end
 
+  def refund!
+    @order.refund! do
+      refund
+    end
+    PostNotificationJob.perform_later(@order.id, Order::REFUNDED, @by)
+  ensure
+    @order.transactions << @transaction if @transaction.present?
+  end
+
   private
 
   def refund

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: Order::SUBMITTED) }
+  let(:order_state) { Order::SUBMITTED }
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
-
+  let(:artwork_inventory_deduct_request_status) { 200 }
+  let(:edition_set_inventory_deduct_request_status) { 200 }
+  let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
+  let(:edition_set_inventory_undeduct_request) do
+    stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json)
+  end
   describe '#reject!' do
-    let(:artwork_inventory_deduct_request_status) { 200 }
-    let(:edition_set_inventory_deduct_request_status) { 200 }
-    let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
-    let(:edition_set_inventory_undeduct_request) do
-      stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json)
-    end
     context 'with a successful refund' do
       before do
         artwork_inventory_undeduct_request
@@ -59,12 +59,6 @@ describe OrderCancellationService, type: :services do
   end
 
   describe '#seller_lapse!' do
-    let(:artwork_inventory_deduct_request_status) { 200 }
-    let(:edition_set_inventory_deduct_request_status) { 200 }
-    let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: artwork_inventory_deduct_request_status, body: {}.to_json) }
-    let(:edition_set_inventory_undeduct_request) do
-      stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: edition_set_inventory_deduct_request_status, body: {}.to_json)
-    end
     context 'with a successful refund' do
       before do
         artwork_inventory_undeduct_request
@@ -111,12 +105,50 @@ describe OrderCancellationService, type: :services do
   end
 
   describe '#refund!' do
-    context 'approved order' do
-      it 'refunds the order' do
-      end
-      it 'undeducts inventory' do
-      end
-      it 'captures refund transaction' do
+    [Order::APPROVED, Order::FULFILLED].each do |state|
+      context "#{state} order" do
+        let(:order_state) { state }
+        context 'with a successful refund' do
+          before do
+            artwork_inventory_undeduct_request
+            edition_set_inventory_undeduct_request
+            service.refund!
+          end
+          it 'calls to undeduct inventory' do
+            expect(artwork_inventory_undeduct_request).to have_been_requested
+            expect(edition_set_inventory_undeduct_request).to have_been_requested
+          end
+          it 'records the transaction' do
+            expect(order.transactions.last.external_id).to_not eq nil
+            expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+            expect(order.transactions.last.status).to eq Transaction::SUCCESS
+          end
+          it 'updates the order state' do
+            expect(order.state).to eq Order::REFUNDED
+          end
+          it 'queues notification job' do
+            expect(PostNotificationJob).to have_been_enqueued.with(order.id, Order::REFUNDED, user_id)
+          end
+        end
+        context 'with an unsuccessful refund' do
+          before do
+            artwork_inventory_undeduct_request
+            edition_set_inventory_undeduct_request
+            allow(Stripe::Refund).to receive(:create)
+              .with(hash_including(charge: captured_charge.id))
+              .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+            expect { service.refund! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
+          end
+          it 'raises a ProcessingError and records the transaction' do
+            expect(order.transactions.last.external_id).to eq captured_charge.id
+            expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+            expect(order.transactions.last.status).to eq Transaction::FAILURE
+          end
+          it 'does not undeduct inventory' do
+            expect(artwork_inventory_undeduct_request).not_to have_been_requested
+            expect(edition_set_inventory_undeduct_request).not_to have_been_requested
+          end
+        end
       end
     end
   end

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -109,4 +109,15 @@ describe OrderCancellationService, type: :services do
       end
     end
   end
+
+  describe '#refund!' do
+    context 'approved order' do
+      it 'refunds the order' do
+      end
+      it 'undeducts inventory' do
+      end
+      it 'captures refund transaction' do
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem
We want admins to be able to refund an order.

# Solution
Added a new _refund_ `action_item` to Order show page. This button only shows up for `approved` and `fulfilled` orders.

Also added a  new `REFUNDED` status to `Order` and used it from newly added `OrderCancellationService.refund!` method. 