### PR TITLE
Set item sales tax to be the collectable state sales tax when available

### DIFF
--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -26,7 +26,7 @@ class SalesTaxService
   def sales_tax
     @sales_tax ||= begin
       tax_response = fetch_sales_tax
-      collectable_tax = tax_response.breakdown.present? ? tax_response.breakdown.state_tax_collectable : tax_response.amount_to_collect
+      collectable_tax = tax_response.breakdown&.state_tax_collectable || tax_response.amount_to_collect
       UnitConverter.convert_dollars_to_cents(collectable_tax)
     end
   rescue Taxjar::Error => e

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -44,6 +44,8 @@ describe SalesTaxService, type: :services do
       shipping: 0
     }
   end
+  let(:tax_response) { double(amount_to_collect: 3.00) }
+  let(:tax_response_with_breakdown) { double(amount_to_collect: 3.00, breakdown: double(state_tax_collectable: 2.00)) }
 
   before do
     silence_warnings do
@@ -81,18 +83,15 @@ describe SalesTaxService, type: :services do
     end
     context 'with a sales tax breakdown' do
       it 'calls fetch_sales_tax and returns the amount of sales tax to collect on a state level' do
-        breakdown_double = double(state_tax_collectable: 2.00)
-        tax_double = double(amount_to_collect: 3.00, breakdown: breakdown_double)
-        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_double)
+        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response_with_breakdown)
         expect(@service_ship.sales_tax).to eq 200
       end
     end
     context 'without a sales tax breakdown' do
       it 'calls fetch_sales_tax and returns the total amount to collect' do
-        tax_double = double(amount_to_collect: 1.00)
-        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_double)
-        expect(tax_double).to receive(:breakdown).and_return(nil)
-        expect(@service_ship.sales_tax).to eq 100
+        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response)
+        expect(tax_response).to receive(:breakdown).and_return(nil)
+        expect(@service_ship.sales_tax).to eq 300
       end
     end
     context 'with an error from TaxJar' do

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -79,9 +79,21 @@ describe SalesTaxService, type: :services do
     before do
       allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
     end
-    it 'calls fetch_sales_tax and returns the sales tax in cents' do
-      expect(@service_ship).to receive(:fetch_sales_tax).and_return(double(amount_to_collect: 1.00))
-      expect(@service_ship.sales_tax).to eq 100
+    context 'with a sales tax breakdown' do
+      it 'calls fetch_sales_tax and returns the amount of sales tax to collect on a state level' do
+        breakdown_double = double(state_tax_collectable: 2.00)
+        tax_double = double(amount_to_collect: 3.00, breakdown: breakdown_double)
+        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_double)
+        expect(@service_ship.sales_tax).to eq 200
+      end
+    end
+    context 'without a sales tax breakdown' do
+      it 'calls fetch_sales_tax and returns the total amount to collect' do
+        tax_double = double(amount_to_collect: 1.00)
+        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_double)
+        expect(tax_double).to receive(:breakdown).and_return(nil)
+        expect(@service_ship.sales_tax).to eq 100
+      end
     end
     context 'with an error from TaxJar' do
       it 'raises a ProcessingError with a code of tax_calculator_failure' do
@@ -130,11 +142,21 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#fetch_sales_tax' do
+    let(:params) do
+      base_tax_params.merge(
+        line_items: [
+          {
+            quantity: line_item.quantity,
+            unit_price: UnitConverter.convert_cents_to_dollars(line_item.price_cents)
+          }
+        ]
+      )
+    end
     it 'calls the Taxjar API with the correct parameters' do
       allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
-      allow(taxjar_client).to receive(:tax_for_order).with(base_tax_params)
+      allow(taxjar_client).to receive(:tax_for_order).with(params)
       @service_ship.send(:fetch_sales_tax)
-      expect(taxjar_client).to have_received(:tax_for_order).with(base_tax_params)
+      expect(taxjar_client).to have_received(:tax_for_order).with(params)
     end
   end
 


### PR DESCRIPTION
### Problem
The response from TaxJar may include taxes for jurisdictions other than states, but we _only_ want to consider state sales tax. This results in us potentially overcharging on sales tax.

### Solution
If a tax breakdown from TaxJar is available (https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order), set the sales tax for that item to be the collectable amount for the state. Otherwise, if it's not available continue to use the overall `amount_to_collect`.

### What Changed
- Uses TaxJar's `breakdown` object to get the state tax collectable (if it's available) and sets sales tax to the state sales tax collectable.
- Adds line item details to the TaxJar parameters, which are required to get the `breakdown` object in the response.