### PR TITLE
Add commission_rate and processing_fee_schedule to line item

### DIFF
--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -25,6 +25,8 @@ class Types::OrderType < Types::BaseObject
   field :state_expires_at, Types::DateTimeType, null: true
   field :last_submitted_at, Types::DateTimeType, null: true
   field :last_approved_at, Types::DateTimeType, null: true
+  field :commission_rate, Float, null: true
+  field :display_commission_rate, String, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
 
   def buyer
@@ -48,5 +50,15 @@ class Types::OrderType < Types::BaseObject
     return if object.fulfillment_type.blank?
 
     object
+  end
+
+  def display_commission_rate
+    return if object.commission_rate.nil?
+
+    ActiveSupport::NumberHelper.number_to_percentage(
+      object.commission_rate * 100,
+      precision: 2,
+      strip_insignificant_zeros: true
+    )
   end
 end

--- a/app/services/order_total_updater_service.rb
+++ b/app/services/order_total_updater_service.rb
@@ -14,6 +14,7 @@ class OrderTotalUpdaterService
       @order.buyer_total_cents = @order.items_total_cents + @order.shipping_total_cents.to_i + @order.tax_total_cents.to_i
       if @commission_rate.present?
         set_commission_on_line_items
+        @order.commission_rate = @commission_rate
         @order.commission_fee_cents = @order.line_items.map(&:commission_fee_cents).sum
       end
       @order.transaction_fee_cents = calculate_transaction_fee

--- a/db/migrate/20181009163308_add_commission_rate_to_order.rb
+++ b/db/migrate/20181009163308_add_commission_rate_to_order.rb
@@ -1,0 +1,7 @@
+class AddCommissionRateToOrder < ActiveRecord::Migration[5.2]
+  def change
+    change_table :orders, bulk: true do |t|
+      t.column :commission_rate, :float
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_03_191806) do
+ActiveRecord::Schema.define(version: 2018_10_09_163308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2018_10_03_191806) do
     t.integer "seller_total_cents"
     t.string "buyer_phone_number"
     t.string "state_reason"
+    t.float "commission_rate"
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["seller_id"], name: "index_orders_on_seller_id"

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -20,6 +20,7 @@ describe Api::GraphqlController, type: :request do
         updated_at: 1.day.ago,
         shipping_total_cents: 100_00,
         commission_fee_cents: 50_00,
+        commission_rate: 0.10,
         seller_total_cents: 50_00,
         buyer_total_cents: 100_00,
         items_total_cents: 0,
@@ -52,6 +53,7 @@ describe Api::GraphqlController, type: :request do
             sellerTotalCents
             buyerTotalCents
             createdAt
+            displayCommissionRate
             lineItems {
               edges {
                 node {
@@ -134,6 +136,11 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.seller_total_cents).to eq 50_00
         expect(result.data.order.buyer_total_cents).to eq 100_00
         expect(result.data.order.created_at).to eq created_at.iso8601
+      end
+
+      it 'formats line item commission_rate into a display string' do
+        result = client.execute(query, id: user1_order1.id)
+        expect(result.data.order.display_commission_rate).to eq '10%'
       end
 
       Order::STATES.each do |state|


### PR DESCRIPTION
Adds new fields to line item and exposes formatted display strings via GraphQL as part of [SELL-976](https://artsyproduct.atlassian.net/browse/SELL-976). Initial pass based off of discussions in Slack [here](https://artsy.slack.com/archives/CB110C6LE/p1539027899000100) and [here](https://artsy.slack.com/archives/CB110C6LE/p1539027970000100).

From the discussion [here](https://artsy.slack.com/archives/CB110C6LE/p1539026352000100), the current plan is to display the transaction fee as "3%" even though we calculate the fee using 2.9% + $0.30, and this may change in the future.