### PR TITLE
Filter admin actions, add ability to sort

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -21,13 +21,19 @@ ActiveAdmin.register Order do
   filter :state, as: :check_boxes, collection: proc { Order::STATES }
   filter :state_reason, as: :check_boxes, collection: proc { Order::REASONS.values.map(&:values).flatten.uniq.map!(&:humanize) }
 
+  controller do
+    def scoped_collection
+      Order.includes :admin_notes
+    end
+  end
+
   index do
     column :code do |order|
       link_to order.code, admin_order_path(order.id)
     end
     column :state
     column :fulfillment_type
-    column 'Last Admin Action' do |order|
+    column :admin_notes, sortable: 'admin_notes.note_type' do |order|
       order.last_admin_note&.note_type&.humanize
     end
     column 'Submitted At', :created_at

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -21,19 +21,13 @@ ActiveAdmin.register Order do
   filter :state, as: :check_boxes, collection: proc { Order::STATES }
   filter :state_reason, as: :check_boxes, collection: proc { Order::REASONS.values.map(&:values).flatten.uniq.map!(&:humanize) }
 
-  controller do
-    def scoped_collection
-      Order.includes :admin_notes
-    end
-  end
-
   index do
     column :code do |order|
       link_to order.code, admin_order_path(order.id)
     end
     column :state
     column :fulfillment_type
-    column :admin_notes, sortable: 'admin_notes.note_type' do |order|
+    column 'Last Admin Action' do |order|
       order.last_admin_note&.note_type&.humanize
     end
     column 'Submitted At', :created_at

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -8,6 +8,8 @@ ActiveAdmin.register Order do
   scope('Pickup Orders') { |scope| scope.where(state: [ Order::APPROVED, Order::FULFILLED, Order::SUBMITTED ], fulfillment_type: Order::PICKUP ) }
   scope('Fulfillment Overdue') { |scope| scope.approved.where('state_expires_at < ?', Time.now) }
   scope('Pending & Abandoned Orders') { |scope| scope.where(state: [ Order::ABANDONED, Order::PENDING ]) }
+  scope('Case Closed') { |scope| scope.by_last_admin_note(AdminNote::TYPES[:case_closed]) }
+  scope('Case Still Open') { |scope| scope.by_last_admin_note(AdminNote::TYPES.except(:case_closed).values) }
 
   filter :id_eq, label: 'Order Id'
   filter :mode, as: :check_boxes, collection: proc { Order::MODES }, label: 'Mode'

--- a/app/controllers/api/health_controller.rb
+++ b/app/controllers/api/health_controller.rb
@@ -7,7 +7,7 @@ module Api
       sidekiq_default_queue_size = Sidekiq::Queue.new.size
       render json: {
         api_healthy: true,
-        worker_health:  sidekiq_default_queue_size < SIDEKIQ_ALERT_THRESHOLD ? 'OK' : 'OY',
+        worker_health: sidekiq_default_queue_size < SIDEKIQ_ALERT_THRESHOLD ? 'OK' : 'OY',
         worker_default_queue_size: sidekiq_default_queue_size
       }
     end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -84,7 +84,7 @@ class Order < ApplicationRecord
   scope :pending, -> { where(state: PENDING) }
   scope :active, -> { where(state: [Order::APPROVED, Order::SUBMITTED]) }
   scope :approved, -> { where(state: APPROVED) }
-  scope :by_last_admin_note, ->(note_type) { where('(SELECT note_type FROM admin_notes WHERE order_id = orders.id ORDER BY created_at DESC limit 1) = ?', note_type) }
+  scope :by_last_admin_note, ->(note_types) { where('(SELECT note_type FROM admin_notes WHERE order_id = orders.id ORDER BY created_at DESC limit 1) in (?)', note_types) }
 
   ACTIONS.each do |action|
     define_method "#{action}!" do |state_reason = nil, &block|

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -202,6 +202,14 @@ RSpec.describe Order, type: :model do
         orders = Order.by_last_admin_note('mediation_contacted_buyer')
         expect(orders).to eq [order1]
       end
+      it 'returns multiple orders for case mediation_contacted_buyer and case_opened_return' do
+        orders = Order.by_last_admin_note(['mediation_contacted_buyer', 'case_opened_return'])
+        expect(orders).to match_array([order1, order2])
+      end
+      it 'returns the only order for case mediation_contacted_buyer and case_opened_cancellation' do
+        orders = Order.by_last_admin_note(['mediation_contacted_buyer', 'case_opened_cancellation'])
+        expect(orders).to eq [order1]
+      end
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -203,11 +203,11 @@ RSpec.describe Order, type: :model do
         expect(orders).to eq [order1]
       end
       it 'returns multiple orders for case mediation_contacted_buyer and case_opened_return' do
-        orders = Order.by_last_admin_note(['mediation_contacted_buyer', 'case_opened_return'])
+        orders = Order.by_last_admin_note(%w[mediation_contacted_buyer case_opened_return])
         expect(orders).to match_array([order1, order2])
       end
       it 'returns the only order for case mediation_contacted_buyer and case_opened_cancellation' do
-        orders = Order.by_last_admin_note(['mediation_contacted_buyer', 'case_opened_cancellation'])
+        orders = Order.by_last_admin_note(%w[mediation_contacted_buyer case_opened_cancellation])
         expect(orders).to eq [order1]
       end
     end


### PR DESCRIPTION
Changes:

- Add two scopes, one for orders with "Case Closed" note, and another for orders with notes on them, but not "Case Closed"
- Add sorting ability based on Last Admin Action. This is how to join against a `has_many` association apparently, I'm not entirely sure how it works.
- Expand the `by_last_admin_note` scope to take an array of note types
- tests for `by_last_admin_note`