### PR TITLE
Always display times in Eastern time, and with the timezone.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,8 @@ class ApplicationController < ActionController::Base
   def set_current_user_for_error_reporting
     Raven.user_context(current_user: current_user) if current_user.present?
   end
+
+  def admin_display_in_eastern_timezone
+    Time.zone = 'Eastern Time (US & Canada)'
+  end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -146,6 +146,7 @@ ActiveAdmin.setup do |config|
   # Active Admin resources and pages from here.
   #
   # config.before_action :do_something_awesome
+  config.before_action :admin_display_in_eastern_timezone
 
   # == Localize Date/Time Format
   #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,9 @@
 
 en:
   hello: "Hello world"
+  date:
+    formats:
+      long: "%B %d, %Y"
+  time:
+    formats:
+      long: "%B %d, %Y %H:%M %Z"


### PR DESCRIPTION
Pairing with @dleve123, we found a couple of configuration changes we could make so that the Exchange app **always** displayed times in the Eastern time zone, and with the time zone explicitly identified.

The previous iteration of this PR required us to manually convert to the eastern time zone any time we were displaying a date, which was cumbersome and easy to mess up. With the approach in this PR, we can be certain that every date rendered by Exchange will be in Eastern time, so we won't accidentally miss any.

In addition, we added the time zone abbreviation to times when they are displayed. This helps give clarity when some times are in Daylight time and some are in Standard time.

Once we changed to this approach, we decided that writing system tests didn't make sense, as they would only be testing that Active Admin & Rails were respecting our configuration changes.

Screenshots of the new time format:

##### Orders index

![Orders index](https://user-images.githubusercontent.com/1627089/47881743-09721e80-ddf5-11e8-85b6-c9484a439e95.png)

##### Order details

![Order details](https://user-images.githubusercontent.com/1627089/47881756-12fb8680-ddf5-11e8-80ce-a1bdab4fa229.png)
 