### PR TITLE
Fix Papertrail versions issue

### DIFF
--- a/db/migrate/20181129132032_fix_versions.rb
+++ b/db/migrate/20181129132032_fix_versions.rb
@@ -1,0 +1,5 @@
+class FixVersions < ActiveRecord::Migration[5.2]
+  def change
+    change_column :versions, :item_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_13_234322) do
+ActiveRecord::Schema.define(version: 2018_11_29_132032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 2018_11_13_234322) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.integer "item_id", null: false
+    t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.jsonb "object"


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PLATFORM-1058

# TLDR;
Since we switched from integer primary keys for models to `uuid`, papertrail has been silently failing storing correct data by trying to insert our `uuid` string field into `integer` field and basically resulting in wrong data in `item_id` field.

# Quick Solution
Papertrail was mainly added as an audit trail to Exchange since we are storing some important data and we do want to track changes on our most important models. Having said that, no one is currently actively using this data and there hasn't been a need to look at them yet. The quickest solution here is to:
- [ ] fix the issue by changing `item_id` to be `string`, this should fix the issue for all new changes to models
- [ ] Archive the table and store in S3 possibly in `artsy-backup/db`, the archived data is still valuable if we ever wanted to go back to papertrail data for older records since they have a the actual `jsonb` data
- [ ] Delete older records with wrong `item_id`