### PR TITLE
Remove Order status link from Order details page

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -174,10 +174,6 @@ ActiveAdmin.register Order do
           end
         end
 
-        row 'Order Status' do
-          link_to "#{order.id}", artsy_order_status_url(order.id)
-        end
-
         if order.state == Order::FULFILLED && order.fulfillment_type == Order::SHIP
           row 'Shipment' do |order|
             fulfillments = order.line_items.map(&:fulfillments).flatten

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,9 +1,4 @@
 module UrlHelper
-  def artsy_order_status_url(order_id)
-    # TODO: add this route to exchange
-    "/order/#{order_id}/status"
-  end
-
   def artsy_view_artwork_url(artwork_id)
     artwork_url = Rails.application.config_for(:force)['artwork_url']
     "#{artwork_url}/#{artwork_id}"


### PR DESCRIPTION
For the context behind this change, please refer to the discussion on the Jira ticket below.

https://artsyproduct.atlassian.net/browse/PLATFORM-981