### PR TITLE
Use all seller sales tax nexuses when calculating sales tax

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -26,6 +26,7 @@ module Errors
       missing_region
       missing_required_info
       missing_required_param
+      no_taxable_addresses
       not_acquireable
       not_found
       unknown_artwork

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -7,7 +7,8 @@ class RecordSalesTaxJob < ApplicationJob
 
     artwork = GravityService.get_artwork(line_item.artwork_id)
     artwork_address = Address.new(artwork[:location])
-    service = SalesTaxService.new(line_item, line_item.order.fulfillment_type, line_item.order.shipping_address, line_item.order.shipping_total_cents, artwork_address)
+    seller_addresses = GravityService.fetch_partner_locations(line_item.order.seller_id)
+    service = SalesTaxService.new(line_item, line_item.order.fulfillment_type, line_item.order.shipping_address, line_item.order.shipping_total_cents, artwork_address, seller_addresses)
     service.record_tax_collected
     line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id) if service.transaction.present?
   end

--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -33,20 +33,6 @@ module GravityService
     nil
   end
 
-  def self.fetch_partner_location(partner_id)
-    partner = fetch_partner(partner_id)
-    raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if partner[:billing_location_id].blank?
-
-    location = Adapters::GravityV1.get("/partner/#{partner_id}/location/#{partner[:billing_location_id]}")
-    Address.new(location.slice(:address, :address_2, :city, :state, :country, :postal_code))
-  rescue Errors::AddressError
-    raise Errors::ValidationError.new(:invalid_seller_address, partner_id: partner_id)
-  rescue Adapters::GravityNotFoundError
-    raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id)
-  rescue Adapters::GravityError
-    raise Errors::InternalError.new(:gravity, message: e.message)
-  end
-
   def self.fetch_partner_locations(partner_id)
     locations = Adapters::GravityV1.get("/partner/#{partner_id}/locations?private=true")
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -47,7 +47,8 @@ class OrderShippingService
   def tax_total_cents
     @tax_total_cents ||= @order.line_items.map do |li|
       artwork_address = Address.new(artworks[li.artwork_id][:location])
-      service = SalesTaxService.new(li, @fulfillment_type, @shipping_address, shipping_total_cents, artwork_address)
+      seller_addresses = GravityService.fetch_partner_locations(@order.seller_id)
+      service = SalesTaxService.new(li, @fulfillment_type, @shipping_address, shipping_total_cents, artwork_address, seller_addresses)
       li.update!(sales_tax_cents: service.sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
       service.sales_tax
     end.sum

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -166,7 +166,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([{country: 'FR'}])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -13,6 +13,7 @@ describe RecordSalesTaxJob, type: :job do
       postal_code: 10013
     }
   end
+  let(:seller_addresses) { [Address.new(country: 'US', region: 'NY', postal_code: '10012')] }
   describe '#perform' do
     before do
       stub_tax_for_order
@@ -28,6 +29,7 @@ describe RecordSalesTaxJob, type: :job do
     context 'with an order that has sales tax to remit' do
       it 'posts a transaction to TaxJar and saves the transaction id' do
         expect(GravityService).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
+        expect(GravityService).to receive(:fetch_partner_locations).with(line_item.order.seller_id).and_return(seller_addresses)
         expect(Address).to receive(:new).with(artwork_location).and_return(Address.new(artwork_location))
         RecordSalesTaxJob.perform_now(line_item.id)
         expect(line_item.reload.sales_tax_transaction_id).to eq '123'

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -26,33 +26,38 @@ describe GravityService, type: :services do
     end
   end
 
-  describe '#fetch_partner_location' do
-    let(:valid_location) { { country: 'US', state: 'NY', postal_code: '12345' } }
-    let(:invalid_location) { { country: 'US', state: 'Floridada' } }
-    before do
-      allow(GravityService).to receive(:fetch_partner).and_return(partner)
-    end
-    it 'fetches the partner' do
-      expect(GravityService).to receive(:fetch_partner).with(partner_id)
-      allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/location/#{partner[:billing_location_id]}").and_return(valid_location)
-      GravityService.fetch_partner_location(partner_id)
-    end
+  describe '#fetch_partner_locations' do
+    let(:valid_locations) { [{ country: 'US', state: 'NY', postal_code: '12345' }, { country: 'US', state: 'FL', postal_code: '67890' }] }
+    let(:invalid_location) { [{ country: 'US', state: 'Floridada' }] }
     it 'calls the correct location Gravity endpoint' do
-      expect(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/location/#{partner[:billing_location_id]}").and_return(valid_location)
-      GravityService.fetch_partner_location(partner_id)
+      expect(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return(valid_locations)
+      GravityService.fetch_partner_locations(partner_id)
     end
-    context 'with a valid partner location' do
-      it 'returns a new address' do
-        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/location/#{partner[:billing_location_id]}").and_return(valid_location)
-        expect(GravityService.fetch_partner_location(partner_id)).to be_a Address
+    context 'with at least one partner location' do
+      context 'with valid partner locations' do
+        it 'returns new addresses for each location' do
+          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return(valid_locations)
+          partner_addresses = GravityService.fetch_partner_locations(partner_id)
+          partner_addresses.each { |ad| expect(ad).to be_a Address }
+        end
+      end
+      context 'with an invalid partner location' do
+        it 'rescues AddressError and raises ValidationError' do
+          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return(invalid_location)
+          expect { GravityService.fetch_partner_locations(partner_id) }.to raise_error do |error|
+            expect(error).to be_a Errors::ValidationError
+            expect(error.code).to eq :invalid_seller_address
+            expect(error.data[:partner_id]).to eq partner_id
+          end
+        end
       end
     end
-    context 'with an invalid partner location' do
-      it 'rescues AddressError and raises ValidationError' do
-        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/location/#{partner[:billing_location_id]}").and_return(invalid_location)
-        expect { GravityService.fetch_partner_location(partner_id) }.to raise_error do |error|
+    context 'with no partner locations' do
+      it 'raises error' do
+        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([])
+        expect { GravityService.fetch_partner_locations(partner_id) }.to raise_error do |error|
           expect(error).to be_a Errors::ValidationError
-          expect(error.code).to eq :invalid_seller_address
+          expect(error.code).to eq :missing_partner_location
           expect(error.data[:partner_id]).to eq partner_id
         end
       end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -10,32 +10,45 @@ describe SalesTaxService, type: :services do
   let(:shipping) do
     {
       country: 'US',
-      postal_code: 10013,
+      postal_code: '10013',
       region: 'NY',
       city: 'New York',
       address_line1: '123 Fake St'
     }
   end
   let(:shipping_address) { Address.new(shipping) }
-  let(:partner_location) do
-    {
-      country: 'US',
-      state: 'NY',
-      city: 'New York',
-      address: '456 Fake St',
-      postal_code: 10013
-    }
+  let!(:seller_locations) do
+    [
+      {
+        country: 'US',
+        state: 'NY',
+        city: 'New York',
+        address: '456 Fake St',
+        postal_code: '10013'
+      },
+      {
+        country: 'US',
+        state: 'MA',
+        city: 'Cambridge',
+        address: '789 Fake St',
+        postal_code: '02139'
+      }
+    ]
   end
-  let(:partner_address) { Address.new(partner_location) }
+  let!(:seller_addresses) { seller_locations.map{ |ad| Address.new(ad) } }
   let(:artwork_location) { Address.new(gravity_v1_artwork[:location]) }
   let(:base_tax_params) do
     {
       amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
-      from_country: partner_location[:country],
-      from_zip: partner_location[:postal_code],
-      from_state: partner_location[:state],
-      from_city: partner_location[:city],
-      from_street: partner_location[:address],
+      nexus_addresses: seller_addresses.map do |ad|
+        {
+          country: ad.country,
+          zip: ad.postal_code,
+          state: ad.region,
+          city: ad.city,
+          street: ad.street_line1
+        }
+      end,
       to_country: shipping_address.country,
       to_zip: shipping_address.postal_code,
       to_state: shipping_address.region,
@@ -52,8 +65,8 @@ describe SalesTaxService, type: :services do
       SalesTaxService.const_set('REMITTING_STATES', ['fl'])
     end
     allow(Taxjar::Client).to receive(:new).with(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key'], api_url: nil).and_return(taxjar_client)
-    @service_ship = SalesTaxService.new(line_item, Order::SHIP, shipping_address, shipping_total_cents, artwork_location)
-    @service_pickup = SalesTaxService.new(line_item, Order::PICKUP, Address.new({}), shipping_total_cents, artwork_location)
+    @service_ship = SalesTaxService.new(line_item, Order::SHIP, shipping_address, shipping_total_cents, artwork_location, seller_addresses)
+    @service_pickup = SalesTaxService.new(line_item, Order::PICKUP, Address.new({}), shipping_total_cents, artwork_location, seller_addresses)
   end
 
   after do
@@ -66,7 +79,7 @@ describe SalesTaxService, type: :services do
     context 'with a destination address in a remitting state' do
       it 'sets shipping_total_cents to the passed in value' do
         shipping[:region] = 'FL'
-        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location)
+        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
         expect(service.instance_variable_get(:@shipping_total_cents)).to eq shipping_total_cents
       end
     end
@@ -78,9 +91,6 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#sales_tax' do
-    before do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
-    end
     context 'with a sales tax breakdown' do
       it 'calls fetch_sales_tax and returns the amount of sales tax to collect on a state level' do
         expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response_with_breakdown)
@@ -102,27 +112,6 @@ describe SalesTaxService, type: :services do
           expect(error.type).to eq :processing
           expect(error.code).to eq :tax_calculator_failure
         end
-      end
-    end
-  end
-
-  describe '#seller_address' do
-    it "returns the partner's location" do
-      expect(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
-      expect(@service_ship.send(:seller_address)).to eq partner_address
-    end
-  end
-
-  describe '#origin_address' do
-    context 'with a fulfillment_type of SHIP' do
-      it 'returns the seller address' do
-        expect(@service_ship).to receive(:seller_address).and_return(partner_address)
-        expect(@service_ship.send(:origin_address)).to eq partner_address
-      end
-    end
-    context 'with a fulfillment_type of PICKUP' do
-      it 'returns the artwork location' do
-        expect(@service_pickup.send(:origin_address)).to eq artwork_location
       end
     end
   end
@@ -152,7 +141,6 @@ describe SalesTaxService, type: :services do
       )
     end
     it 'calls the Taxjar API with the correct parameters' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
       allow(taxjar_client).to receive(:tax_for_order).with(params)
       @service_ship.send(:fetch_sales_tax)
       expect(taxjar_client).to have_received(:tax_for_order).with(params)
@@ -173,7 +161,6 @@ describe SalesTaxService, type: :services do
         before do
           order.submit!
           order.approve!
-          allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
         end
         it 'raises a ProcessingError with a code of tax_recording_failure' do
           expect(taxjar_client).to receive(:create_order).and_raise(Taxjar::Error)
@@ -195,7 +182,7 @@ describe SalesTaxService, type: :services do
     context 'when line item does not have sales tax' do
       it 'does nothing' do
         line_item.sales_tax_cents = 0
-        service = SalesTaxService.new(line_item, Order::SHIP, shipping_address, shipping_total_cents, artwork_location)
+        service = SalesTaxService.new(line_item, Order::SHIP, shipping_address, shipping_total_cents, artwork_location, seller_addresses)
         allow(service).to receive(:artsy_should_remit_taxes?).and_return(true)
         allow(service).to receive(:post_transaction)
         service.record_tax_collected
@@ -219,7 +206,6 @@ describe SalesTaxService, type: :services do
       order.approve!
     end
     it 'calls the Taxjar API with the correct parameters' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
       expect(taxjar_client).to receive(:create_order).with(params)
       @service_ship.send(:post_transaction)
     end
@@ -231,7 +217,7 @@ describe SalesTaxService, type: :services do
         it 'returns true' do
           SalesTaxService::REMITTING_STATES.each do |state|
             shipping[:region] = state
-            service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location)
+            service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
             expect(service.send(:artsy_should_remit_taxes?)).to be true
           end
         end
@@ -245,7 +231,7 @@ describe SalesTaxService, type: :services do
     context 'with an order that has a non-US destination address' do
       it 'returns false' do
         shipping[:country] = 'FR'
-        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location)
+        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
         expect(service.send(:artsy_should_remit_taxes?)).to be false
       end
     end
@@ -296,16 +282,12 @@ describe SalesTaxService, type: :services do
       )
     end
     it 'calls the TaxJar API with the correct parameters' do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
       expect(taxjar_client).to receive(:create_refund).with(params)
       @service_ship.send(:post_refund, transaction_date)
     end
   end
 
   describe '#construct_tax_params' do
-    before do
-      allow(GravityService).to receive(:fetch_partner_location).with(order.seller_id).and_return(partner_address)
-    end
     it 'returns the parameters shared by all API calls to TaxJar' do
       expect(@service_ship.send(:construct_tax_params)).to eq base_tax_params
     end


### PR DESCRIPTION
### Problem
Per legal's request, we need to consider every partner location as a sales tax nexus when calculating sales tax. Previously we were either using the artwork location or the partner's primary billing address as the seller's nexus when calculating sales tax.

### Solution
Fetch all partner locations and pass them in as part of the base parameters we send to TaxJar when we make requests, i.e. calculating sales tax.

### What Changed
- Creates `GravityService.fetch_partner_locations` that fetches all locations from a partner. Deleted `GravityService.fetch_partner_location`, which previously served the same purpose when we were only considering one location at a time.
- Passes in all partner locations in call to TaxJar for estimating sales tax.

This PR also takes care of a few other issues opportunistically, namely the fact that we ask for tax estimates on non-US orders even though only US-based addresses are taxable for our purposes. This isn't currently an issue since BN is only launched in the US. 

- Adds `address_taxable?` method to `SalesTaxService` that checks if an address is taxable for our purposes. Currently only US-based addresses are taxable.
- Raises error on initialization of `SalesTaxService` if the seller has no taxable addresses and sets sales tax to 0.
