### PR TITLE
Remove ability for sales admins to access orders via GraphQL

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -51,12 +51,8 @@ class Types::QueryType < Types::BaseObject
     context[:current_user][:roles].include?('trusted')
   end
 
-  def sales_admin?
-    context[:current_user][:roles].include?('sales_admin')
-  end
-
   def validate_order_request!(order)
-    return if trusted? || sales_admin? ||
+    return if trusted? ||
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
               (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
@@ -64,7 +60,7 @@ class Types::QueryType < Types::BaseObject
   end
 
   def validate_orders_request!(params)
-    return if trusted? || sales_admin?
+    return if trusted?
 
     if params[:buyer_id].present?
       raise ActiveRecord::RecordNotFound unless params[:buyer_id] == context[:current_user][:id]

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -330,25 +330,6 @@ describe Api::GraphqlController, type: :request do
           end
         end
       end
-
-      context "sales admin accessing another account's order" do
-        let(:jwt_roles) { 'sales_admin' }
-
-        it 'allows action' do
-          expect do
-            client.execute(query, id: user2_order1.id)
-          end.to_not raise_error
-        end
-
-        it 'returns expected payload' do
-          result = client.execute(query, id: user2_order1.id)
-          expect(result.data.order.buyer.id).to eq user2_order1.buyer_id
-          expect(result.data.order.seller.id).to eq user2_order1.seller_id
-          expect(result.data.order.currency_code).to eq 'USD'
-          expect(result.data.order.state).to eq 'PENDING'
-          expect(result.data.order.items_total_cents).to eq 0
-        end
-      end
     end
 
     context 'partner accessing order' do

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -166,23 +166,6 @@ describe Api::GraphqlController, type: :request do
       end
     end
 
-    context "sales admin accessing another account's order" do
-      let(:jwt_roles) { 'sales_admin' }
-
-      it 'allows action' do
-        expect do
-          client.execute(query, buyerId: second_user)
-        end.to_not raise_error
-      end
-
-      it 'returns expected payload' do
-        result = client.execute(query, buyerId: second_user)
-        expect(result.data.orders.edges.count).to eq 1
-        ids = ids_from_result_data(result)
-        expect(ids).to match_array([user2_order1.id])
-      end
-    end
-
     describe 'total_count' do
       let(:query_with_total_count) do
         <<-GRAPHQL


### PR DESCRIPTION
### Problem
We only want sales admins to access orders through our admin app.

Addresses [PURCHASE-627](https://artsyproduct.atlassian.net/browse/PURCHASE-627).

### Solution
Remove ability for sales admins to access orders via GraphQL.

### What changed
- Sales admins can no longer access orders via GraphQL