### PR TITLE
Line Item List Price

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -299,6 +299,7 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
+  offerTotalCents: Int! @deprecated(reason: "itemsTotalCents reflects offer total for offer orders.")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -279,6 +279,8 @@ type Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+
+  # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int!
   lastApprovedAt: DateTime
   lastOffer: Offer
@@ -297,7 +299,6 @@ type Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offerTotalCents: Int
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -191,7 +191,8 @@ type LineItem {
     last: Int
   ): FulfillmentConnection
   id: ID!
-  priceCents: Int!
+  listPriceCents: Int!
+  priceCents: Int! @deprecated(reason: "switch to use listPrice")
   quantity: Int!
   updatedAt: DateTime!
 }
@@ -321,6 +322,7 @@ type Order {
   stateReason: String
   stateUpdatedAt: DateTime
   taxTotalCents: Int
+  totalListPriceCents: Int!
   transactionFeeCents: Int
   updatedAt: DateTime!
 }

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -192,7 +192,7 @@ type LineItem {
   ): FulfillmentConnection
   id: ID!
   listPriceCents: Int!
-  priceCents: Int! @deprecated(reason: "switch to use listPrice")
+  priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   updatedAt: DateTime!
 }

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -45,7 +45,7 @@ ActiveAdmin.register Order do
     OrderCancellationService.new(resource).refund!
     redirect_to resource_path, notice: "Refunded!"
   end
-  
+
   member_action :approve_order, method: :post do
     OrderApproveService.new(resource, current_user[:id]).process!
     redirect_to resource_path, notice: "Order approved!"
@@ -64,7 +64,7 @@ ActiveAdmin.register Order do
     end
   end
 
-  
+
   action_item :approve_order, only: :show do
     if order.state == Order::SUBMITTED
       link_to 'Approve Order', approve_order_admin_order_path(order), method: :post, data: {confirm: 'Approve this order?'}
@@ -246,7 +246,7 @@ ActiveAdmin.register Order do
         end
       end
 
-      items_total = order.items_total_cents.to_f/100
+      items_total = order.total_list_price_cents.to_f/100
       shipping_total = order.shipping_total_cents.to_f/100
       tax_total = order.tax_total_cents.to_f/100
       sub_total = items_total + shipping_total + tax_total
@@ -256,7 +256,7 @@ ActiveAdmin.register Order do
       seller_payout = sub_total - transaction_fee - commission_fee
 
       attributes_table_for order do
-        row "Artwork Price" do |order|
+        row "Artwork List Price" do |order|
           number_to_currency items_total
         end
         row "Shipping" do |order|

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -7,8 +7,8 @@ module Errors
       credit_card_missing_external_id
       credit_card_not_found
       failed_order_code_generation
-      invalid_artwork_address
       invalid_amount_cents
+      invalid_artwork_address
       invalid_commission_rate
       invalid_order
       invalid_seller_address
@@ -31,8 +31,9 @@ module Errors
       no_taxable_addresses
       not_acquireable
       not_found
-      not_offerable
       not_last_offer
+      not_offerable
+      offer_more_than_one_line_item
       unknown_artwork
       unknown_edition_set
       unknown_partner

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -53,7 +53,7 @@ class OrderEvent < Events::BaseEvent
 
   def line_item_detail(line_item)
     {
-      price_cents: line_item.price_cents,
+      price_cents: line_item.list_price_cents,
       artwork_id: line_item.artwork_id,
       edition_set_id: line_item.edition_set_id,
       quantity: line_item.quantity,

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -54,6 +54,7 @@ class OrderEvent < Events::BaseEvent
   def line_item_detail(line_item)
     {
       price_cents: line_item.list_price_cents,
+      list_price_cents: line_item.list_price_cents,
       artwork_id: line_item.artwork_id,
       edition_set_id: line_item.edition_set_id,
       quantity: line_item.quantity,

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -47,6 +47,7 @@ class TransactionEvent < Events::BaseEvent
   def line_item_detail(line_item)
     {
       price_cents: line_item.list_price_cents,
+      list_price_cents: line_item.list_price_cents,
       artwork_id: line_item.artwork_id,
       edition_set_id: line_item.edition_set_id,
       quantity: line_item.quantity,

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -46,7 +46,7 @@ class TransactionEvent < Events::BaseEvent
 
   def line_item_detail(line_item)
     {
-      price_cents: line_item.price_cents,
+      price_cents: line_item.list_price_cents,
       artwork_id: line_item.artwork_id,
       edition_set_id: line_item.edition_set_id,
       quantity: line_item.quantity,

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -3,7 +3,7 @@ class Types::LineItemType < Types::BaseObject
   graphql_name 'LineItem'
 
   field :id, ID, null: false
-  field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPrice'
+  field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPriceCents'
   field :list_price_cents, Integer, null: false
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -3,9 +3,8 @@ class Types::LineItemType < Types::BaseObject
   graphql_name 'LineItem'
 
   field :id, ID, null: false
-  field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPrice or effectivePrice'
+  field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPrice'
   field :list_price_cents, Integer, null: false
-  field :effective_price, Integer, null: true
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true
   field :quantity, Integer, null: false

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -3,7 +3,9 @@ class Types::LineItemType < Types::BaseObject
   graphql_name 'LineItem'
 
   field :id, ID, null: false
-  field :price_cents, Integer, null: false
+  field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPrice or effectivePrice'
+  field :list_price_cents, Integer, null: false
+  field :effective_price, Integer, null: true
   field :artwork_id, String, null: false
   field :edition_set_id, String, null: true
   field :quantity, Integer, null: false
@@ -11,4 +13,8 @@ class Types::LineItemType < Types::BaseObject
   field :created_at, Types::DateTimeType, null: false
   field :updated_at, Types::DateTimeType, null: false
   field :fulfillments, Types::FulfillmentType.connection_type, null: true
+
+  def price_cents
+    object.list_price_cents
+  end
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -30,6 +30,7 @@ class Types::OrderType < Types::BaseObject
     argument :from_id, String, required: false
     argument :from_type, String, required: false
   end
+  field :total_list_price_cents, Integer, null: false
   field :offer_total_cents, Integer, null: true
   field :last_offer, Types::OfferType, null: true
   field :tax_total_cents, Integer, null: true

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -31,6 +31,7 @@ class Types::OrderType < Types::BaseObject
     argument :from_type, String, required: false
   end
   field :total_list_price_cents, Integer, null: false
+  field :offer_total_cents, Integer, null: false, deprecation_reason: 'itemsTotalCents reflects offer total for offer orders.'
   field :last_offer, Types::OfferType, null: true
   field :tax_total_cents, Integer, null: true
   field :transaction_fee_cents, Integer, null: true, seller_only: true
@@ -75,5 +76,10 @@ class Types::OrderType < Types::BaseObject
     else
       object.offers.all
     end
+  end
+
+  def offer_total_cents
+    # This can be removed once reaction is updated to `itemsTotalCents`
+    object.items_total_cents
   end
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -76,4 +76,8 @@ class Types::OrderType < Types::BaseObject
       object.offers.all
     end
   end
+
+  def offer_total_cents
+    object.last_offer&.amount_cents
+  end
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -14,7 +14,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :currency_code, String, null: false
   field :display_commission_rate, String, null: true
-  field :items_total_cents, Integer, null: false
+  field :items_total_cents, Integer, null: false, description: 'Item total in cents, for Offer Orders this field reflects current offer'
   field :last_approved_at, Types::DateTimeType, null: true
   field :last_submitted_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true
@@ -31,7 +31,6 @@ class Types::OrderType < Types::BaseObject
     argument :from_type, String, required: false
   end
   field :total_list_price_cents, Integer, null: false
-  field :offer_total_cents, Integer, null: true
   field :last_offer, Types::OfferType, null: true
   field :tax_total_cents, Integer, null: true
   field :transaction_fee_cents, Integer, null: true, seller_only: true
@@ -76,9 +75,5 @@ class Types::OrderType < Types::BaseObject
     else
       object.offers.all
     end
-  end
-
-  def offer_total_cents
-    object.last_offer&.amount_cents
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -3,7 +3,15 @@ class LineItem < ApplicationRecord
   has_many :line_item_fulfillments, dependent: :destroy
   has_many :fulfillments, through: :line_item_fulfillments
 
+  before_create :validate_creation
+
   def total_amount_cents
-    order.mode == Order::BUY ? list_price_cents * quantity : order.last_offer.amount_cents
+    order.mode == Order::BUY ? list_price_cents * quantity : order.last_offer&.amount_cents
+  end
+
+  private
+
+  def validate_creation
+    # Offer orders can have only one line item
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -6,12 +6,17 @@ class LineItem < ApplicationRecord
   before_create :validate_creation
 
   def total_amount_cents
-    order.mode == Order::BUY ? list_price_cents * quantity : order.last_offer&.amount_cents
+    order.mode == Order::BUY ? total_list_price : order.last_offer&.amount_cents
+  end
+
+  def total_list_price
+    list_price_cents * quantity
   end
 
   private
 
   def validate_creation
     # Offer orders can have only one line item
+    raise Errors::ValidationError, :offer_more_than_one_line_item if order.mode == Order::OFFER && order.line_items.exists?
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -4,6 +4,6 @@ class LineItem < ApplicationRecord
   has_many :fulfillments, through: :line_item_fulfillments
 
   def total_amount_cents
-    price_cents * quantity
+    order.mode == Order::BUY ? list_price_cents * quantity : order.last_offer.amount_cents
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -146,6 +146,10 @@ class Order < ApplicationRecord
     admin_notes.order(:created_at).last
   end
 
+  def total_list_price_cents
+    line_items.map(&:total_list_price).sum
+  end
+
   private
 
   def state_reason_inclusion

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -147,7 +147,7 @@ class Order < ApplicationRecord
   end
 
   def total_list_price_cents
-    line_items.map(&:total_list_price).sum
+    line_items.map(&:total_list_price_cents).sum
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -146,10 +146,6 @@ class Order < ApplicationRecord
     admin_notes.order(:created_at).last
   end
 
-  def current_total_cents
-    mode == OFFER ? offer_total_cents : items_total_cents
-  end
-
   private
 
   def state_reason_inclusion

--- a/app/services/base_create_order_service.rb
+++ b/app/services/base_create_order_service.rb
@@ -34,7 +34,7 @@ class BaseCreateOrderService
         artwork_id: @artwork_id,
         artwork_version_id: @artwork[:current_version_id],
         edition_set_id: @edition_set_id,
-        price_cents: artwork_price,
+        list_price_cents: artwork_price,
         quantity: @quantity
       )
       OrderTotalUpdaterService.new(@order).update_totals!

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -75,7 +75,7 @@ class SalesTaxService
     @tax_client.tax_for_order(
       construct_tax_params(
         line_items: [{
-          unit_price: UnitConverter.convert_cents_to_dollars(@line_item.price_cents),
+          unit_price: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents / @line_item.quantity),
           quantity: @line_item.quantity
         }]
       )

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -75,7 +75,7 @@ class SalesTaxService
     @tax_client.tax_for_order(
       construct_tax_params(
         line_items: [{
-          unit_price: UnitConverter.convert_cents_to_dollars(@line_item.total_amount_cents / @line_item.quantity),
+          unit_price: UnitConverter.convert_cents_to_dollars(@line_item.effective_price_cents),
           quantity: @line_item.quantity
         }]
       )

--- a/db/migrate/20181105214933_rename_line_item_price_cents.rb
+++ b/db/migrate/20181105214933_rename_line_item_price_cents.rb
@@ -1,0 +1,6 @@
+class RenameLineItemPriceCents < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :line_items, :price_cents, :list_price_cents
+    remove_column :orders, :offer_total_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_30_164042) do
+ActiveRecord::Schema.define(version: 2018_11_05_214933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2018_10_30_164042) do
     t.uuid "order_id"
     t.string "artwork_id"
     t.string "edition_set_id"
-    t.integer "price_cents"
+    t.integer "list_price_cents"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "quantity", default: 1, null: false
@@ -121,7 +121,6 @@ ActiveRecord::Schema.define(version: 2018_10_30_164042) do
     t.float "commission_rate"
     t.string "mode", null: false
     t.uuid "last_offer_id"
-    t.integer "offer_total_cents"
     t.string "original_user_agent"
     t.string "original_user_ip"
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"

--- a/spec/controllers/api/requests/create_offer_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_offer_order_with_artwork_mutation_request_spec.rb
@@ -94,7 +94,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.seller_id).to eq partner_id
                 expect(order.seller_type).to eq 'gallery'
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -114,7 +114,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -174,7 +174,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -197,7 +197,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.buyer_id).to eq jwt_user_id
               expect(order.seller_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 5400_12
+              expect(order.line_items.first.list_price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 2
@@ -219,7 +219,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.buyer_id).to eq jwt_user_id
               expect(order.seller_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 5400_12
+              expect(order.line_items.first.list_price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 2
@@ -239,7 +239,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 5400_12
+                expect(order.line_items.first.list_price_cents).to eq 5400_12
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to be_nil
                 expect(order.line_items.first.quantity).to eq 1

--- a/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_order_with_artwork_mutation_request_spec.rb
@@ -95,7 +95,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.seller_id).to eq partner_id
                 expect(order.seller_type).to eq 'gallery'
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -115,7 +115,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -174,7 +174,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 4200_42
+                expect(order.line_items.first.list_price_cents).to eq 4200_42
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
                 expect(order.line_items.first.quantity).to eq 2
@@ -212,7 +212,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.buyer_id).to eq jwt_user_id
               expect(order.seller_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 5400_12
+              expect(order.line_items.first.list_price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 2
@@ -233,7 +233,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.buyer_id).to eq jwt_user_id
               expect(order.seller_id).to eq partner_id
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 5400_12
+              expect(order.line_items.first.list_price_cents).to eq 5400_12
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 2
@@ -252,7 +252,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.buyer_id).to eq jwt_user_id
                 expect(order.seller_id).to eq partner_id
                 expect(order.line_items.count).to eq 1
-                expect(order.line_items.first.price_cents).to eq 5400_12
+                expect(order.line_items.first.list_price_cents).to eq 5400_12
                 expect(order.line_items.first.artwork_id).to eq 'artwork-id'
                 expect(order.line_items.first.edition_set_id).to be_nil
                 expect(order.line_items.first.quantity).to eq 1

--- a/spec/controllers/api/requests/fulfill_at_once_request_spec.rb
+++ b/spec/controllers/api/requests/fulfill_at_once_request_spec.rb
@@ -8,7 +8,7 @@ describe Api::GraphqlController, type: :request do
     let(:credit_card_id) { 'cc-1' }
     let(:order) { Fabricate(:order, seller_id: partner_id, buyer_id: user_id) }
     let!(:line_items) do
-      Array.new(2) { Fabricate(:line_item, order: order, price_cents: 200) }
+      Array.new(2) { Fabricate(:line_item, order: order, list_price_cents: 200) }
     end
 
     let(:mutation) do

--- a/spec/controllers/api/requests/order_field_permissions_spec.rb
+++ b/spec/controllers/api/requests/order_field_permissions_spec.rb
@@ -19,7 +19,7 @@ describe Api::GraphqlController, type: :request do
         seller_total_cents: 1050_00
       )
     end
-    let!(:line_item) { Fabricate(:line_item, price_cents: 100_00, quantity: 2, commission_fee_cents: 40_00, order: order) }
+    let!(:line_item) { Fabricate(:line_item, list_price_cents: 100_00, quantity: 2, commission_fee_cents: 40_00, order: order) }
     context 'as buyer' do
       let(:jwt_partner_ids) { [] }
       let(:jwt_user_id) { user_id }
@@ -37,6 +37,7 @@ describe Api::GraphqlController, type: :request do
                   node {
                     id
                     priceCents
+                    listPriceCents
                     quantity
                     commissionFeeCents
                   }
@@ -53,7 +54,7 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.seller_total_cents).to be_nil
         expect(result.data.order.buyer_total_cents).to eq 1100_00
         expect(result.data.order.line_items.edges.first.node.commission_fee_cents).to be_nil
-        expect(result.data.order.line_items.edges.first.node.price_cents).to eq 100_00
+        expect(result.data.order.line_items.edges.first.node.list_price_cents).to eq 100_00
       end
     end
 
@@ -73,6 +74,7 @@ describe Api::GraphqlController, type: :request do
                   node {
                     id
                     priceCents
+                    listPriceCents
                     quantity
                     commissionFeeCents
                   }
@@ -89,6 +91,7 @@ describe Api::GraphqlController, type: :request do
         expect(result.data.order.commission_fee_cents).to eq 30_00
         expect(result.data.order.line_items.edges.first.node.commission_fee_cents).to eq 40_00
         expect(result.data.order.line_items.edges.first.node.price_cents).to eq 100_00
+        expect(result.data.order.line_items.edges.first.node.list_price_cents).to eq 100_00
       end
     end
 

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -32,7 +32,7 @@ describe Api::GraphqlController, type: :request do
     end
     let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
     let(:line_item) do
-      Fabricate(:line_item, order: order, price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
+      Fabricate(:line_item, order: order, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
     end
 
     let(:mutation) do

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -31,8 +31,8 @@ describe OrderEvent, type: :events do
               buyer_total_cents: 380,
               **shipping_info)
   end
-  let(:line_item1) { Fabricate(:line_item, price_cents: 200, order: order, commission_fee_cents: 40) }
-  let(:line_item2) { Fabricate(:line_item, price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
+  let(:line_item1) { Fabricate(:line_item, list_price_cents: 200, order: order, commission_fee_cents: 40) }
+  let(:line_item2) { Fabricate(:line_item, list_price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
   let!(:line_items) { [line_item1, line_item2] }
   let(:line_item_properties) do
     [

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -38,6 +38,7 @@ describe OrderEvent, type: :events do
     [
       {
         price_cents: 200,
+        list_price_cents: 200,
         artwork_id: line_item1.artwork_id,
         edition_set_id: line_item1.edition_set_id,
         quantity: 1,
@@ -45,6 +46,7 @@ describe OrderEvent, type: :events do
       },
       {
         price_cents: 100,
+        list_price_cents: 100,
         artwork_id: line_item2.artwork_id,
         edition_set_id: line_item2.edition_set_id,
         quantity: 2,

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -37,6 +37,7 @@ describe TransactionEvent, type: :events do
     [
       {
         price_cents: 200,
+        list_price_cents: 200,
         artwork_id: line_item1.artwork_id,
         edition_set_id: line_item1.edition_set_id,
         quantity: 1,
@@ -44,6 +45,7 @@ describe TransactionEvent, type: :events do
       },
       {
         price_cents: 100,
+        list_price_cents: 100,
         artwork_id: line_item2.artwork_id,
         edition_set_id: line_item2.edition_set_id,
         quantity: 2,

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -30,8 +30,8 @@ describe TransactionEvent, type: :events do
               **shipping_info)
   end
   let(:transaction) { Fabricate(:transaction, order: order, failure_code: 'stolen_card', failure_message: 'who stole it?', status: Transaction::FAILURE) }
-  let(:line_item1) { Fabricate(:line_item, price_cents: 200, order: order, commission_fee_cents: 40) }
-  let(:line_item2) { Fabricate(:line_item, price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
+  let(:line_item1) { Fabricate(:line_item, list_price_cents: 200, order: order, commission_fee_cents: 40) }
+  let(:line_item2) { Fabricate(:line_item, list_price_cents: 100, quantity: 2, order: order, commission_fee_cents: 20) }
   let!(:line_items) { [line_item1, line_item2] }
   let(:line_item_properties) do
     [

--- a/spec/fabricators/line_item_fabricator.rb
+++ b/spec/fabricators/line_item_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:line_item) do
-  price_cents { 100_00 }
+  list_price_cents { 100_00 }
   artwork_id { sequence(:artwork_id) { |i| "artwork-id-#{i}" } }
   quantity { 1 }
   order { Fabricate(:order) }

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe LineItem, type: :model do
+  let(:mode) { Order::BUY }
+  let(:order) { Fabricate(:order, mode: mode) }
+
+  describe 'validation' do
+    context 'Buy Order' do
+      it 'can create many line items' do
+        expect do
+          order.line_items.create!(quantity: 2)
+          order.line_items.create!(quantity: 3)
+        end.to change(order.line_items, :count).by(2)
+      end
+    end
+
+    context 'Offer Order' do
+      let(:mode) { Order::OFFER }
+      it 'creates line item' do
+        expect do
+          order.line_items.create!(quantity: 2)
+        end.to change(order.line_items, :count).by(1)
+      end
+      it 'raises error when creating second line item' do
+        order.line_items.create!(quantity: 2)
+        expect do
+          order.line_items.create!(quantity: 4)
+        end.to raise_error do |error|
+          expect(error.type).to eq :validation
+          expect(error.code).to eq :offer_more_than_one_line_item
+        end
+      end
+    end
+  end
+  describe '#total_amount_cents' do
+    context 'Offer Order' do
+      let(:mode) { Order::OFFER }
+      context 'without last offer' do
+        it 'returns nil' do
+          line_item = Fabricate(:line_item, order: order, list_price_cents: 200, quantity: 3)
+          Fabricate(:offer, order: order, amount_cents: 420)
+          expect(line_item.total_amount_cents).to be_nil
+        end
+      end
+      context 'with last offer' do
+        it 'returns offer amount' do
+          line_item = Fabricate(:line_item, order: order, list_price_cents: 200, quantity: 3)
+          offer = Fabricate(:offer, order: order, amount_cents: 420)
+          order.update!(last_offer: offer)
+          expect(line_item.total_amount_cents).to eq 420
+        end
+      end
+    end
+    context 'Buy Order' do
+      it 'returns total list price' do
+        line_item = Fabricate(:line_item, order: order, list_price_cents: 200, quantity: 3)
+        expect(line_item.total_amount_cents).to eq 600
+      end
+    end
+  end
+
+  describe '#total_list_price' do
+    it 'returns proper list price' do
+      line_item = Fabricate(:line_item, list_price_cents: 200, quantity: 3)
+      expect(line_item.total_list_price).to eq 600
+    end
+  end
+end

--- a/spec/models/order_line_item_spec.rb
+++ b/spec/models/order_line_item_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe LineItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/services/create_buy_order_service_spec.rb
+++ b/spec/services/create_buy_order_service_spec.rb
@@ -20,7 +20,7 @@ describe CreateBuyOrderService, type: :services do
             expect(order.buyer_id).to eq user_id
             expect(order.seller_id).to eq 'gravity-partner-id'
             expect(order.line_items.count).to eq 1
-            expect(order.line_items.first.price_cents).to eq 5400_12
+            expect(order.line_items.first.list_price_cents).to eq 5400_12
             expect(order.line_items.first.artwork_id).to eq 'artwork-id'
             expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
             expect(order.line_items.first.edition_set_id).to be_nil
@@ -52,7 +52,7 @@ describe CreateBuyOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
@@ -75,7 +75,7 @@ describe CreateBuyOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
@@ -143,7 +143,7 @@ describe CreateBuyOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'

--- a/spec/services/create_offer_order_service_spec.rb
+++ b/spec/services/create_offer_order_service_spec.rb
@@ -25,7 +25,7 @@ describe CreateOfferOrderService, type: :services do
             expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
             expect(order.line_items.first.edition_set_id).to be_nil
             expect(order.line_items.first.quantity).to eq 2
-            expect(order.items_total_cents).to eq 10800_24
+            expect(order.items_total_cents).to be_nil
             expect(order.mode).to eq Order::OFFER
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end

--- a/spec/services/create_offer_order_service_spec.rb
+++ b/spec/services/create_offer_order_service_spec.rb
@@ -20,13 +20,12 @@ describe CreateOfferOrderService, type: :services do
             expect(order.buyer_id).to eq user_id
             expect(order.seller_id).to eq 'gravity-partner-id'
             expect(order.line_items.count).to eq 1
-            expect(order.line_items.first.price_cents).to eq 5400_12
+            expect(order.line_items.first.list_price_cents).to eq 5400_12
             expect(order.line_items.first.artwork_id).to eq 'artwork-id'
             expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
             expect(order.line_items.first.edition_set_id).to be_nil
             expect(order.line_items.first.quantity).to eq 2
             expect(order.items_total_cents).to eq 10800_24
-            expect(order.offer_total_cents).to be_nil
             expect(order.mode).to eq Order::OFFER
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
@@ -53,7 +52,7 @@ describe CreateOfferOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
@@ -76,7 +75,7 @@ describe CreateOfferOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'
@@ -144,7 +143,7 @@ describe CreateOfferOrderService, type: :services do
               expect(order.buyer_id).to eq user_id
               expect(order.seller_id).to eq 'gravity-partner-id'
               expect(order.line_items.count).to eq 1
-              expect(order.line_items.first.price_cents).to eq 4200_42
+              expect(order.line_items.first.list_price_cents).to eq 4200_42
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.artwork_version_id).to eq 'current-version-id'
               expect(order.line_items.first.edition_set_id).to eq 'edition-set-id'

--- a/spec/services/offers/initial_offer_service_spec.rb
+++ b/spec/services/offers/initial_offer_service_spec.rb
@@ -8,7 +8,7 @@ describe Offers::InitialOfferService, type: :services do
     let(:state) { Order::PENDING }
     let(:state_reason) { nil }
     let(:order) { Fabricate(:order, seller_id: user_id, seller_type: Order::USER, state: state, state_reason: state_reason, mode: mode) }
-    let!(:line_item) { Fabricate(:line_item, order: order, price_cents: 500) }
+    let!(:line_item) { Fabricate(:line_item, order: order, list_price_cents: 500) }
     let(:service) { Offers::InitialOfferService.new(order, amount_cents, user_id) }
     context 'Buy Order' do
       let(:mode) { Order::BUY }
@@ -51,8 +51,7 @@ describe Offers::InitialOfferService, type: :services do
         expect(offer.creator_id).to eq user_id
         expect(order.reload.state).to eq state
         expect(order.last_offer).to eq offer
-        expect(order.items_total_cents).to eq 5_00
-        expect(order.offer_total_cents).to eq 2_00
+        expect(order.items_total_cents).to eq 2_00
       end
     end
   end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe OrderApproveService, type: :services do
   include_context 'use stripe mock'
   let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: Order::SUBMITTED) }
-  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, price_cents: 124_00)] }
+  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderApproveService.new(order, user_id) }
 

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -4,7 +4,7 @@ describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
   let(:order_state) { Order::SUBMITTED }
   let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state) }
-  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, price_cents: 124_00)] }
+  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
   let(:artwork_inventory_deduct_request_status) { 200 }

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -5,7 +5,7 @@ describe OrderService, type: :services do
   let(:state) { Order::PENDING }
   let(:state_reason) { state == Order::CANCELED ? 'seller_lapsed' : nil }
   let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: state, state_reason: state_reason) }
-  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, price_cents: 124_00)] }
+  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
 
   describe 'set_payment!' do

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -19,8 +19,8 @@ describe OrderSubmitService, type: :services do
   let(:artwork2) { { _id: 'a-2', current_version_id: '1' } }
   let!(:line_items) do
     [
-      Fabricate(:line_item, order: order, price_cents: 2000_00, artwork_id: artwork1[:_id], artwork_version_id: artwork1[:current_version_id], quantity: 1),
-      Fabricate(:line_item, order: order, price_cents: 8000_00, artwork_id: artwork2[:_id], artwork_version_id: artwork2[:current_version_id], edition_set_id: 'es-1', quantity: 2)
+      Fabricate(:line_item, order: order, list_price_cents: 2000_00, artwork_id: artwork1[:_id], artwork_version_id: artwork1[:current_version_id], quantity: 1),
+      Fabricate(:line_item, order: order, list_price_cents: 8000_00, artwork_id: artwork2[:_id], artwork_version_id: artwork2[:current_version_id], edition_set_id: 'es-1', quantity: 2)
     ]
   end
   let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id }, deactivated_at: nil } }

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -64,8 +64,7 @@ describe OrderTotalUpdaterService, type: :service do
     end
     context 'OFFER order' do
       let(:mode) { Order::OFFER }
-      let(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
-      let!(:line_items) { [line_item1 ] }
+      let!(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
 
       context 'with last_offer' do
         let(:offer) { Fabricate(:offer, order: order, amount_cents: 300_00) }
@@ -82,7 +81,7 @@ describe OrderTotalUpdaterService, type: :service do
               expect(order.buyer_total_cents).to eq(300_00 + 50_00 + 60_00)
               expect(order.transaction_fee_cents).to eq 12_19
               expect(order.commission_fee_cents).to be_nil
-              expect(order.seller_total_cents).to eq(300_00 + 50_00 + 60_00 - (12_19))
+              expect(order.seller_total_cents).to eq(300_00 + 50_00 + 60_00 - 12_19)
             end
           end
           context 'with commission rate' do

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -16,8 +16,8 @@ describe OrderTotalUpdaterService, type: :service do
         end
       end
       context 'with line items' do
-        let(:line_item1) { Fabricate(:line_item, order: order, price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
-        let(:line_item2) { Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
+        let(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
+        let(:line_item2) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
         let!(:line_items) { [line_item1, line_item2] }
         context 'with shipping and tax' do
           let(:shipping_total_cents) { 50_00 }
@@ -64,8 +64,8 @@ describe OrderTotalUpdaterService, type: :service do
     end
     context 'OFFER order' do
       let(:mode) { Order::OFFER }
-      let(:line_item1) { Fabricate(:line_item, order: order, price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
-      let(:line_item2) { Fabricate(:line_item, order: order, price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
+      let(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
+      let(:line_item2) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
       let!(:line_items) { [line_item1, line_item2] }
 
       context 'with last_offer' do
@@ -79,8 +79,7 @@ describe OrderTotalUpdaterService, type: :service do
           context 'without commission rate' do
             it 'sets correct totals on the order' do
               OrderTotalUpdaterService.new(order).update_totals!
-              expect(order.items_total_cents).to eq 500_00
-              expect(order.offer_total_cents).to eq 300_00
+              expect(order.items_total_cents).to eq 300_00
               expect(order.buyer_total_cents).to eq(300_00 + 50_00 + 60_00)
               expect(order.transaction_fee_cents).to eq 12_19
               expect(order.commission_fee_cents).to be_nil
@@ -102,8 +101,7 @@ describe OrderTotalUpdaterService, type: :service do
             end
             it 'sets correct totals on the order' do
               OrderTotalUpdaterService.new(order, 0.40).update_totals!
-              expect(order.items_total_cents).to eq 500_00
-              expect(order.offer_total_cents).to eq 300_00
+              expect(order.items_total_cents).to eq 300_00
               expect(order.buyer_total_cents).to eq(300_00 + 50_00 + 60_00)
               expect(order.transaction_fee_cents).to eq 12_19
               expect(order.commission_fee_cents).to eq 120_00
@@ -111,8 +109,8 @@ describe OrderTotalUpdaterService, type: :service do
             end
             it 'does not set commission on line items' do
               OrderTotalUpdaterService.new(order, 0.40).update_totals!
-              expect(line_item1.reload.commission_fee_cents).to be_nil
-              expect(line_item2.reload.commission_fee_cents).to be_nil
+              expect(line_item1.reload.commission_fee_cents).to eq 12000
+              expect(line_item2.reload.commission_fee_cents).to eq 12000
             end
           end
         end

--- a/spec/services/order_total_updater_service_spec.rb
+++ b/spec/services/order_total_updater_service_spec.rb
@@ -64,9 +64,8 @@ describe OrderTotalUpdaterService, type: :service do
     end
     context 'OFFER order' do
       let(:mode) { Order::OFFER }
-      let(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 100_00, sales_tax_cents: 500, should_remit_sales_tax: true) }
-      let(:line_item2) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
-      let!(:line_items) { [line_item1, line_item2] }
+      let(:line_item1) { Fabricate(:line_item, order: order, list_price_cents: 200_00, quantity: 2, sales_tax_cents: 10_00, should_remit_sales_tax: false) }
+      let!(:line_items) { [line_item1 ] }
 
       context 'with last_offer' do
         let(:offer) { Fabricate(:offer, order: order, amount_cents: 300_00) }
@@ -83,7 +82,7 @@ describe OrderTotalUpdaterService, type: :service do
               expect(order.buyer_total_cents).to eq(300_00 + 50_00 + 60_00)
               expect(order.transaction_fee_cents).to eq 12_19
               expect(order.commission_fee_cents).to be_nil
-              expect(order.seller_total_cents).to eq(410_00 - 12_19 - 500)
+              expect(order.seller_total_cents).to eq(300_00 + 50_00 + 60_00 - (12_19))
             end
           end
           context 'with commission rate' do
@@ -105,12 +104,11 @@ describe OrderTotalUpdaterService, type: :service do
               expect(order.buyer_total_cents).to eq(300_00 + 50_00 + 60_00)
               expect(order.transaction_fee_cents).to eq 12_19
               expect(order.commission_fee_cents).to eq 120_00
-              expect(order.seller_total_cents).to eq(410_00 - (12_19 + 120_00 + 500))
+              expect(order.seller_total_cents).to eq(410_00 - (12_19 + 120_00))
             end
             it 'does not set commission on line items' do
               OrderTotalUpdaterService.new(order, 0.40).update_totals!
               expect(line_item1.reload.commission_fee_cents).to eq 12000
-              expect(line_item2.reload.commission_fee_cents).to eq 12000
             end
           end
         end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -4,7 +4,7 @@ require 'support/gravity_helper'
 describe SalesTaxService, type: :services do
   let(:taxjar_client) { double }
   let(:order) { Fabricate(:order, id: 1) }
-  let!(:line_item) { Fabricate(:line_item, id: 1, order: order, price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
+  let!(:line_item) { Fabricate(:line_item, id: 1, order: order, list_price_cents: 2000_00, artwork_id: 'gravity_artwork_1', sales_tax_cents: 100) }
   let(:shipping_total_cents) { 2222 }
   let(:transaction_id) { "#{line_item.order.id}__#{line_item.id}" }
   let(:shipping) do
@@ -39,7 +39,7 @@ describe SalesTaxService, type: :services do
   let(:artwork_location) { Address.new(gravity_v1_artwork[:location]) }
   let(:base_tax_params) do
     {
-      amount: UnitConverter.convert_cents_to_dollars(line_item.price_cents),
+      amount: UnitConverter.convert_cents_to_dollars(line_item.list_price_cents),
       nexus_addresses: seller_addresses.map do |ad|
         {
           country: ad.country,
@@ -160,7 +160,7 @@ describe SalesTaxService, type: :services do
         line_items: [
           {
             quantity: line_item.quantity,
-            unit_price: UnitConverter.convert_cents_to_dollars(line_item.price_cents)
+            unit_price: UnitConverter.convert_cents_to_dollars(line_item.list_price_cents)
           }
         ]
       )


### PR DESCRIPTION
# Problem(s)
We introduced `offer` in #261 , with that change, calculating some total amounts got complicated. Generally the relation between an `offer` and `lineItem` is little strange. Offers are made on `order`, they end up defining the total amounts being paid to seller and buyer and should be used to calculate things like shipping and tax as well.

# Solution
It seems the easiest/cleanest solution was to limit the number of line items on offer orders to 1. This means offer orders can't have more than one line item.
The `total_amount_cents` of that line item is calculated by the last offer of the order.
We still want to know the original `list_price` for that order, for that to work, we now have `total_list_price_cents` on `orderType` which basically calculates that by sum of all `list_price * quantity` of `line_items` of the order.

# Deprecated Field
we renamed `price_cents` to `list_price_cents` on `LineItem` to be more accurate about what that field represents. 
From GraphQL perspective we kept `price_cents` around but deprecated it and for now it returns `list_price_cents` so no change needed in clients immediately.

cc: @artsy/analytics  

this addresses: https://artsyproduct.atlassian.net/browse/PURCHASE-578
