### PR TITLE
@yuki24: Don't log all SQL in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
 I noticed we're spouting debug-level logs from a bunch of systems including Exchange.