### PR TITLE
Only run coveralls when on CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require 'coveralls'
-Coveralls.wear!('rails')
+if ENV.fetch('CI', false)
+  require 'coveralls'
+  Coveralls.wear!('rails')
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
This commit means that coveralls is only run on CI and no other
environment.

* Circle CI [sets the CI ENV variable][0]
* Cleans up stdout when running `rspec`
  + also, loading less code is almost always a good thing!

[0]:https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables