### PR TITLE
Add order id to transaction events

### DIFF
--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -19,6 +19,7 @@ class TransactionEvent < Events::BaseEvent
     order = @object.order
     {
       order: {
+        id: order.id,
         buyer_id: order.buyer_id,
         buyer_total_cents: order.buyer_total_cents,
         buyer_type: order.buyer_type,

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -75,6 +75,7 @@ describe TransactionEvent, type: :events do
   describe '#properties' do
     it 'returns correct properties for a submitted order' do
       order.submit!
+      expect(event.properties[:order][:id]).to eq order.id
       expect(event.properties[:order][:code]).to eq order.code
       expect(event.properties[:order][:currency_code]).to eq 'USD'
       expect(event.properties[:order][:state]).to eq 'submitted'


### PR DESCRIPTION
# Problem
Add order `id` to `order` section in `TransactionEvent`.

# Solution
Add it