### PR TITLE
Add `buyerTotalCents` to `OfferType`

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -336,6 +336,7 @@ type Mutation {
 # An Offer
 type Offer {
   amountCents: Int!
+  buyerTotalCents: Int
   createdAt: DateTime!
   creatorId: String!
   from: OrderPartyUnion!

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -13,11 +13,16 @@ class Types::OfferType < Types::BaseObject
   field :order, Types::OrderInterface, null: false
   field :responds_to, Types::OfferType, null: true
   field :from_participant, Types::OrderParticipantEnum, null: true
+  field :buyer_total_cents, Integer, null: true
 
   def from
     OpenStruct.new(
       id: object.from_id,
       type: object.from_type
     )
+  end
+
+  def buyer_total_cents
+    object.amount_cents + object.tax_total_cents + object.shipping_total_cents if object.tax_total_cents.present? && object.shipping_total_cents.present?
   end
 end

--- a/spec/controllers/api/requests/add_initial_offer_to_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/add_initial_offer_to_order_mutation_request_spec.rb
@@ -65,6 +65,7 @@ describe Api::GraphqlController, type: :request do
                     myLastOffer {
                       id
                       amountCents
+                      buyerTotalCents
                       submittedAt
                       creatorId
                       from {
@@ -154,6 +155,7 @@ describe Api::GraphqlController, type: :request do
           expect(response_order.my_last_offer.responds_to).to be_nil
           expect(response_order.my_last_offer.creator_id).to eq user_id
           expect(response_order.my_last_offer.submitted_at).to be_nil
+          expect(response_order.my_last_offer.buyer_total_cents).to be_nil # tax and shipping not yet set
           expect(response_order.offers.edges.count).to eq 0 # offer is not submitted yet
         end
       end

--- a/spec/controllers/api/requests/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offer_set_shipping_mutation_request_spec.rb
@@ -50,6 +50,11 @@ describe Api::GraphqlController, type: :request do
                       id
                     }
                   }
+                  ... on OfferOrder {
+                    myLastOffer {
+                      buyerTotalCents
+                    }
+                  }
                 }
               }
               ... on OrderWithMutationFailure {
@@ -260,6 +265,10 @@ describe Api::GraphqlController, type: :request do
             expect(line_item.reload.sales_tax_cents).to be_nil
             expect(order.reload.tax_total_cents).to be_nil
             expect(offer.reload.tax_total_cents).to eq 116
+          end
+
+          it 'calculates offer buyer_total_cents as the sum of amount_cents, shipping_total_cents and tax_total_cents' do
+            expect(@response.data.set_shipping.order_or_error.order.my_last_offer.buyer_total_cents).to eq offer.amount_cents + offer.reload.tax_total_cents + offer.reload.shipping_total_cents
           end
         end
 


### PR DESCRIPTION
Exposes `buyerTotalCents` field on `OfferType` that returns the total amount the buyer is expected to pay for the offer.

Addresses [PURCHASE-684](https://artsyproduct.atlassian.net/browse/PURCHASE-684).