### PR TITLE
Relax address validation requirements

### DIFF
--- a/app/services/gravity_service.rb
+++ b/app/services/gravity_service.rb
@@ -38,8 +38,6 @@ module GravityService
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?
 
     locations.map { |loc| Address.new(loc) }
-  rescue Errors::AddressError
-    raise Errors::ValidationError.new(:invalid_seller_address, partner_id: partner_id)
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_partner, partner_id: partner_id)
   rescue Adapters::GravityError

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -72,7 +72,7 @@ class OrderShippingService
   end
 
   def validate_shipping_location!
-    raise Errors::ValidationError, :missing_country unless @shipping_address&.country.present?
+    raise Errors::ValidationError, :missing_country if @shipping_address&.country.blank?
 
     domestic_shipping_only = artworks.any? do |(_, artwork)|
       artwork[:international_shipping_fee_cents].nil? && international_shipping?(artwork[:location])

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -72,6 +72,8 @@ class OrderShippingService
   end
 
   def validate_shipping_location!
+    raise Errors::ValidationError, :missing_country unless @shipping_address&.country.present?
+
     domestic_shipping_only = artworks.any? do |(_, artwork)|
       artwork[:international_shipping_fee_cents].nil? && international_shipping?(artwork[:location])
     end

--- a/app/services/order_shipping_service.rb
+++ b/app/services/order_shipping_service.rb
@@ -62,8 +62,8 @@ class OrderShippingService
         end
       end.sum
     end
-  rescue Errors::AddressError
-    raise Errors::ValidationError, :invalid_artwork_address
+  rescue Errors::AddressError => e
+    raise Errors::ValidationError, e.code
   end
 
   def validate_artwork!(artwork)

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -7,24 +7,20 @@ class SalesTaxService
     shipping_address,
     shipping_total_cents,
     artwork_location,
-    seller_nexus_addresses,
+    nexus_addresses,
     tax_client = Taxjar::Client.new(
       api_key: Rails.application.config_for(:taxjar)['taxjar_api_key'],
       api_url: Rails.application.config_for(:taxjar)['taxjar_api_url'].presence
     )
   )
 
-    nexus_addresses = seller_nexus_addresses.select { |ad| address_taxable?(ad) }
-    # There's nothing to do here if there are no taxable addresses.
-    raise Errors::ValidationError, :no_taxable_addresses if nexus_addresses.blank?
-
+    @seller_nexus_addresses = process_nexus_addresses!(nexus_addresses)
     @line_item = line_item
     @fulfillment_type = fulfillment_type
     @tax_client = tax_client
     @artwork_location = artwork_location
     @shipping_address = shipping_address
     @shipping_total_cents = artsy_should_remit_taxes? ? shipping_total_cents : 0
-    @seller_nexus_addresses = nexus_addresses
     @transaction = nil
     @refund = nil
   end
@@ -62,7 +58,7 @@ class SalesTaxService
 
   def address_taxable?(address)
     # For the time being, we're only considering addresses in the United States to be taxable.
-    address.country == Carmen::Country.coded('US').code
+    address.united_states?
   end
 
   def get_transaction(id)
@@ -126,7 +122,32 @@ class SalesTaxService
   end
 
   def destination_address
-    @destination_address ||= @fulfillment_type == Order::SHIP ? @shipping_address : @artwork_location
+    @destination_address ||= begin
+      address = @fulfillment_type == Order::SHIP ? @shipping_address : @artwork_location
+      validate_destination_address!(address)
+      address
+    rescue Errors::AddressError => e
+      raise Errors::ValidationError, :invalid_artwork_address if @fulfillment_type == Order::PICKUP
+      raise Errors::ValidationError, e.code
+    end
+  end
+
+  def validate_destination_address!(destination_address)
+    raise Errors::AddressError, :missing_region if destination_address.region.nil?
+    raise Errors::AddressError, :missing_postal_code if destination_address.postal_code.nil?
+  end
+
+  
+  def process_nexus_addresses!(seller_nexus_addresses)
+    nexus_addresses = seller_nexus_addresses.select{ |ad| address_taxable?(ad) }
+    raise Errors::ValidationError, :no_taxable_addresses if nexus_addresses.blank?
+    
+    nexus_addresses.each { |ad| validate_nexus_address!(ad) } 
+    nexus_addresses
+  end
+  
+  def validate_nexus_address!(nexus_address)
+    raise Errors::ValidationError, :invalid_seller_address if nexus_address.region.nil?
   end
 
   def transaction_id

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -126,18 +126,17 @@ class SalesTaxService
       address = @fulfillment_type == Order::SHIP ? @shipping_address : @artwork_location
       validate_destination_address!(address)
       address
-    rescue Errors::AddressError => e
+    rescue Errors::ValidationError => e
       raise Errors::ValidationError, :invalid_artwork_address if @fulfillment_type == Order::PICKUP
-      raise Errors::ValidationError, e.code
+      raise e
     end
   end
 
   def validate_destination_address!(destination_address)
-    raise Errors::AddressError, :missing_region if destination_address.region.nil?
-    raise Errors::AddressError, :missing_postal_code if destination_address.postal_code.nil?
+    raise Errors::ValidationError, :missing_region if destination_address.region.nil?
+    raise Errors::ValidationError, :missing_postal_code if destination_address.postal_code.nil?
   end
 
-  
   def process_nexus_addresses!(seller_nexus_addresses)
     nexus_addresses = seller_nexus_addresses.select{ |ad| address_taxable?(ad) }
     raise Errors::ValidationError, :no_taxable_addresses if nexus_addresses.blank?

--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -93,14 +93,16 @@ class SalesTaxService
   end
 
   def destination_address
-    @destination_address ||= begin
-      address = @fulfillment_type == Order::SHIP ? @shipping_address : @artwork_location
-      validate_destination_address!(address)
-      address
-    rescue Errors::ValidationError => e
-      raise Errors::ValidationError, :invalid_artwork_address if @fulfillment_type == Order::PICKUP
-      raise e
-    end
+    @destination_address ||=
+      begin
+        address = @fulfillment_type == Order::SHIP ? @shipping_address : @artwork_location
+        validate_destination_address!(address)
+        address
+      rescue Errors::ValidationError => e
+        raise Errors::ValidationError, :invalid_artwork_address if @fulfillment_type == Order::PICKUP
+
+        raise e
+      end
   end
 
   def address_taxable?(address)
@@ -114,17 +116,17 @@ class SalesTaxService
   end
 
   def process_nexus_addresses!(seller_nexus_addresses)
-    nexus_addresses = seller_nexus_addresses.select{ |ad| address_taxable?(ad) }
+    nexus_addresses = seller_nexus_addresses.select { |ad| address_taxable?(ad) }
     raise Errors::ValidationError, :no_taxable_addresses if nexus_addresses.blank?
-    
-    nexus_addresses.each { |ad| validate_nexus_address!(ad) } 
+
+    nexus_addresses.each { |ad| validate_nexus_address!(ad) }
     nexus_addresses
   end
-  
+
   def validate_nexus_address!(nexus_address)
     raise Errors::ValidationError, :invalid_seller_address if nexus_address.region.nil?
   end
-  
+
   def post_transaction
     transaction_date = @line_item.order.last_approved_at.iso8601
     @tax_client.create_order(

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -1,6 +1,6 @@
 class Address
   attr_reader :country, :region, :city, :street_line1, :street_line2, :postal_code
-
+  UNITED_STATES = Carmen::Country.coded('US')
   def initialize(address)
     @address = parse(address)
     @country = @address[:country]
@@ -21,15 +21,14 @@ class Address
   end
 
   def united_states?
-    @country == Carmen::Country.coded('US').code
+    @country == UNITED_STATES.code
   end
 
   # The "continental United States" is defined as any US state that isn't Alaska or Hawaii.
   def continental_us?
-    us = Carmen::Country.coded('US')
     united_states? &&
-      @region != us.subregions.coded('HI').code &&
-      @region != us.subregions.coded('AK').code
+      @region != UNITED_STATES.subregions.coded('HI').code &&
+      @region != UNITED_STATES.subregions.coded('AK').code
   end
 
   private
@@ -49,7 +48,7 @@ class Address
   end
 
   def parse_region(country, region)
-    return region unless country&.code == Carmen::Country.coded('US').code || country&.code == Carmen::Country.coded('CA').code
+    return region unless country&.code == UNITED_STATES.code || country&.code == Carmen::Country.coded('CA').code
 
     parsed_region = country.subregions.named(region) || country.subregions.coded(region)
     parsed_region&.code

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -21,10 +21,14 @@ class Address
       @postal_code == other.postal_code
   end
 
+  def united_states?
+    @country == Carmen::Country.coded('US').code
+  end
+
   # The "continental United States" is defined as any US state that isn't Alaska or Hawaii.
   def continental_us?
     us = Carmen::Country.coded('US')
-    @country == us.code &&
+    united_states? &&
       @region != us.subregions.coded('HI').code &&
       @region != us.subregions.coded('AK').code
   end
@@ -54,17 +58,5 @@ class Address
 
   def validate!
     raise Errors::AddressError, :missing_country if @address[:country].nil?
-
-    validate_us_address! if @address[:country] == Carmen::Country.coded('US').code
-    validate_ca_address! if @address[:country] == Carmen::Country.coded('CA').code
-  end
-
-  def validate_us_address!
-    raise Errors::AddressError, :missing_region if @address[:region].nil?
-    raise Errors::AddressError, :missing_postal_code if @address[:postal_code].nil?
-  end
-
-  def validate_ca_address!
-    raise Errors::AddressError, :missing_region if @address[:region].nil?
   end
 end

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -3,7 +3,6 @@ class Address
 
   def initialize(address)
     @address = parse(address)
-    validate! if address.present?
     @country = @address[:country]
     @region = @address[:region]
     @city = @address[:city]
@@ -54,9 +53,5 @@ class Address
 
     parsed_region = country.subregions.named(region) || country.subregions.coded(region)
     parsed_region&.code
-  end
-
-  def validate!
-    raise Errors::AddressError, :missing_country if @address[:country].nil?
   end
 end

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -189,6 +189,11 @@ describe Api::GraphqlController, type: :request do
         end
 
         context 'with a US-based shipping address' do
+          before do
+            allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+            allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([{country: 'US', state: 'NY'}])
+          end
           let(:shipping_country) { 'US' }
           context 'without a state' do
             let(:shipping_region) { nil }
@@ -207,19 +212,6 @@ describe Api::GraphqlController, type: :request do
               expect(response.data.set_shipping.order_or_error).to respond_to(:error)
               expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
               expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_postal_code'
-            end
-          end
-        end
-
-        context 'with a Canada based shipping address' do
-          let(:shipping_country) { 'CA' }
-          context 'without a province or territory' do
-            let(:shipping_region) { nil }
-            it 'returns proper error' do
-              response = client.execute(mutation, set_shipping_input)
-              expect(response.data.set_shipping.order_or_error).to respond_to(:error)
-              expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
-              expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
             end
           end
         end

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -192,7 +192,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([{country: 'US', state: 'NY'}])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do

--- a/spec/lib/address_spec.rb
+++ b/spec/lib/address_spec.rb
@@ -60,18 +60,6 @@ describe Address do
       end
     end
   end
-  describe '#validate!' do
-    context 'with a missing country' do
-      it 'raises an error' do
-        address_params[:country] = nil
-        expect { Address.new(address_params) }.to raise_error do |error|
-          expect(error).to be_a Errors::AddressError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :missing_country
-        end
-      end
-    end
-  end
   describe '#==' do
     context 'with an address that has the same address attributes' do
       context 'with an empty address' do

--- a/spec/lib/address_spec.rb
+++ b/spec/lib/address_spec.rb
@@ -72,41 +72,6 @@ describe Address do
       end
     end
   end
-  describe '#validate_us_address!' do
-    context 'with missing region' do
-      it 'raises an error' do
-        address_params[:region] = nil
-        expect { Address.new(address_params) }.to raise_error do |error|
-          expect(error).to be_a Errors::AddressError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :missing_region
-        end
-      end
-    end
-    context 'with missing postal code' do
-      it 'raises an error' do
-        address_params[:postal_code] = nil
-        expect { Address.new(address_params) }.to raise_error do |error|
-          expect(error).to be_a Errors::AddressError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :missing_postal_code
-        end
-      end
-    end
-  end
-  describe '#validate_ca_address!' do
-    context 'with missing region' do
-      it 'raises an error' do
-        address_params[:region] = nil
-        address_params[:country] = 'CA'
-        expect { Address.new(address_params) }.to raise_error do |error|
-          expect(error).to be_a Errors::AddressError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :missing_region
-        end
-      end
-    end
-  end
   describe '#==' do
     context 'with an address that has the same address attributes' do
       context 'with an empty address' do

--- a/spec/services/gravity_service_spec.rb
+++ b/spec/services/gravity_service_spec.rb
@@ -41,16 +41,6 @@ describe GravityService, type: :services do
           partner_addresses.each { |ad| expect(ad).to be_a Address }
         end
       end
-      context 'with an invalid partner location' do
-        it 'rescues AddressError and raises ValidationError' do
-          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/locations?private=true").and_return(invalid_location)
-          expect { GravityService.fetch_partner_locations(partner_id) }.to raise_error do |error|
-            expect(error).to be_a Errors::ValidationError
-            expect(error.code).to eq :invalid_seller_address
-            expect(error.data[:partner_id]).to eq partner_id
-          end
-        end
-      end
     end
     context 'with no partner locations' do
       it 'raises error' do

--- a/spec/services/order_shipping_service_spec.rb
+++ b/spec/services/order_shipping_service_spec.rb
@@ -150,20 +150,4 @@ describe OrderShippingService, type: :services do
       end
     end
   end
-
-  describe '#tax_total_cents' do
-    context 'with an invalid artwork location' do
-      before do
-        allow(GravityService).to receive(:fetch_partner_locations).and_return([Address.new(country: 'US', state: 'FL', postal_code: '12345')])
-      end
-      it 'rescues AddressError and raises ValidationError with a code of invalid_artwork_address' do
-        artwork[:region] = 'Floridada'
-        allow(GravityService).to receive(:get_artwork).and_return(artwork)
-        expect { @service_domestic_shipping.send(:tax_total_cents) }.to raise_error do |error|
-          expect(error).to be_a Errors::ValidationError
-          expect(error.code).to eq :invalid_artwork_address
-        end
-      end
-    end
-  end
 end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -77,42 +77,27 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#initialize' do
-    context 'with taxable nexus addresses' do
-      context 'with a destination address in a remitting state' do
-        it 'sets shipping_total_cents to the passed in value' do
-          shipping[:region] = 'FL'
-          service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
-          expect(service.instance_variable_get(:@shipping_total_cents)).to eq shipping_total_cents
-        end
-        it 'sets seller_nexus_addresses to only be taxable seller addresses' do
-          service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses + [untaxable_address])
-          expect(service.instance_variable_get(:@seller_nexus_addresses)).to eq seller_addresses
-        end
-      end
-      context 'with a destination address in a non-remitting state' do
-        it 'sets shipping_total_cents to 0' do
-          expect(@service_ship.instance_variable_get(:@shipping_total_cents)).to eq 0
-        end
+    context 'with a destination address in a remitting state' do
+      it 'sets seller_nexus_addresses to only be taxable seller addresses' do
+        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses + [untaxable_address])
+        expect(service.instance_variable_get(:@seller_nexus_addresses)).to eq seller_addresses
       end
     end
-    context 'with empty seller addresses' do
-      it 'raises error' do
-        expect { SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, []) }.to raise_error do |error|
-          expect(error).to be_a Errors::ValidationError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :no_taxable_addresses
-        end
+  end
+
+  describe '#effective_shipping_total_cents' do
+    context 'with a destination address in a remitting state' do
+      it 'sets effective_shipping_total_cents to @shipping_total_cents' do
+        shipping[:region] = 'FL'
+        service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
+        expect(service.send(:effective_shipping_total_cents)).to eq shipping_total_cents
       end
     end
-    context 'with untaxable seller addresses' do
-      it 'raises error' do
-        expect { SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, [untaxable_address]) }.to raise_error do |error|
-          expect(error).to be_a Errors::ValidationError
-          expect(error.type).to eq :validation
-          expect(error.code).to eq :no_taxable_addresses
-        end
+    context 'with a destination address in a non-remitting state' do
+      it 'sets effective_shipping_total_cents to 0' do
+        expect(@service_ship.send(:effective_shipping_total_cents)).to eq 0
       end
-    end
+    end    
   end
 
   describe '#sales_tax' do
@@ -143,13 +128,65 @@ describe SalesTaxService, type: :services do
 
   describe '#destination_address' do
     context 'with a fulfillment_type of SHIP' do
-      it 'returns the shipping address' do
-        expect(@service_ship.send(:destination_address)).to eq shipping_address
+      context 'with a valid address' do
+        it 'returns the shipping address' do
+          expect(@service_ship.send(:destination_address)).to eq shipping_address
+        end
+      end
+      context 'with an invalid address' do
+        context 'with missing region' do
+          it 'raises a missing_region error' do
+            shipping[:region] = nil
+            service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
+            expect { service.send(:destination_address) }.to raise_error do |error|
+              expect(error).to be_a Errors::ValidationError
+              expect(error.type).to eq :validation
+              expect(error.code).to eq :missing_region
+            end
+          end
+        end
+        context 'with missing postal code' do
+          it 'raises a missing_postal_code error' do
+            shipping[:postal_code] = nil
+            service = SalesTaxService.new(line_item, Order::SHIP, Address.new(shipping), shipping_total_cents, artwork_location, seller_addresses)
+            expect { service.send(:destination_address) }.to raise_error do |error|
+              expect(error).to be_a Errors::ValidationError
+              expect(error.type).to eq :validation
+              expect(error.code).to eq :missing_postal_code
+            end
+          end
+        end
       end
     end
     context 'with a fulfillment_type of PICKUP' do
-      it 'returns the origin address' do
-        expect(@service_pickup.send(:destination_address)).to eq artwork_location
+      context 'with a valid address' do
+        it 'returns the origin address' do
+          expect(@service_pickup.send(:destination_address)).to eq artwork_location
+        end
+      end
+      context 'with an invalid address' do
+        context 'with missing region' do
+          it 'raises an invalid_artwork_address error' do
+            invalid_artwork_location = Address.new(country: 'US', postal_code: '10013')
+            service = SalesTaxService.new(line_item, Order::PICKUP, Address.new(shipping), shipping_total_cents, invalid_artwork_location, seller_addresses)
+            expect { service.send(:destination_address) }.to raise_error do |error|
+              expect(error).to be_a Errors::ValidationError
+              expect(error.type).to eq :validation
+              expect(error.code).to eq :invalid_artwork_address
+            end
+          end
+        end
+        context 'with missing postal code' do
+          it 'raises an invalid_artwork_address error' do
+            invalid_artwork_location = Address.new(country: 'US', region: 'NY')
+            service = SalesTaxService.new(line_item, Order::PICKUP, Address.new(shipping), shipping_total_cents, invalid_artwork_location, seller_addresses)
+            expect { service.send(:destination_address) }.to raise_error do |error|
+              expect(error).to be_a Errors::ValidationError
+              expect(error.type).to eq :validation
+              expect(error.code).to eq :invalid_artwork_address
+            end
+          end
+        end
       end
     end
   end
@@ -331,6 +368,51 @@ describe SalesTaxService, type: :services do
     context 'with a non-US-based address' do
       it 'returns false' do
         expect(@service_ship.send(:address_taxable?, untaxable_address)).to eq false
+      end
+    end
+  end
+
+  describe '#process_nexus_addresses' do
+    context 'with no addresses' do
+      it 'raises an error' do
+        expect { @service_ship.send(:process_nexus_addresses!, []) }.to raise_error do |error|
+          expect(error).to be_a Errors::ValidationError
+          expect(error.type).to eq :validation
+          expect(error.code).to eq :no_taxable_addresses
+        end
+      end
+    end
+    context 'with no valid taxable addresses' do
+      it 'raises an error' do
+        expect { @service_ship.send(:process_nexus_addresses!, [untaxable_address]) }.to raise_error do |error|
+          expect(error).to be_a Errors::ValidationError
+          expect(error.type).to eq :validation
+          expect(error.code).to eq :no_taxable_addresses
+        end
+      end
+    end
+    context 'with taxable addresses' do
+      it 'filters out non-taxable addresses' do
+        addresses = seller_addresses + [untaxable_address]
+        expect(@service_ship.send(:process_nexus_addresses!, addresses)).to eq seller_addresses
+      end
+      it 'validates taxable addresses' do
+        seller_addresses.each do |ad|
+          expect(@service_ship).to receive(:validate_nexus_address!).with(ad)
+        end
+        @service_ship.send(:process_nexus_addresses!, seller_addresses)
+      end
+    end
+  end
+  context '#validate_nexus_address!' do
+    context 'with an address with a missing region' do
+      it 'raises an error' do
+        invalid_address = Address.new(country: 'US')
+        expect { @service_ship.send(:validate_nexus_address!, invalid_address) }.to raise_error do |error|
+          expect(error).to be_a Errors::ValidationError
+          expect(error.type).to eq :validation
+          expect(error.code).to eq :invalid_seller_address
+        end
       end
     end
   end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -97,7 +97,7 @@ describe SalesTaxService, type: :services do
       it 'sets effective_shipping_total_cents to 0' do
         expect(@service_ship.send(:effective_shipping_total_cents)).to eq 0
       end
-    end    
+    end
   end
 
   describe '#sales_tax' do


### PR DESCRIPTION
### Problem
It turns out TaxJar does not need a postal code for _seller nexus addresses_ -- the state is enough for sales tax calculation purposes. (We still need a postal code for shipping/artwork pickup addresses, though.) Additionally, our logic for validating addresses for sales tax calculations lives in the `Address` model when it should more properly live in `SalesTaxService`.

### Solution
Refactor our address validation logic to reside in `SalesTaxService` and not require seller nexus addresses to have a postal code.

### What changed
- Move sales tax address validation logic to `SalesTaxService`
- Separate out address validation based on role in sales tax calculation (i.e., destination address or seller nexus address)
- Create new `effective_shipping_total_cents` that stores the value of what amount we should use for shipping
- Reorder private methods in `SalesTaxService` so that in-use methods are nearer to the top