### PR TITLE
Skip verify_authenticity_token for API endpoints

### DIFF
--- a/app/controllers/api/base_api_controller.rb
+++ b/app/controllers/api/base_api_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class BaseApiController < ApplicationController
     skip_before_action :require_artsy_authentication
+    skip_before_action :verify_authenticity_token
     before_action :authenticate_request!
-    protect_from_forgery with: :null_session
   end
 end


### PR DESCRIPTION
# Problem
Getting LOT of these warnings
```
Can't verify CSRF token authenticity.
```
in all of our API requests.

We've set
```
protect_from_forgery with: :null_session
```
in `BaseApiConroller` before which seems to allow calls without CSRF and just nullifies the session, but the warning message is still there!

# Possible Solution?
Skip `verify_authenticity_token` in API controller all together!

I tried to do few other things like adding 👇 to main controller
```
protect_from_forgery unless: -> { request.format.json? }
```
which didn't work, I think we are safe with skipping this on API controllers, but let me know if you think otherwise.