### PR TITLE
Filter out pending offers in order.offers

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -313,6 +313,7 @@ type Order {
     first: Int
     fromId: String
     fromType: String
+    includePending: Boolean
 
     # Returns the last _n_ elements from the list.
     last: Int

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -2,6 +2,8 @@ class Offer < ApplicationRecord
   belongs_to :order
   belongs_to :responds_to, class_name: 'Offer', optional: true
 
+  scope :submitted, -> { where.not(submitted_at: nil) }
+
   def last_offer?
     order.last_offer == self
   end

--- a/spec/controllers/api/requests/initial_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/initial_offer_mutation_request_spec.rb
@@ -135,7 +135,7 @@ describe Api::GraphqlController, type: :request do
           expect(response_order.last_offer.from.id).to eq user_id
           expect(response_order.last_offer.responds_to).to be_nil
           expect(response_order.last_offer.creator_id).to eq user_id
-          expect(response_order.offers.edges.count).to eq 1
+          expect(response_order.offers.edges.count).to eq 0 # offer is not submitted yet
         end
       end
     end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe Offer, type: :model do
       expect(first_offer.last_offer?).to eq(false)
     end
   end
+
+  describe '#scopes' do
+    describe 'submitted' do
+      let!(:offer1) { Fabricate(:offer, submitted_at: Time.now) }
+      let!(:offer2) { Fabricate(:offer, submitted_at: nil) }
+      let!(:offer3) { Fabricate(:offer, submitted_at: nil) }
+      it 'returns submitted offers' do
+        expect(Offer.submitted).to match_array [offer1]
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem
We want to filter out pending offers when returning `order.offers` in GraphQL by default and we want to allow option to adding them if needed.
https://artsyproduct.atlassian.net/browse/PURCHASE-649

# Solution
Added a new scope for `submitted` offers to `Offer` model.
Updated `order.offers` to by default use `submitted` scope, and in case newly optional `includePending` was passed, add them to the response.