### PR TITLE
Relax items_total_cents requirement

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -282,7 +282,7 @@ type Order {
   id: ID!
 
   # Item total in cents, for Offer Orders this field reflects current offer
-  itemsTotalCents: Int!
+  itemsTotalCents: Int
   lastApprovedAt: DateTime
   lastOffer: Offer
   lastSubmittedAt: DateTime

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -14,7 +14,7 @@ class Types::OrderType < Types::BaseObject
   field :credit_card_id, String, null: true
   field :currency_code, String, null: false
   field :display_commission_rate, String, null: true
-  field :items_total_cents, Integer, null: false, description: 'Item total in cents, for Offer Orders this field reflects current offer'
+  field :items_total_cents, Integer, null: true, description: 'Item total in cents, for Offer Orders this field reflects current offer'
   field :last_approved_at, Types::DateTimeType, null: true
   field :last_submitted_at, Types::DateTimeType, null: true
   field :line_items, Types::LineItemType.connection_type, null: true

--- a/spec/controllers/api/requests/create_offer_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/create_offer_order_with_artwork_mutation_request_spec.rb
@@ -23,6 +23,8 @@ describe Api::GraphqlController, type: :request do
               ... on OrderWithMutationSuccess {
                 order {
                   id
+                  itemsTotalCents
+                  totalListPriceCents
                   buyer {
                     ... on Partner {
                       id
@@ -88,6 +90,8 @@ describe Api::GraphqlController, type: :request do
                 order_id = response.data.create_offer_order_with_artwork.order_or_error.order.id
                 expect(order_id).not_to be_nil
                 expect(response.data.create_offer_order_with_artwork.order_or_error).not_to respond_to(:error)
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.items_total_cents).to be_nil
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.total_list_price_cents).to eq 840084
                 order = Order.find(order_id)
                 expect(order.currency_code).to eq 'USD'
                 expect(order.buyer_id).to eq jwt_user_id


### PR DESCRIPTION
Follow up on comments in #273 , we don't have `items_total_cents` for offer orders till offer is added.