### PR TITLE
Remove _deprecated_ offerTotal

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -76,7 +76,6 @@ type BuyOrder implements Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offerTotalCents: Int! @deprecated(reason: "itemsTotalCents reflects offer total for offer orders.")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -387,7 +386,6 @@ type OfferOrder implements Order {
   ): LineItemConnection
   mode: OrderModeEnum
   myLastOffer: Offer
-  offerTotalCents: Int! @deprecated(reason: "itemsTotalCents reflects offer total for offer orders.")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String
@@ -450,7 +448,6 @@ interface Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offerTotalCents: Int! @deprecated(reason: "itemsTotalCents reflects offer total for offer orders.")
   offers(
     # Returns the elements in the list that come after the specified cursor.
     after: String

--- a/app/graphql/types/order_interface.rb
+++ b/app/graphql/types/order_interface.rb
@@ -35,7 +35,6 @@ module Types::OrderInterface
   field :updated_at, Types::DateTimeType, null: false
 
   # Deprecated
-  field :offer_total_cents, Integer, null: false, deprecation_reason: 'itemsTotalCents reflects offer total for offer orders.'
   field :last_offer, Types::OfferType, null: true, deprecation_reason: 'Switch to OfferOrder lastOffer'
   field :offers, Types::OfferType.connection_type, deprecation_reason: 'Switch to OfferOrder offers', null: true do
     argument :from_id, String, required: false
@@ -48,11 +47,6 @@ module Types::OrderInterface
     offers = object.offers.submitted
     offers = offers.where(args.slice(:from_id, :from_type)) if args.keys.any? { |ar| %i[from_id from_type].include? ar }
     offers
-  end
-
-  def offer_total_cents
-    # This can be removed once reaction is updated to `itemsTotalCents`
-    object.items_total_cents
   end
 
   def buyer

--- a/spec/controllers/api/requests/deprecated_fields_requests_sepc.rb
+++ b/spec/controllers/api/requests/deprecated_fields_requests_sepc.rb
@@ -32,7 +32,6 @@ describe Api::GraphqlController, type: :request do
           order(id: $id) {
             id
             mode
-            offerTotalCents
             lastOffer {
               id
             }
@@ -56,11 +55,6 @@ describe Api::GraphqlController, type: :request do
     it 'includes offers' do
       result = client.execute(query, id: order.id)
       expect(result.data.order.offers.edges.map(&:node).map(&:id)).to match_array [buyer_offer1.id]
-    end
-    it 'includes offerTotalCents' do
-      order.update!(last_offer: buyer_offer2)
-      result = client.execute(query, id: order.id)
-      expect(result.data.order.offer_total_cents).to eq 420
     end
   end
 end


### PR DESCRIPTION
This field is not used in Reaction anymore, in MP we [already switched it to use `itemsTotalCents` ](https://github.com/artsy/metaphysics/blob/master/src/schema/ecommerce/types/order.ts#L75), we are now good to remove it from Exchange.