### PR TITLE
Make :not_found return 404 instead of 401

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -24,7 +24,8 @@ module ErrorHandler
         else
           status = :unauthorized
         end
-        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: status
+        http_status = exception.code == :not_found ? :not_found : :unauthorized
+        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: http_status
       end
 
       rescue_from Errors::ValidationError do |exception|

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -19,11 +19,6 @@ module ErrorHandler
 
       rescue_from Errors::AuthError do |exception|
         log_exception(exception)
-        if exception.code == :not_found
-          status = :not_found
-        else
-          status = :unauthorized
-        end
         http_status = exception.code == :not_found ? :not_found : :unauthorized
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: http_status
       end

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -19,7 +19,12 @@ module ErrorHandler
 
       rescue_from Errors::AuthError do |exception|
         log_exception(exception)
-        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :unauthorized
+        if exception.code == :not_found
+          status = :not_found
+        else
+          status = :unauthorized
+        end
+        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: status
       end
 
       rescue_from Errors::ValidationError do |exception|

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -17,12 +17,6 @@ module ErrorHandler
         render json: { errors: [Types::ApplicationErrorType.format_root_level_error(type: :validation, code: :not_found, data: { message: exception.to_s })] }, status: :not_found
       end
 
-      rescue_from Errors::AuthError do |exception|
-        log_exception(exception)
-        http_status = exception.code == :not_found ? :not_found : :unauthorized
-        render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: http_status
-      end
-
       rescue_from Errors::ValidationError do |exception|
         log_exception(exception)
         render json: { errors: [Types::ApplicationErrorType.root_level_from_application_error(exception)] }, status: :bad_request

--- a/app/controllers/errors/auth_error.rb
+++ b/app/controllers/errors/auth_error.rb
@@ -1,7 +1,0 @@
-module Errors
-  class AuthError < ApplicationError
-    def initialize(code)
-      super(:auth, code)
-    end
-  end
-end

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -1,8 +1,5 @@
 module Errors
   ERROR_TYPES = {
-    auth: %i[
-      not_found
-    ],
     validation: %i[
       credit_card_deactivated
       credit_card_missing_customer

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -60,16 +60,16 @@ class Types::QueryType < Types::BaseObject
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
               (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
-    raise Errors::AuthError, :not_found
+    raise ActiveRecord::RecordNotFound
   end
 
   def validate_orders_request!(params)
     return if trusted? || sales_admin?
 
     if params[:buyer_id].present?
-      raise Errors::AuthError, :not_found unless params[:buyer_id] == context[:current_user][:id]
+      raise ActiveRecord::RecordNotFound unless params[:buyer_id] == context[:current_user][:id]
     elsif params[:seller_id].present?
-      raise Errors::AuthError, :not_found unless context[:current_user][:partner_ids].include?(params[:seller_id])
+      raise ActiveRecord::RecordNotFound unless context[:current_user][:partner_ids].include?(params[:seller_id])
     else
       raise Errors::ValidationError, :missing_params
     end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -102,13 +102,13 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'user accessing their order' do
-      it 'returns permission error when query for orders by user not in jwt' do
+      it 'returns not found error when query for orders by user not in jwt' do
         expect do
           client.execute(query, id: user2_order1.id)
         end.to raise_error do |error|
           expect(error).to be_a(Graphlient::Errors::ServerError)
-          expect(error.message).to eq 'the server responded with status 401'
-          expect(error.status_code).to eq 401
+          expect(error.message).to eq 'the server responded with status 404'
+          expect(error.status_code).to eq 404
           expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
           expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
         end
@@ -200,8 +200,8 @@ describe Api::GraphqlController, type: :request do
             client.execute(query, id: user2_order1.id)
           end.to raise_error do |error|
             expect(error).to be_a(Graphlient::Errors::ServerError)
-            expect(error.message).to eq 'the server responded with status 401'
-            expect(error.status_code).to eq 401
+            expect(error.message).to eq 'the server responded with status 404'
+            expect(error.status_code).to eq 404
             expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
             expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
           end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -110,7 +110,7 @@ describe Api::GraphqlController, type: :request do
           expect(error.message).to eq 'the server responded with status 404'
           expect(error.status_code).to eq 404
           expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
-          expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
+          expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
         end
       end
 
@@ -203,7 +203,7 @@ describe Api::GraphqlController, type: :request do
             expect(error.message).to eq 'the server responded with status 404'
             expect(error.status_code).to eq 404
             expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
-            expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
+            expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
           end
         end
       end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -67,7 +67,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'query with sellerId' do
-      it 'returns permission error when query for sellerId not in jwt' do
+      it 'returns not found error when query for sellerId not in jwt' do
         expect do
           client.execute(query, sellerId: 'someone-elses-partnerid')
         end.to raise_error do |error|

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -75,7 +75,7 @@ describe Api::GraphqlController, type: :request do
           expect(error.message).to eq 'the server responded with status 404'
           expect(error.status_code).to eq 404
           expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
-          expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
+          expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
         end
       end
       it 'returns partners orders' do
@@ -143,7 +143,7 @@ describe Api::GraphqlController, type: :request do
             expect(error.status_code).to eq 404
             expect(error.message).to eq 'the server responded with status 404'
             expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
-            expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
+            expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
           end
         end
       end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -72,8 +72,8 @@ describe Api::GraphqlController, type: :request do
           client.execute(query, sellerId: 'someone-elses-partnerid')
         end.to raise_error do |error|
           expect(error).to be_a(Graphlient::Errors::ServerError)
-          expect(error.message).to eq 'the server responded with status 401'
-          expect(error.status_code).to eq 401
+          expect(error.message).to eq 'the server responded with status 404'
+          expect(error.status_code).to eq 404
           expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
           expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
         end
@@ -140,8 +140,8 @@ describe Api::GraphqlController, type: :request do
             client.execute(query, buyerId: 'someone-elses-userid')
           end.to raise_error do |error|
             expect(error).to be_a(Graphlient::Errors::ServerError)
-            expect(error.message).to eq 'the server responded with status 401'
-            expect(error.status_code).to eq 401
+            expect(error.status_code).to eq 404
+            expect(error.message).to eq 'the server responded with status 404'
             expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
             expect(error.response['errors'].first['extensions']['type']).to eq 'auth'
           end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-539

We decided a while back that users should receive 404 when trying to look at orders that they should not have access to. Users currently receive a 401 and this PR is changing it to 404 as intended. This is technically a breaking change, but I couldn't find any evidence of anyone relying on specific status codes. Certainly not from the reaction/force side. But would still be good to check about volt and etc

integration tested manually against metaphysics 
![image](https://user-images.githubusercontent.com/1242537/47101920-47871400-d233-11e8-92f4-cfc570b9a4c5.png)

