### PR TITLE
Call the appropriate GravityService method to get partner location info

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -113,10 +113,12 @@ ActiveAdmin.register Order do
 
       partner_info = GravityService.fetch_partner(order.seller_id)
       if partner_info.present?
-        partner_location = GravityService.fetch_partner_location(order.seller_id)
+        partner_locations = GravityService.fetch_partner_locations(order.seller_id)
 
-        if partner_location.present?
+        if partner_locations.present?
 
+          #TODO - handle multiple partner_locations properly, instead of just taking the first.
+          partner_location = partner_locations.first
           partner_info[:partner_location] = partner_location
 
           attributes_table_for partner_info do


### PR DESCRIPTION
A method was renamed; we had one call that didn't get switched over to the new name. For now, we're just showing the first partner location returned by Gravity.
