### PR TITLE
[wip] Update hokusai test environment variables to include CI values

### DIFF
--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -12,20 +12,21 @@ services:
     - DATABASE_HOST=exchange-db
     - DATABASE_USER=postgres
     - REDIS_URL=redis://exchange-redis
-
-    - CI_PULL_REQUEST=$CI_PULL_REQUEST
-    - CIRCLE_PULL_REQUEST=$CIRCLE_PULL_REQUEST
-    - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
-    - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
-    - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
-    - CI=$CI
-
+    - CI
+    - CIRCLECI
+    - CIRCLE_BRANCH
+    - CIRCLE_BUILD_NUM
+    - CIRCLE_NODE_INDEX
+    - CIRCLE_NODE_TOTAL
+    - CIRCLE_PULL_REQUEST
+    - CIRCLE_SHA1
+    - CI_PULL_REQUEST
+    - COVERALLS_REPO_TOKEN
+    - DANGER_GITHUB_API_TOKEN
     command: ./hokusai/ci.sh
     depends_on:
       - exchange-db
       - exchange-redis
-    volumes:
-      - "../.git:/app/.git:ro"
   exchange-db:
     image: postgres:9.6-alpine
   exchange-redis:


### PR DESCRIPTION
Circle CI 2.0 does not support docker volume mounting or opening ports via the docker executor:

https://discuss.circleci.com/t/why-circleci-2-0-does-not-support-mounting-folders/11605/15

If your CI build needs more control over docker orchestration, including these features, you should be using the machine executor.

Circle CI executor types: https://circleci.com/docs/2.0/executor-types/

To support test coverage reporting via Coveralls while continuing to use the Circle CI docker executor, we can instead pass environment variables from the host to the container.