### PR TITLE
Fix ReminderJob failures

### DIFF
--- a/app/jobs/reminder_follow_up_job.rb
+++ b/app/jobs/reminder_follow_up_job.rb
@@ -10,10 +10,10 @@ class ReminderFollowUpJob < ApplicationJob
 
     case order.state
     when Order::SUBMITTED
-      PostNotificationJob.perform_now(order.id, Order::REMINDER_EVENT_VERB[:pending_approval])
+      OrderEvent.post(order, Order::REMINDER_EVENT_VERB[:pending_approval])
 
     when Order::APPROVED
-      PostNotificationJob.perform_now(order.id, Order::REMINDER_EVENT_VERB[:pending_fulfillment])
+      OrderEvent.post(order, Order::REMINDER_EVENT_VERB[:pending_fulfillment])
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -57,8 +57,8 @@ class Order < ApplicationRecord
   ].freeze
 
   REMINDER_EVENT_VERB = {
-    'pending_approval' => 'pending_approval'.freeze,
-    'pending_fulfillment' => 'pending_fulfillment'.freeze
+    pending_approval: 'pending_approval'.freeze,
+    pending_fulfillment: 'pending_fulfillment'.freeze
   }.freeze
 
   AUCTION_SELLER_TYPE = 'auction'.freeze


### PR DESCRIPTION
# Problem
`ReminderJob`s are currently failing:
https://sentry.io/artsynet/exchange-production/issues/744695337/?query=is:unresolved

# Cause
We are accessing hash with symbol while the hash has String keys.

# Fix
Switch to symbols for reminder action hash. Also directly call `OrderEvent.post` in `ReminderJob` and avoid extra order fetching

