### PR TITLE
enable statsd for exchange

### DIFF
--- a/app/services/create_order_service.rb
+++ b/app/services/create_order_service.rb
@@ -33,6 +33,7 @@ class CreateOrderService
       )
       OrderTotalUpdaterService.new(@order).update_totals!
     end
+    Exchange.dogstatsd.increment 'order.create'
     post_process
   rescue ActiveRecord::RecordInvalid => e
     raise Errors::ValidationError.new(:invalid_order, message: e.message)

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -46,6 +46,7 @@ class OrderSubmitService
 
     @order.line_items.map do |li|
       artwork = GravityService.get_artwork(li[:artwork_id])
+      Exchange.dogstatsd.increment 'submit.artwork_version_mismatch'
       raise Errors::ProcessingError, :artwork_version_mismatch if artwork[:current_version_id] != li[:artwork_version_id]
     end
     @credit_card = GravityService.get_credit_card(@order.credit_card_id)

--- a/config/initializers/datadog_statsd.rb
+++ b/config/initializers/datadog_statsd.rb
@@ -1,0 +1,20 @@
+module Datadog
+  module StatsdDisabled
+    attr_accessor :disabled
+
+    def send_to_socket(message)
+      print message
+      super unless disabled
+    end
+  end
+end
+
+Datadog::Statsd.prepend Datadog::StatsdDisabled
+
+module Exchange
+  def self.dogstatsd
+    @dogstatsd ||= Datadog::Statsd.new(ENV.fetch('DATADOG_TRACE_AGENT_HOSTNAME', 'localhost'), 8125,
+      tags: ["service:exchange"]
+    ).tap { |d| d.disabled = !(ENV['DATADOG_ENABLED'] == 'true') }
+  end
+end


### PR DESCRIPTION
Only records 1 metric for now, order create. We can circle back and track lots of stuff once we verify this works.