### PR TITLE
Fix broken seller mutations

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,6 +1,6 @@
 class Mutations::BaseMutation < GraphQL::Schema::RelayClassicMutation
   def validate_seller_request!(order)
-    raise Errors::ValidationError, :not_found unless order.seller_type == Order::PARTNER && context[:current_user]['partner_ids'].include?(order.seller_id)
+    raise Errors::ValidationError, :not_found unless order.seller_type != Order::USER && context[:current_user]['partner_ids'].include?(order.seller_id)
   end
 
   def validate_buyer_request!(order)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -58,7 +58,7 @@ class Types::QueryType < Types::BaseObject
   def validate_order_request!(order)
     return if trusted? || sales_admin? ||
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
-              (order.seller_type == Order::PARTNER && context[:current_user][:partner_ids].include?(order.seller_id))
+              (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
     raise Errors::AuthError, :not_found
   end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -23,7 +23,7 @@ describe OrderEvent, type: :events do
               buyer_type: Order::USER,
               buyer_phone_number: '00123459876',
               seller_id: partner_id,
-              seller_type: Order::PARTNER,
+              seller_type: 'gallery',
               currency_code: 'usd',
               shipping_total_cents: 50,
               tax_total_cents: 30,
@@ -83,7 +83,7 @@ describe OrderEvent, type: :events do
       expect(event.properties[:buyer_type]).to eq Order::USER
       expect(event.properties[:fulfillment_type]).to eq Order::SHIP
       expect(event.properties[:seller_id]).to eq partner_id
-      expect(event.properties[:seller_type]).to eq Order::PARTNER
+      expect(event.properties[:seller_type]).to eq 'gallery'
       expect(event.properties[:items_total_cents]).to eq 300
       expect(event.properties[:shipping_total_cents]).to eq 50
       expect(event.properties[:tax_total_cents]).to eq 30

--- a/spec/fabricators/order_fabricator.rb
+++ b/spec/fabricators/order_fabricator.rb
@@ -3,7 +3,7 @@ Fabricator(:order) do
   buyer_id { sequence(:user_id) { |i| "user-id-#{i}" } }
   buyer_type { 'user' }
   seller_id { sequence(:partner_id) { |i| "partner-id-#{i}" } }
-  seller_type { 'partner' }
+  seller_type { 'gallery' }
   state { Order::PENDING }
   items_total_cents { 0 }
   currency_code { 'USD' }


### PR DESCRIPTION
# Cause
After #220 was merged, we no longer have `seller_type` as `partner` and in `BaseMutation` when checking for user's access to order we were checking if `seller_type` is `partner` then check the `id`.

# Fix
Check if `seller_type` is NOT `user` then check for partner id.