### PR TITLE
Post Events on Failed Charges

### DIFF
--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -1,0 +1,53 @@
+class TransactionEvent < Events::BaseEvent
+  TOPIC = 'commerce'.freeze
+  ACTIONS = [
+    FAILED = 'failed'.freeze
+  ].freeze
+
+  def self.post(transaction, action, user_id)
+    event = new(user: user_id, action: action, model: transaction)
+    Artsy::EventService.post_event(topic: TOPIC, event: event)
+  end
+
+  def subject
+    {
+      id: @subject
+    }
+  end
+
+  def properties
+    order = @object.order
+    {
+      order: {
+        buyer_id: order.buyer_id,
+        buyer_total_cents: order.buyer_total_cents,
+        buyer_type: order.buyer_type,
+        code: order.code,
+        created_at: order.created_at,
+        currency_code: order.currency_code,
+        fulfillment_type: order.fulfillment_type,
+        items_total_cents: order.items_total_cents,
+        line_items: order.line_items.map { |li| line_item_detail(li) },
+        seller_id: order.seller_id,
+        seller_type: order.seller_type,
+        state: order.state,
+        state_reason: order.state_reason,
+        state_expires_at: order.state_expires_at,
+        updated_at: order.updated_at
+      },
+      failure_code: @object.failure_code,
+      failure_message: @object.failure_message,
+      transaction_type: @object.transaction_type
+    }
+  end
+
+  def line_item_detail(line_item)
+    {
+      price_cents: line_item.price_cents,
+      artwork_id: line_item.artwork_id,
+      edition_set_id: line_item.edition_set_id,
+      quantity: line_item.quantity,
+      commission_fee_cents: line_item.commission_fee_cents
+    }
+  end
+end

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -1,7 +1,7 @@
 class TransactionEvent < Events::BaseEvent
   TOPIC = 'commerce'.freeze
   ACTIONS = [
-    FAILED = 'failed'.freeze
+    CREATED = 'created'.freeze
   ].freeze
 
   def self.post(transaction, action, user_id)
@@ -37,7 +37,8 @@ class TransactionEvent < Events::BaseEvent
       },
       failure_code: @object.failure_code,
       failure_message: @object.failure_message,
-      transaction_type: @object.transaction_type
+      transaction_type: @object.transaction_type,
+      status: @object.status
     }
   end
 

--- a/app/jobs/post_transaction_notification_job.rb
+++ b/app/jobs/post_transaction_notification_job.rb
@@ -1,0 +1,8 @@
+class PostTransactionNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(transaction_id, action, user_id = nil)
+    transaction = Transaction.find(transaction_id)
+    TransactionEvent.post(transaction, action, user_id)
+  end
+end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -63,7 +63,7 @@ class OrderSubmitService
   end
 
   def notify_failed_charge
-    PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::FAILED, @by)
+    PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::CREATED, @by)
   end
 
   def construct_charge_params

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -63,7 +63,7 @@ class OrderSubmitService
   end
 
   def notify_failed_charge
-    PostNotificationJob.perform_later(@order.id, Order::SUBMITTED, @by)
+    PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::FAILED, @by)
   end
 
   def construct_charge_params

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe TransactionEvent, type: :events do
+  let(:partner_id) { 'partner-1' }
+  let(:user_id) { 'user-1' }
+  let(:shipping_info) do
+    {
+      fulfillment_type: Order::SHIP,
+      shipping_name: 'Fname Lname',
+      shipping_address_line1: '123 Main St',
+      shipping_address_line2: 'Apt 2',
+      shipping_city: 'Chicago',
+      shipping_country: 'USA',
+      shipping_postal_code: '60618',
+      shipping_region: 'IL'
+    }
+  end
+  let(:order) do
+    Fabricate(:order,
+              buyer_id: user_id,
+              buyer_type: Order::USER,
+              buyer_phone_number: '00123459876',
+              seller_id: partner_id,
+              seller_type: 'gallery',
+              currency_code: 'usd',
+              shipping_total_cents: 50,
+              tax_total_cents: 30,
+              items_total_cents: 300,
+              buyer_total_cents: 380,
+              **shipping_info)
+  end
+  let(:transaction) { Fabricate(:transaction, order: order, failure_code: 'stolen_card', failure_message: 'who stole it?') }
+  let(:line_item1) { Fabricate(:line_item, price_cents: 200, order: order, commission_fee_cents: 40) }
+  let(:line_item2) { Fabricate(:line_item, price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
+  let!(:line_items) { [line_item1, line_item2] }
+  let(:line_item_properties) do
+    [
+      {
+        price_cents: 200,
+        artwork_id: line_item1.artwork_id,
+        edition_set_id: line_item1.edition_set_id,
+        quantity: 1,
+        commission_fee_cents: 40
+      },
+      {
+        price_cents: 100,
+        artwork_id: line_item2.artwork_id,
+        edition_set_id: line_item2.edition_set_id,
+        quantity: 2,
+        commission_fee_cents: 20
+      }
+    ]
+  end
+  let(:event) { TransactionEvent.new(user: user_id, action: TransactionEvent::FAILED, model: transaction) }
+
+  describe 'post' do
+    it 'calls ArtsyEventService to post event' do
+      expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(TransactionEvent))
+      TransactionEvent.post(order, TransactionEvent::FAILED, user_id)
+    end
+  end
+
+  describe '#subject' do
+    it 'returns user id' do
+      expect(event.subject[:id]).to eq user_id
+    end
+  end
+
+  describe '#object' do
+    it 'returns order id' do
+      expect(event.object[:id]).to eq transaction.id.to_s
+    end
+  end
+
+  describe '#properties' do
+    it 'returns correct properties for a submitted order' do
+      order.submit!
+      expect(event.properties[:order][:code]).to eq order.code
+      expect(event.properties[:order][:currency_code]).to eq 'USD'
+      expect(event.properties[:order][:state]).to eq 'submitted'
+      expect(event.properties[:order][:buyer_id]).to eq user_id
+      expect(event.properties[:order][:buyer_type]).to eq Order::USER
+      expect(event.properties[:order][:fulfillment_type]).to eq Order::SHIP
+      expect(event.properties[:order][:seller_id]).to eq partner_id
+      expect(event.properties[:order][:seller_type]).to eq 'gallery'
+      expect(event.properties[:order][:items_total_cents]).to eq 300
+      expect(event.properties[:order][:updated_at]).not_to be_nil
+      expect(event.properties[:order][:created_at]).not_to be_nil
+      expect(event.properties[:order][:line_items].count).to eq 2
+      expect(event.properties[:order][:line_items]).to match_array(line_item_properties)
+      expect(event.properties[:failure_code]).to eq 'stolen_card'
+      expect(event.properties[:failure_message]).to eq 'who stole it?'
+    end
+  end
+end

--- a/spec/fabricators/transaction_fabricator.rb
+++ b/spec/fabricators/transaction_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:transaction) do
+  external_id { SecureRandom.hex(10) }
+  source_id { SecureRandom.hex(10) }
+  order { Fabricate(:order) }
+end

--- a/spec/jobs/post_transaction_notification_job_spec.rb
+++ b/spec/jobs/post_transaction_notification_job_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe PostTransactionNotificationJob, type: :job do
   let(:transaction) { Fabricate(:transaction, failure_code: 'stolen_card', failure_message: 'nvm! left the card at home', order: order) }
   it 'finds the transaction and posts the event' do
     expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(TransactionEvent))
-    PostTransactionNotificationJob.new.perform(transaction.id, TransactionEvent::FAILED, order.buyer_id)
+    PostTransactionNotificationJob.new.perform(transaction.id, TransactionEvent::CREATED, order.buyer_id)
   end
 end

--- a/spec/jobs/post_transaction_notification_job_spec.rb
+++ b/spec/jobs/post_transaction_notification_job_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe PostTransactionNotificationJob, type: :job do
+  let(:order) { Fabricate(:order) }
+  let(:transaction) { Fabricate(:transaction, failure_code: 'stolen_card', failure_message: 'nvm! left the card at home', order: order) }
+  it 'finds the transaction and posts the event' do
+    expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(TransactionEvent))
+    PostTransactionNotificationJob.new.perform(transaction.id, TransactionEvent::FAILED, order.buyer_id)
+  end
+end

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -156,6 +156,7 @@ describe OrderSubmitService, type: :services do
           allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
           allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
           expect(PostNotificationJob).not_to receive(:perform_later)
+          expect(PostTransactionNotificationJob).to receive(:perform_later)
           expect(OrderFollowUpJob).not_to receive(:perform_later)
           expect { service.process! }.to raise_error do |error|
             expect(error).to be_a(Errors::ProcessingError)


### PR DESCRIPTION
# Problem
CRT team wants to get notified every time a charge fails to get processed during BNMO checkout, similar to what they currently have in #fraud

# Solution
Added a new `TransactionEvent`, for now only with `failed` as the only possible action. We call this now from the `ensure` block in submit order service only if transaction failed.

# Follow up
- [ ] Update APRB to listen on these events and show proper messages.
- [ ] This adds new type of events to the same topic for transactions, make sure Pulse does not break and only listens on `order` routing key.