### PR TITLE
PLATFORM-977 - add confirmation dialog to “Refund” button in admin

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -44,7 +44,7 @@ ActiveAdmin.register Order do
   end
 
   action_item :refund, only: :show do
-    link_to 'Refund', refund_admin_order_path(order), method: :post if [Order::APPROVED, Order::FULFILLED].include? order.state
+    link_to 'Refund', refund_admin_order_path(order), method: :post, data: {confirm: 'Are you sure you want to refund this order?'} if [Order::APPROVED, Order::FULFILLED].include? order.state
   end
 
   sidebar :contact_info, only: :show do


### PR DESCRIPTION
Adds a confirmation dialog to the "Refund" button in the admin, so people don't accidentally refund orders.

Note: This PR does not include tests, because I don't really know how to add them for the admin. If anyone reviewing feels like they can help me with that, that would be grand. If not, we have another story for adding admin tests later (https://artsyproduct.atlassian.net/browse/PLATFORM-1021).