### PR TITLE
Add Orders sorting over state_expires_at

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -195,9 +195,11 @@ type Order {
   buyerTotalCents: Int
   code: String!
   commissionFeeCents: Int
+  commissionRate: Float
   createdAt: DateTime!
   creditCardId: String
   currencyCode: String!
+  displayCommissionRate: String
   id: ID!
   itemsTotalCents: Int!
   lastApprovedAt: DateTime
@@ -230,6 +232,12 @@ type Order {
 
 # Fields to sort by
 enum OrderConnectionSortEnum {
+  # Sort by the timestamp the state of the order expires at in ascending order
+  STATE_EXPIRES_AT_ASC
+
+  # Sort by the timestamp the state of the order expires at in descending order
+  STATE_EXPIRES_AT_DESC
+
   # Sort by the timestamp the state of order was last updated in ascending order
   STATE_UPDATED_AT_ASC
 
@@ -294,6 +302,9 @@ enum OrderStateEnum {
 
   # order is still pending submission by buyer
   PENDING
+
+  # order is refunded after being approved or fulfilled
+  REFUNDED
 
   # order is submitted by buyer
   SUBMITTED

--- a/app/graphql/types/order_connection_sort_enum.rb
+++ b/app/graphql/types/order_connection_sort_enum.rb
@@ -6,4 +6,6 @@ class Types::OrderConnectionSortEnum < Types::BaseEnum
   value 'UPDATED_AT_DESC', 'Sort by the timestamp the order was last updated in descending order'
   value 'STATE_UPDATED_AT_ASC', 'Sort by the timestamp the state of order was last updated in ascending order'
   value 'STATE_UPDATED_AT_DESC', 'Sort by the timestamp the state of order was last updated in descending order'
+  value 'STATE_EXPIRES_AT_ASC', 'Sort by the timestamp the state of the order expires at in ascending order'
+  value 'STATE_EXPIRES_AT_DESC', 'Sort by the timestamp the state of the order expires at in descending order'
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -29,23 +29,22 @@ class Types::QueryType < Types::BaseObject
   def orders(params)
     validate_orders_request!(params)
     sort = params.delete(:sort)
-    query = Order.where(params)
-
-    case sort
-    when 'UPDATED_AT_ASC'
-      query.order(updated_at: :asc)
-    when 'UPDATED_AT_DESC'
-      query.order(updated_at: :desc)
-    when 'STATE_UPDATED_AT_ASC'
-      query.order(state_updated_at: :asc)
-    when 'STATE_UPDATED_AT_DESC'
-      query.order(state_updated_at: :desc)
-    else
-      query
-    end
+    order_clause = sort_to_order[sort] || {}
+    Order.where(params).order(order_clause)
   end
 
   private
+
+  def sort_to_order
+    {
+      'UPDATED_AT_ASC' => { updated_at: :asc },
+      'UPDATED_AT_DESC' => { updated_at: :desc },
+      'STATE_UPDATED_AT_ASC' => { state_updated_at: :asc },
+      'STATE_UPDATED_AT_DESC' => { state_updated_at: :desc },
+      'STATE_EXPIRES_AT_ASC' => { state_expires_at: :asc },
+      'STATE_EXPIRES_AT_DESC' => { state_expires_at: :desc }
+    }
+  end
 
   def trusted?
     context[:current_user][:roles].include?('trusted')

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -119,6 +119,22 @@ describe Api::GraphqlController, type: :request do
         ids = ids_from_result_data(result)
         expect(ids).to eq([user1_order1.id, user1_order2.id])
       end
+
+      it 'sorts by state_expires_at in ascending order' do
+        user1_order1.update!(state_expires_at: 1.day.from_now)
+        user1_order2.update!(state_expires_at: 2.days.from_now)
+        result = client.execute(query, buyerId: user_id, sort: 'STATE_EXPIRES_AT_ASC')
+        ids = ids_from_result_data(result)
+        expect(ids).to eq([user1_order1.id, user1_order2.id])
+      end
+
+      it 'sorts by state_expires_at in descending order' do
+        user1_order1.update!(state_expires_at: 1.day.from_now)
+        user1_order2.update!(state_expires_at: 2.days.from_now)
+        result = client.execute(query, buyerId: user_id, sort: 'STATE_EXPIRES_AT_DESC')
+        ids = ids_from_result_data(result)
+        expect(ids).to eq([user1_order2.id, user1_order1.id])
+      end
     end
 
     context 'trusted user rules' do


### PR DESCRIPTION
As part of [SELL-1042](https://artsyproduct.atlassian.net/browse/SELL-1042), enable orders to be sorted over `state_expires_at`. This will enable Volt to sort its "Ready to Ship" tab to show the soonest to expire orders to the top.