### PR TITLE
Make postal code optional

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -186,6 +186,6 @@ class Order < ApplicationRecord
   end
 
   def complete_shipping_details?
-    [shipping_name, shipping_address_line1, shipping_city, shipping_country, shipping_postal_code, buyer_phone_number].all?(&:present?)
+    [shipping_name, shipping_address_line1, shipping_city, shipping_country, buyer_phone_number].all?(&:present?)
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -214,4 +214,27 @@ RSpec.describe Order, type: :model do
       end
     end
   end
+
+  describe 'shipping_info?' do
+    context 'SHIP' do
+      let(:order_shipping_params) { { fulfillment_type: Order::SHIP, shipping_name: 'Col', shipping_address_line1: 'Address line', shipping_city: 'Brooklyn', shipping_country: 'US', buyer_phone_number: '123' } }
+      it 'does not require postal code' do
+        order = Fabricate(:order, fulfillment_type: Order::SHIP, shipping_name: 'Col', shipping_address_line1: 'Address line', shipping_city: 'Brooklyn', shipping_country: 'US', buyer_phone_number: '123')
+        expect(order.shipping_info?).to be true
+      end
+
+      %i[shipping_name shipping_address_line1 shipping_city shipping_country buyer_phone_number].each do |attr|
+        it "requires #{attr}" do
+          order = Fabricate(:order, order_shipping_params.except(attr))
+          expect(order.shipping_info?).to be false
+        end
+      end
+    end
+    context 'PICKUP' do
+      it 'does not require any shipping field' do
+        order = Fabricate(:order, fulfillment_type: Order::PICKUP, shipping_name: nil, shipping_address_line1: nil, shipping_city: nil, shipping_country: nil, buyer_phone_number: nil)
+        expect(order.shipping_info?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-564

Postal code is not mandatory for submitting an order.

# Solution
Remove it from the list of mandatory shipping fields and add spec for it.