### PR TITLE
Add Rake task so that `bundle exec rake` fails when there's schema diff

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,5 +13,5 @@ if %w[development test].include? Rails.env
   RuboCop::RakeTask.new(:rubocop)
 
   Rake::Task[:default].clear
-  task default: %i[rubocop spec coveralls:push]
+  task default: %i[graphql:schema:diff_check rubocop spec coveralls:push]
 end

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -295,6 +295,7 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
+  offerTotalCents: Int
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,19 +1,18 @@
 namespace 'graphql' do
   namespace 'schema' do
+    SCHEMA_FILE_PATH = '_schema.graphql'.freeze
+    ORIG_SCHEMA_PATH = '_schema.graphql.orig'.freeze
+
     desc 'fail if there is ungenerated diff in _schema.graphql'
     task :diff_check do
       puts 'Checking for GraphQL schema diffs...'
-      no_schema_diff_exists = system(
-        'cp _schema.graphql _schema.graphql.orig &&' \
-        'rake graphql:schema:idl > /dev/null && ' \
-        'diff _schema.graphql.orig _schema.graphql'
-      )
 
-      if no_schema_diff_exists
-        system('rm _schema.graphql.orig')
-      else
-        raise failure_message
-      end
+      cp SCHEMA_FILE_PATH, ORIG_SCHEMA_PATH, verbose: false
+      Rake::Task['graphql:schema:idl'].invoke
+
+      raise failure_message unless identical?(SCHEMA_FILE_PATH, ORIG_SCHEMA_PATH)
+    ensure
+      rm(ORIG_SCHEMA_PATH, verbose: false) if File.exist?(ORIG_SCHEMA_PATH)
     end
 
     def failure_message

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,13 +1,19 @@
 namespace 'graphql' do
   namespace 'schema' do
-    desc 'fail if there is uncommitted diff in _schema.graphql'
+    desc 'fail if there is ungenerated diff in _schema.graphql'
     task :diff_check do
-      is_successful = system(
+      puts 'Checking for GraphQL schema diffs...'
+      no_schema_diff_exists = system(
+        'cp _schema.graphql{,.orig} &&' \
         'rake graphql:schema:idl > /dev/null && ' \
-        'git diff --exit-code _schema.graphql > /dev/null'
+        'diff _schema.graphql.orig _schema.graphql'
       )
 
-      raise(failure_message) unless is_successful
+      if no_schema_diff_exists
+        system('rm _schema.graphql.orig')
+      else
+        raise failure_message
+      end
     end
 
     def failure_message

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -4,7 +4,7 @@ namespace 'graphql' do
     task :diff_check do
       puts 'Checking for GraphQL schema diffs...'
       no_schema_diff_exists = system(
-        'cp _schema.graphql{,.orig} &&' \
+        'cp _schema.graphql _schema.graphql.orig &&' \
         'rake graphql:schema:idl > /dev/null && ' \
         'diff _schema.graphql.orig _schema.graphql'
       )

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,0 +1,18 @@
+namespace 'graphql' do
+  namespace 'schema' do
+    desc 'fail if there is uncommitted diff in _schema.graphql'
+    task :diff_check do
+      is_successful = system(
+        'rake graphql:schema:idl > /dev/null && ' \
+        'git diff --exit-code _schema.graphql > /dev/null'
+      )
+
+      raise(failure_message) unless is_successful
+    end
+
+    def failure_message
+      "\nYou changed your GraphQL types without updating the schema. \n" \
+        "Run a `rake graphql:schema:idl` and commit to perform the schema update.\n\n"
+    end
+  end
+end


### PR DESCRIPTION
If a developer forgets to run `rake graphql:schema:idl` and commit the
schema diff after changing GraphQL types, then `bundle exec rake` fails.

* Adds new `rake graphql:schema:diff_check`
* Adds new task as the first step of default Rake task