### PR TITLE
Stripe Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ Exchange aspires to be responsible for the various types of e-commerce interacti
 * GitHub: https://github.com/artsy/exchange/
 * Point People: [@ashkan18][ashkan18], [@williardx][williardx]
 
+
+## Deployment
+### Staging
+PRs merged to `master` are automatically deployed to staging by CI.
+
+### Production
+Mention in #dev slack channel that you are going to deploy and then run:
+```
+hokusai pipeline promote --git-remote upstream
+```
+Assuming `upstream` points to Artsy's repository.
+
 ## Setup
 
 * Fork the project to your GitHub account

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -7,7 +7,7 @@ module Api
       error!('Missing required header.', 400) unless sig_header
       begin
         event = Stripe::Webhook.construct_event(request.body.read, signature_header, Rails.application.config_for(:stripe)['webhook_secret'])
-        WebhookService.process_stripe_event(event)
+        StripeWebhookService.new(event).process!
       rescue JSON::ParserError => e
         error!('Invalid payload.', 400)
       rescue Stripe::SignatureVerificationError => e

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  class WebhookController < Api::BaseApiController
+    skip_before_action :authenticate_request!
+
+    def stripe
+      signature_header = request.headers['Stripe-Signature']
+      error!('Missing required header.', 400) unless sig_header
+      begin
+        event = Stripe::Webhook.construct_event(request.body.read, signature_header, Rails.application.config_for(:stripe)['webhook_secret'])
+        WebhookService.process_stripe_event(event)
+      rescue JSON::ParserError => e
+        error!('Invalid payload.', 400)
+      rescue Stripe::SignatureVerificationError => e
+        Rails.logger.info("Received request with invalid stripe signature: #{sig_header}")
+        error!('Invalid request header.', 400)
+      end
+    end
+
+    private
+
+    def stripe_params
+      params.require(:id)
+    end
+  end
+end

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -1,25 +1,19 @@
 module Api
-  class WebhookController < Api::BaseApiController
+  class WebhooksController < Api::BaseApiController
     skip_before_action :authenticate_request!
 
     def stripe
       signature_header = request.headers['Stripe-Signature']
-      error!('Missing required header.', 400) unless sig_header
+      error!('Missing required header.', 400) unless signature_header
       begin
         event = Stripe::Webhook.construct_event(request.body.read, signature_header, Rails.application.config_for(:stripe)['webhook_secret'])
         StripeWebhookService.new(event).process!
       rescue JSON::ParserError => e
-        error!('Invalid payload.', 400)
+        render json: { error: 'Invalid payload' }, status: 400
       rescue Stripe::SignatureVerificationError => e
-        Rails.logger.info("Received request with invalid stripe signature: #{sig_header}")
-        error!('Invalid request header.', 400)
+        Rails.logger.info("Received request with invalid stripe signature: #{signature_header}")
+        render json: { error: 'Invalid request header' }, status: 400
       end
-    end
-
-    private
-
-    def stripe_params
-      params.require(:id)
     end
   end
 end

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -8,11 +8,11 @@ module Api
       begin
         event = Stripe::Webhook.construct_event(request.body.read, signature_header, Rails.application.config_for(:stripe)['webhook_secret'])
         StripeWebhookService.new(event).process!
-      rescue JSON::ParserError => e
-        render json: { error: 'Invalid payload' }, status: 400
-      rescue Stripe::SignatureVerificationError => e
+      rescue JSON::ParserError
+        render json: { error: 'Invalid payload' }, status: :bad_request
+      rescue Stripe::SignatureVerificationError
         Rails.logger.info("Received request with invalid stripe signature: #{signature_header}")
-        render json: { error: 'Invalid request header' }, status: 400
+        render json: { error: 'Invalid request header' }, status: :bad_request
       end
     end
   end

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -47,6 +47,8 @@ module Errors
       tax_recording_failure
       tax_calculator_failure
       tax_refund_failure
+      unknown_event_charge
+      received_partial_refund
     ],
     internal: %i[
       generic

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -182,6 +182,6 @@ class Order < ApplicationRecord
   end
 
   def complete_shipping_details?
-    [shipping_name, shipping_address_line1, shipping_city, shipping_country, shipping_postal_code, buyer_phone_number].all?(&:present?)
+    [shipping_name, shipping_address_line1, shipping_city, shipping_country, buyer_phone_number].all?(&:present?)
   end
 end

--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -10,7 +10,7 @@ class StripeWebhookService
     when 'charge.refunded'
       process_refund_event
     else
-      Rails.logger.debug("ignore event #{event[:id]} with type: #{event[:type]}")
+      Rails.logger.debug("ignore event #{@event[:id]} with type: #{@event[:type]}")
     end
   end
 
@@ -20,6 +20,7 @@ class StripeWebhookService
     order = Order.find_by(external_charge_id: @event.data.object.id)
     raise Errors::ProcessingError.new(:unknown_event_charge, event_id: @event.id, charge_id: @event.data.object.id) unless order
     raise Errors::ProcessingError.new(:received_partial_refund, event_id: @event.id, charge_id: @event.data.object.id) unless @event.data.object.refunded
+
     order.refund! do
       order.transactions.create!(external_id: @event.id, destination_id: @event.data.object.destination_id, source_id: @event.data.object.source.id, amount_cents: @event.data.object.amount, status: Transaction::SUCCESS, transaction_type: Transaction::REFUND)
     end

--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -1,0 +1,28 @@
+class StripeWebhookService
+  PROCESSED_EVENT_TYPES = %w[charge.refunded charge.failed].freeze
+
+  def initialize(event)
+    @event = event
+  end
+
+  def process!
+    case @event.type
+    when 'charge.refunded'
+      process_refund_event
+    else
+      Rails.logger.debug("ignore event #{event[:id]} with type: #{event[:type]}")
+    end
+  end
+
+  private
+
+  def process_refund_event
+    order = Order.find_by(external_charge_id: @event.data.object.id)
+    raise Errors::ProcessingError.new(:unknown_event_charge, event_id: @event.id, charge_id: @event.data.object.id) unless order
+    raise Errors::ProcessingError.new(:received_partial_refund, event_id: @event.id, charge_id: @event.data.object.id) unless @event.data.object.refunded
+    order.refund! do
+      order.transaction.create(external_id: @event.id, destination_id: @event.data.object.destination_id, source_id: @event.data.object.source.id, amount_cents: @event.data.object.amount, status: Transaction::SUCCESS, transaction_type: Transaction::REFUND)
+    end
+    order.line_items.each { |li| GravityService.undeduct_inventory(li) }
+  end
+end

--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -21,7 +21,7 @@ class StripeWebhookService
     raise Errors::ProcessingError.new(:unknown_event_charge, event_id: @event.id, charge_id: @event.data.object.id) unless order
     raise Errors::ProcessingError.new(:received_partial_refund, event_id: @event.id, charge_id: @event.data.object.id) unless @event.data.object.refunded
     order.refund! do
-      order.transaction.create(external_id: @event.id, destination_id: @event.data.object.destination_id, source_id: @event.data.object.source.id, amount_cents: @event.data.object.amount, status: Transaction::SUCCESS, transaction_type: Transaction::REFUND)
+      order.transactions.create!(external_id: @event.id, destination_id: @event.data.object.destination_id, source_id: @event.data.object.source.id, amount_cents: @event.data.object.amount, status: Transaction::SUCCESS, transaction_type: Transaction::REFUND)
     end
     order.line_items.each { |li| GravityService.undeduct_inventory(li) }
   end

--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -19,6 +19,7 @@ class StripeWebhookService
   def process_refund_event
     order = Order.find_by(external_charge_id: @event.data.object.id)
     raise Errors::ProcessingError.new(:unknown_event_charge, event_id: @event.id, charge_id: @event.data.object.id) unless order
+    return if order.state == Order::REFUNDED # ignore if it's already refunded
     raise Errors::ProcessingError.new(:received_partial_refund, event_id: @event.id, charge_id: @event.data.object.id) unless @event.data.object.refunded
 
     order.refund! do

--- a/app/services/webhook_service.rb
+++ b/app/services/webhook_service.rb
@@ -1,0 +1,4 @@
+class WebhookService
+  def self.process_stripe_event(event)
+  end
+end

--- a/app/services/webhook_service.rb
+++ b/app/services/webhook_service.rb
@@ -1,4 +1,0 @@
-class WebhookService
-  def self.process_stripe_event(event)
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   namespace :api do
     post '/graphql', to: 'graphql#execute'
     get '/health', to: 'health#index'
-    post '/webhooks/stripe', to: 'webhook#stripe'
+    post '/webhooks/stripe', to: 'webhooks#stripe'
   end
   resources :admin_notes
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   namespace :api do
     post '/graphql', to: 'graphql#execute'
     get '/health', to: 'health#index'
+    post '/webhooks/stripe', to: 'webhook#stripe'
   end
   resources :admin_notes
 end

--- a/config/stripe.yml
+++ b/config/stripe.yml
@@ -1,5 +1,6 @@
 development: &default
   stripe_api_key: <%= ENV['STRIPE_API_KEY'] || '' %>
+  webhook_secret: <%= ENV['STRIPE_WEBHOOK_SECRET'] || 'https://media.giphy.com/media/NdKVEei95yvIY/giphy.gif' %>
 test:
   <<: *default
 production:

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -45,7 +45,7 @@ describe Api::WebhooksController, type: :request do
     it 'ignores events we dont care about' do
       allow(Stripe::Webhook).to receive(:construct_event).and_return(random_event)
       post '/api/webhooks/stripe', params: random_event_payload, headers: { 'HTTP_STRIPE_SIGNATURE' => 'test_header' }
-      expect(response.status).to eq 201
+      expect(response.status).to eq 204
       expect(order.reload.transactions.count).to eq 0
     end
   end

--- a/spec/controllers/api/webhooks_controller_spec.rb
+++ b/spec/controllers/api/webhooks_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe Api::WebhooksController, type: :request do
+  describe '@POST #api/webhooks/stripe' do
+    include_context 'use stripe mock'
+    let(:state) { Order::APPROVED }
+    let(:external_charge_id) { 'ch_some_id' }
+    let!(:order) { Fabricate(:order, state: state, external_charge_id: external_charge_id) }
+    let!(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'artwork-1') }
+    let(:event_charge_id) { external_charge_id }
+    let(:fully_refunded) { true }
+    let(:charge_refunded_payload) do
+      StripeMock.mock_webhook_payload(
+        'charge.refunded',
+        id: event_charge_id,
+        refunded: fully_refunded,
+        destination_id: 'mer_123'
+      )
+    end
+    let(:charge_refunded_event) do
+      StripeMock.mock_webhook_event(
+        'charge.refunded',
+        id: event_charge_id,
+        refunded: fully_refunded,
+        destination_id: 'mer_123'
+      )
+    end
+    let(:random_event_payload) { StripeMock.mock_webhook_payload('plan.updated') }
+    let(:random_event) { StripeMock.mock_webhook_event('plan.updated') }
+    it 'returns 400 for unauthorized requests with wrong signature' do
+      allow(Stripe::Webhook).to receive(:construct_event).and_raise(Stripe::SignatureVerificationError.new('invalid signature', '402'))
+      post '/api/webhooks/stripe', params: charge_refunded_payload, headers: { 'HTTP_STRIPE_SIGNATURE' => 'test_header' }
+      expect(response.status).to eq 400
+    end
+    it 'refunds the order' do
+      allow(Stripe::Webhook).to receive(:construct_event).and_return(charge_refunded_event)
+      expect(GravityService).to receive(:undeduct_inventory).once.with(line_item)
+      post '/api/webhooks/stripe', params: charge_refunded_payload, headers: { 'HTTP_STRIPE_SIGNATURE' => 'test_header' }
+      expect(response.status).to eq 204
+      expect(order.reload.state).to eq Order::REFUNDED
+      new_transaction = order.transactions.last
+      expect(new_transaction.external_id).to eq charge_refunded_event.id
+      expect(new_transaction.source_id).to eq charge_refunded_event.data.object.source.id
+    end
+    it 'ignores events we dont care about' do
+      allow(Stripe::Webhook).to receive(:construct_event).and_return(random_event)
+      post '/api/webhooks/stripe', params: random_event_payload, headers: { 'HTTP_STRIPE_SIGNATURE' => 'test_header' }
+      expect(response.status).to eq 201
+      expect(order.reload.transactions.count).to eq 0
+    end
+  end
+end

--- a/spec/services/stripe_webhook_service_spec.rb
+++ b/spec/services/stripe_webhook_service_spec.rb
@@ -52,5 +52,13 @@ describe StripeWebhookService, type: :services do
         expect(new_transaction.source_id).to eq charge_refunded_event.data.object.source.id
       end
     end
+
+    context 'already refunded order' do
+      let(:state) { Order::REFUNDED }
+      it 'does not update the order' do
+        expect(GravityService).not_to receive(:undeduct_inventory)
+        expect { service.process! }.to change(order.transactions, :count).by(0)
+      end
+    end
   end
 end

--- a/spec/services/stripe_webhook_service_spec.rb
+++ b/spec/services/stripe_webhook_service_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe StripeWebhookService, type: :services do
+  include_context 'use stripe mock'
+  let(:state) { Order::APPROVED }
+  let(:external_charge_id) { 'ch_some_id' }
+  let!(:order) { Fabricate(:order, state: state, external_charge_id: external_charge_id) }
+  let!(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'artwork-1') }
+
+  context 'charge.refunded event' do
+    let(:event_charge_id) { external_charge_id }
+    let(:fully_refunded) { true }
+    let(:charge_refunded_event) { StripeMock.mock_webhook_event('charge.refunded', id: event_charge_id, refunded: fully_refunded) }
+    let(:service) { StripeWebhookService.new(charge_refunded_event) }
+    context 'unknown charge id' do
+      let(:event_charge_id) { 'ch_random' }
+      it 'raises unknown_event_charge' do
+        expect { service.process! }.to raise_error do |e|
+          expect(e.type).to eq :processing
+          expect(e.code).to eq :unknown_event_charge
+          expect(e.data[:event_id]).to eq charge_refunded_event.id
+          expect(e.data[:charge_id]).to eq event_charge_id
+        end
+      end
+    end
+    context 'known charge id' do
+      it 'stores transaction and refunds the charge' do
+      end
+      it 'undeducts inventory' do
+      end
+    end
+    context 'partial refunds' do
+      let(:fully_refunded) { false }
+      it 'raises unknown_event_charge' do
+        expect { service.process! }.to raise_error do |e|
+          expect(e.type).to eq :processing
+          expect(e.code).to eq :received_partial_refund
+          expect(e.data[:event_id]).to eq charge_refunded_event.id
+          expect(e.data[:charge_id]).to eq event_charge_id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Problem
When partner's setup their Stripe account, they get full access to Stripe's dashboard. They refund charges from their dashboard (it's really hard to do it from there, but it's possible 🤷‍♂️ )

Stripe can send us webhooks on different events, we want to be sync with Stripe data and know if a charge got refunded on the dashboard.

# Change
Add a new `@POST /api/webhooks/stripe` which will be used to receive Stripe's webhooks. Also added a new `StripeWebhookService` which will receive an event and in case of `charge.refund` it handles mark the charge as refunded on our system and undeduct the inventory.

One thing to note is, we do get these webhooks even if we are the one who initiated the refund, so we need to make sure we ignore these webhooks if order is already refunded.

# Migration
We need to setup Stripe to deliver these events.
