### PR TITLE
Use total sales tax amount when calculating sales tax

### DIFF
--- a/app/services/sales_tax_service.rb
+++ b/app/services/sales_tax_service.rb
@@ -26,11 +26,7 @@ class SalesTaxService
   end
 
   def sales_tax
-    @sales_tax ||= begin
-      tax_response = fetch_sales_tax
-      collectable_tax = tax_response.breakdown&.state_tax_collectable || tax_response.amount_to_collect
-      UnitConverter.convert_dollars_to_cents(collectable_tax)
-    end
+    @sales_tax ||= UnitConverter.convert_dollars_to_cents(fetch_sales_tax.amount_to_collect)
   rescue Taxjar::Error => e
     raise Errors::ProcessingError.new(:tax_calculator_failure, message: e.message)
   end

--- a/spec/services/sales_tax_service_spec.rb
+++ b/spec/services/sales_tax_service_spec.rb
@@ -101,18 +101,9 @@ describe SalesTaxService, type: :services do
   end
 
   describe '#sales_tax' do
-    context 'with a sales tax breakdown' do
-      it 'calls fetch_sales_tax and returns the amount of sales tax to collect on a state level' do
-        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response_with_breakdown)
-        expect(@service_ship.sales_tax).to eq 200
-      end
-    end
-    context 'without a sales tax breakdown' do
-      it 'calls fetch_sales_tax and returns the total amount to collect' do
-        expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response)
-        expect(tax_response).to receive(:breakdown).and_return(nil)
-        expect(@service_ship.sales_tax).to eq 300
-      end
+    it 'calls fetch_sales_tax and returns the total amount to collect' do
+      expect(@service_ship).to receive(:fetch_sales_tax).and_return(tax_response)
+      expect(@service_ship.sales_tax).to eq 300
     end
     context 'with an error from TaxJar' do
       it 'raises a ProcessingError with a code of tax_calculator_failure' do


### PR DESCRIPTION
### Problem
Partially reverts https://github.com/artsy/exchange/pull/239

Per legal's request, we're now going to be charging the _total_ collectable sales tax inclusive of state, city, county and other special jurisdiction taxes when calculating sales tax. Previously, we were only charging state sales tax.

### Solution
Pass along whatever total tax amount we obtain in TaxJar's `amount_to_collect` parameter

### What Changed
- Stop using breakdown object in sales tax parameter to selectively pull out state sales tax and instead use `amount_to_collect` parameter.