### PR TITLE
Add submitted_at to Offer

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -243,6 +243,7 @@ type Offer {
   id: ID!
   order: Order!
   respondsTo: Offer
+  submittedAt: DateTime
 }
 
 # The connection type for Offer.

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -7,6 +7,7 @@ class Types::OfferType < Types::BaseObject
   field :amount_cents, Integer, null: false
   field :creator_id, String, null: false
   field :created_at, Types::DateTimeType, null: false
+  field :submitted_at, Types::DateTimeType, null: true
   field :order, Types::OrderType, null: false
   field :responds_to, Types::OfferType, null: true
 

--- a/db/migrate/20181108193631_add_submitted_at_to_offers.rb
+++ b/db/migrate/20181108193631_add_submitted_at_to_offers.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToOffers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :offers, :submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_05_214933) do
+ActiveRecord::Schema.define(version: 2018_11_08_193631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2018_11_05_214933) do
     t.uuid "responds_to_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "submitted_at"
     t.index ["order_id"], name: "index_offers_on_order_id"
     t.index ["responds_to_id"], name: "index_offers_on_responds_to_id"
   end

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -59,6 +59,7 @@ describe Api::GraphqlController, type: :request do
             lastOffer {
               id
               amountCents
+              submittedAt
               respondsTo {
                 id
               }
@@ -87,6 +88,7 @@ describe Api::GraphqlController, type: :request do
                 node {
                   id
                   amountCents
+                  submittedAt
                   from {
                     __typename
                     ... on User {
@@ -130,6 +132,7 @@ describe Api::GraphqlController, type: :request do
             lastOffer {
               id
               amountCents
+              submittedAt
               respondsTo {
                 id
               }
@@ -156,6 +159,7 @@ describe Api::GraphqlController, type: :request do
                 node {
                   id
                   amountCents
+                  submittedAt
                 }
               }
             }
@@ -221,7 +225,7 @@ describe Api::GraphqlController, type: :request do
 
       context 'with offers' do
         let(:order_mode) { Order::OFFER }
-        let!(:offer1) { Fabricate(:offer, order: user1_order1, amount_cents: 200, from_id: user_id, from_type: Order::USER) }
+        let!(:offer1) { Fabricate(:offer, order: user1_order1, amount_cents: 200, from_id: user_id, from_type: Order::USER, submitted_at: Date.new(2018, 1, 1)) }
         let!(:offer2) { Fabricate(:offer, order: user1_order1, amount_cents: 300, from_id: partner_id, from_type: 'gallery', responds_to_id: offer1.id) }
         before do
           user1_order1.update! last_offer: offer2
@@ -233,6 +237,7 @@ describe Api::GraphqlController, type: :request do
           expect(result.data.order.offers.edges.map(&:node).map(&:amount_cents)).to match_array [200, 300]
           expect(result.data.order.offers.edges.map(&:node).map(&:from).map(&:id)).to match_array [user_id, partner_id]
           expect(result.data.order.offers.edges.map(&:node).map(&:from).map(&:__typename)).to match_array %w[User Partner]
+          expect(result.data.order.offers.edges.first.node.submitted_at).to eq '2018-01-01T00:00:00Z'
         end
         it 'includes last_offer' do
           result = client.execute(query, id: user1_order1.id)


### PR DESCRIPTION
# Problem
Offers can be created without being submitted yet. We want to know about un-submitted offers and also we want to know when they are submitted.

# Solution
Added `submitted_at` to `Offer` and expose it in the GraphQL response.