### PR TITLE
More generic `seller_type`

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -326,6 +326,7 @@ type PageInfo {
 
 type Partner {
   id: String!
+  type: String!
 }
 
 type Pickup {

--- a/app/graphql/types/order_party_union_type.rb
+++ b/app/graphql/types/order_party_union_type.rb
@@ -1,5 +1,6 @@
 class Types::Partner < Types::BaseObject
   field :id, String, null: false
+  field :type, String, null: false
 end
 
 class Types::User < Types::BaseObject
@@ -13,10 +14,8 @@ class Types::OrderPartyUnionType < Types::BaseUnion
     case object.type
     when Order::USER
       Types::User
-    when Order::PARTNER
-      Types::Partner
     else
-      raise "Unexpected Return value: #{object.inspect}"
+      Types::Partner
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -49,10 +49,7 @@ class Order < ApplicationRecord
     PARTNER = 'partner'.freeze
   ].freeze
 
-  SELLER_TYPES = [
-    AUCTION = 'auction'.freeze,
-    GALLERY = 'gallery'.freeze
-  ].freeze
+  AUCTION_SELLER_TYPE = 'auction'.freeze
 
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'
   has_many :transactions, dependent: :destroy
@@ -98,7 +95,7 @@ class Order < ApplicationRecord
   end
 
   def auction_seller?
-    seller_type == AUCTION
+    seller_type == AUCTION_SELLER_TYPE
   end
 
   def to_s

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -49,6 +49,11 @@ class Order < ApplicationRecord
     PARTNER = 'partner'.freeze
   ].freeze
 
+  SELLER_TYPES = [
+    AUCTION = 'auction'.freeze,
+    GALLERY = 'gallery'.freeze
+  ].freeze
+
   has_many :line_items, dependent: :destroy, class_name: 'LineItem'
   has_many :transactions, dependent: :destroy
   has_many :state_histories, dependent: :destroy
@@ -90,6 +95,10 @@ class Order < ApplicationRecord
 
   def payment_info?
     credit_card_id.present?
+  end
+
+  def auction_seller?
+    seller_type == AUCTION
   end
 
   def to_s

--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -18,7 +18,7 @@ class CreateOrderService
         buyer_id: @user_id,
         buyer_type: Order::USER,
         seller_id: @artwork[:partner][:_id],
-        seller_type: Order::PARTNER,
+        seller_type: @artwork[:partner][:type].downcase,
         currency_code: @artwork[:price_currency],
         state: Order::PENDING,
         state_updated_at: Time.now.utc,

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -92,7 +92,7 @@ class OrderSubmitService
       buyer_type: @order.buyer_type,
       seller_id: @order.seller_id,
       seller_type: @order.seller_type,
-      type: @order.seller_type == 'auction' ? 'auction-bn' : 'bn-mo'
+      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo'
     }
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -92,7 +92,7 @@ class OrderSubmitService
       buyer_type: @order.buyer_type,
       seller_id: @order.seller_id,
       seller_type: @order.seller_type,
-      type: 'bn-mo'
+      type: @order.seller_type == 'auction' ? 'auction-bn' : 'bn-mo'
     }
   end
 end

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -92,6 +92,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.currency_code).to eq 'USD'
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
+                expect(order.seller_type).to eq 'gallery'
                 expect(order.line_items.count).to eq 1
                 expect(order.line_items.first.price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'


### PR DESCRIPTION
# Problem
For Auction Buy Now works, we want to use a different `type` for Stripe's `metadata` when creating charges.

https://artsyproduct.atlassian.net/browse/PURCHASE-547

# Solution
Currently `seller_type` was hardcoded to be `partner`, we now make sure `seller_type` reflects the `partner[:type]` of the artwork. This way we store the partner type at the time of order on `Order` properly.

We use ☝️ to detect what should we send Stripe for `type` field of charge metadata. 

We also updated `OrderPartyUnion` to work with new cases of `seller_type` field.

# Migration
```ruby
Order.update_all!(seller_type: 'gallery')
```