### PR TITLE
Verify that credit given in set payment step belongs to buyer

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -11,6 +11,7 @@ module Errors
       invalid_amount_cents
       invalid_artwork_address
       invalid_commission_rate
+      invalid_credit_card
       invalid_offer
       invalid_order
       invalid_seller_address
@@ -31,7 +32,6 @@ module Errors
       missing_required_info
       missing_required_param
       no_taxable_addresses
-      non_buyer_credit_card
       not_acquireable
       not_found
       not_last_offer

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -31,6 +31,7 @@ module Errors
       missing_required_info
       missing_required_param
       no_taxable_addresses
+      non_buyer_credit_card
       not_acquireable
       not_found
       not_last_offer

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -3,7 +3,7 @@ module OrderService
     raise Errors::ValidationError.new(:invalid_state, state: order.state) unless order.state == Order::PENDING
 
     credit_card = GravityService.get_credit_card(credit_card_id)
-    raise Errors::ValidationError.new(:non_buyer_credit_card, credit_card_id: credit_card_id) unless credit_card.dig(:user, :_id) == order.buyer_id
+    raise Errors::ValidationError.new(:invalid_credit_card, credit_card_id: credit_card_id) unless credit_card.dig(:user, :_id) == order.buyer_id
 
     order.update!(credit_card_id: credit_card_id)
     order

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -2,6 +2,9 @@ module OrderService
   def self.set_payment!(order, credit_card_id)
     raise Errors::ValidationError.new(:invalid_state, state: order.state) unless order.state == Order::PENDING
 
+    credit_card = GravityService.get_credit_card(credit_card_id)
+    raise Errors::ValidationError.new(:non_buyer_credit_card, credit_card_id: credit_card_id) unless credit_card.dig(:user, :_id) == order.buyer_id
+
     order.update!(credit_card_id: credit_card_id)
     order
   end

--- a/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
@@ -95,7 +95,7 @@ describe Api::GraphqlController, type: :request do
             expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
             response = client.execute(mutation, set_payment_input)
             expect(response.data.set_payment.order_or_error.error.type).to eq 'validation'
-            expect(response.data.set_payment.order_or_error.error.code).to eq 'non_buyer_credit_card'
+            expect(response.data.set_payment.order_or_error.error.code).to eq 'invalid_credit_card'
             expect(order.reload.credit_card_id).to be_nil
           end
         end

--- a/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_payment_mutation_request_spec.rb
@@ -6,6 +6,7 @@ describe Api::GraphqlController, type: :request do
     let(:partner_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'gravity-cc-1' }
+    let(:credit_card) { { id: credit_card_id, user: { _id: user_id } } }
     let(:order) { Fabricate(:order, seller_id: partner_id, buyer_id: user_id) }
 
     let(:mutation) do
@@ -74,15 +75,30 @@ describe Api::GraphqlController, type: :request do
         end
       end
 
-      it 'sets payments on the order' do
-        response = client.execute(mutation, set_payment_input)
-        expect(response.data.set_payment.order_or_error.order.id).to eq order.id.to_s
-        expect(response.data.set_payment.order_or_error.order.state).to eq 'PENDING'
-        expect(response.data.set_payment.order_or_error.order.credit_card_id).to eq 'gravity-cc-1'
-        expect(response.data.set_payment.order_or_error).not_to respond_to(:error)
-        expect(order.reload.credit_card_id).to eq credit_card_id
-        expect(order.state).to eq Order::PENDING
-        expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+      context 'with an order in pending state' do
+        context 'with a credit card that belongs to the buyer' do
+          it 'sets payments on the order' do
+            expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
+            response = client.execute(mutation, set_payment_input)
+            expect(response.data.set_payment.order_or_error.order.id).to eq order.id.to_s
+            expect(response.data.set_payment.order_or_error.order.state).to eq 'PENDING'
+            expect(response.data.set_payment.order_or_error.order.credit_card_id).to eq 'gravity-cc-1'
+            expect(response.data.set_payment.order_or_error).not_to respond_to(:error)
+            expect(order.reload.credit_card_id).to eq credit_card_id
+            expect(order.state).to eq Order::PENDING
+            expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+          end
+        end
+        context 'with a credit card that does not belong to the buyer' do
+          let(:invalid_credit_card) { { id: credit_card_id, user: { _id: 'someone_else' } } }
+          it 'raises an error' do
+            expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
+            response = client.execute(mutation, set_payment_input)
+            expect(response.data.set_payment.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_payment.order_or_error.error.code).to eq 'non_buyer_credit_card'
+            expect(order.reload.credit_card_id).to be_nil
+          end
+        end
       end
     end
   end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -26,7 +26,7 @@ describe OrderService, type: :services do
           expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
           expect { OrderService.set_payment!(order, credit_card_id) }.to raise_error do |error|
             expect(error).to be_a Errors::ValidationError
-            expect(error.code).to eq :non_buyer_credit_card
+            expect(error.code).to eq :invalid_credit_card
           end
         end
       end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -4,7 +4,7 @@ describe OrderService, type: :services do
   include_context 'use stripe mock'
   let(:state) { Order::PENDING }
   let(:state_reason) { state == Order::CANCELED ? 'seller_lapsed' : nil }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: state, state_reason: state_reason) }
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: state, state_reason: state_reason, buyer_id: 'b123') }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
 
@@ -12,9 +12,23 @@ describe OrderService, type: :services do
     let(:credit_card_id) { 'gravity-cc-1' }
     context 'order in pending state' do
       let(:state) { Order::PENDING }
-      it 'sets credit_card_id on the order' do
-        OrderService.set_payment!(order, credit_card_id)
-        expect(order.reload.credit_card_id).to eq 'gravity-cc-1'
+      context "with a credit card id for the buyer's credit card" do
+        let(:credit_card) { { id: credit_card_id, user: { _id: 'b123' } } }
+        it 'sets credit_card_id on the order' do
+          expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
+          OrderService.set_payment!(order, credit_card_id)
+          expect(order.reload.credit_card_id).to eq 'gravity-cc-1'
+        end
+      end
+      context 'with a credit card id for credit card not belonging to the buyer' do
+        let(:invalid_credit_card) { { id: credit_card_id, user: { _id: 'b456' } } }
+        it 'raises an error' do
+          expect(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
+          expect { OrderService.set_payment!(order, credit_card_id) }.to raise_error do |error|
+            expect(error).to be_a Errors::ValidationError
+            expect(error.code).to eq :non_buyer_credit_card
+          end
+        end
       end
     end
     Order::STATES.reject { |s| s == Order::PENDING }.each do |state|
@@ -28,9 +42,6 @@ describe OrderService, type: :services do
         end
       end
     end
-  end
-
-  describe 'set_shipping!' do
   end
 
   describe 'fulfill_at_once!' do


### PR DESCRIPTION
### Problem
When setting the buyer's credit card on an order, we don't currently check whether or not the credit card is actually associated with the buyer's user. This creates a vulnerability where an attacker could pass in any credit card ID they choose.

Resolves [PURCHASE-583](https://artsyproduct.atlassian.net/browse/PURCHASE-583).

### Solution
Verify that the user ID on the credit card ID given in `OrderService.set_payment!`  matches the buyer's user ID on the order.