### PR TITLE
Add from_participant to Offer and expose it in OfferType

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -322,6 +322,7 @@ type Offer {
   createdAt: DateTime!
   creatorId: String!
   from: OrderPartyUnion!
+  fromParticipant: OrderParticipantEnum
   id: ID!
   order: Order!
   respondsTo: Offer

--- a/app/graphql/types/offer_order_type.rb
+++ b/app/graphql/types/offer_order_type.rb
@@ -12,7 +12,7 @@ class Types::OfferOrderType < Types::BaseObject
   def offers(**args)
     offers = object.offers.submitted
     offers = offers.where(args.slice(:from_id, :from_type)) if args.keys.any? { |ar| %i[from_id from_type].include? ar }
-    offers
+    offers.order(created_at: :desc)
   end
 
   def my_last_offer
@@ -24,10 +24,9 @@ class Types::OfferOrderType < Types::BaseObject
   def awaiting_response_from
     return unless object.mode == Order::OFFER && object.state == Order::SUBMITTED
 
-    if object&.last_offer&.from_id == object.seller_id && object&.last_offer&.from_type == object.seller_type
-      'buyer'
-    elsif object&.last_offer&.from_id == object.buyer_id && object&.last_offer&.from_type == object.buyer_type
-      'seller'
+    case object&.last_offer&.from_participant
+    when Order::BUYER then Order::SELLER
+    when Order::SELLER then Order::BUYER
     end
   end
 end

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -12,6 +12,7 @@ class Types::OfferType < Types::BaseObject
   field :submitted_at, Types::DateTimeType, null: true
   field :order, Types::OrderInterface, null: false
   field :responds_to, Types::OfferType, null: true
+  field :from_participant, Types::OrderParticipantEnum, null: true
 
   def from
     OpenStruct.new(

--- a/app/graphql/types/order_participant_enum.rb
+++ b/app/graphql/types/order_participant_enum.rb
@@ -1,4 +1,4 @@
 class Types::OrderParticipantEnum < Types::BaseEnum
-  value 'BUYER', 'Participant on the buyer side', value: 'buyer'
-  value 'SELLER', 'Participant on the seller side', value: 'seller'
+  value 'BUYER', 'Participant on the buyer side', value: Order::BUYER
+  value 'SELLER', 'Participant on the seller side', value: Order::SELLER
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -12,4 +12,12 @@ class Offer < ApplicationRecord
   def submitted?
     submitted_at.present?
   end
+
+  def from_participant
+    if from_id == order.seller_id && from_type == order.seller_type
+      Order::SELLER
+    elsif from_id == order.buyer_id && from_type == order.buyer_type
+      Order::BUYER
+    end
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,6 +6,12 @@ class Order < ApplicationRecord
     BUY = 'buy'.freeze,
     OFFER = 'offer'.freeze
   ].freeze
+
+  PARTICIPANTS = [
+    BUYER = 'buyer'.freeze,
+    SELLER = 'seller'.freeze
+  ].freeze
+
   # For more docs about states go to:
   # https://www.notion.so/artsy/37c311363ef046c3aa546047e60cc58a?v=de68d5bbc30748f88b0d92a059bc0ba8
   STATES = [

--- a/spec/controllers/api/requests/order_my_offer_request_spec.rb
+++ b/spec/controllers/api/requests/order_my_offer_request_spec.rb
@@ -5,15 +5,15 @@ describe Api::GraphqlController, type: :request do
     include_context 'GraphQL Client'
     let(:partner_id) { jwt_partner_ids.first }
     let(:buyer_id) { jwt_user_id }
-    let(:seller_id) { 'user2' }
+    let(:seller_user_id) { 'user2' }
     let!(:order) do
       Fabricate(
         :order,
         mode: Order::OFFER,
         seller_id: partner_id,
-        seller_type: 'partner',
+        seller_type: 'gallery',
         buyer_id: buyer_id,
-        buyer_type: 'user',
+        buyer_type: Order::USER,
         shipping_total_cents: 100_00,
         commission_fee_cents: 50_00,
         commission_rate: 0.10,
@@ -25,7 +25,7 @@ describe Api::GraphqlController, type: :request do
     end
     let(:buyer_offer1) { Fabricate(:offer, order: order, amount_cents: 200, from_id: buyer_id, from_type: Order::USER, creator_id: buyer_id, submitted_at: 2.days.ago, created_at: 2.days.ago) }
     let(:buyer_offer2) { Fabricate(:offer, order: order, amount_cents: 300, from_id: buyer_id, from_type: Order::USER, creator_id: buyer_id, created_at: 1.day.ago, shipping_total_cents: 100_00, tax_total_cents: 200_00) }
-    let(:seller_offer) { Fabricate(:offer, order: order, amount_cents: 200, from_id: buyer_id, from_type: 'gallery', creator_id: seller_id, submitted_at: Date.new(2018, 1, 2)) }
+    let(:seller_offer) { Fabricate(:offer, order: order, amount_cents: 200, from_id: partner_id, from_type: 'gallery', creator_id: seller_user_id, submitted_at: Date.new(2018, 1, 2)) }
     let(:query) do
       <<-GRAPHQL
         query($id: ID) {
@@ -48,6 +48,7 @@ describe Api::GraphqlController, type: :request do
                 edges {
                   node {
                     id
+                    fromParticipant
                   }
                 }
               }
@@ -79,6 +80,8 @@ describe Api::GraphqlController, type: :request do
         it 'returns all submitted offers for order.offers' do
           expect(@result.data.order.offers.edges.count).to eq 2
           expect(@result.data.order.offers.edges.map(&:node).map(&:id)).to match_array [buyer_offer1.id, seller_offer.id]
+          expect(@result.data.order.offers.edges.first.node.from_participant).to eq 'SELLER'
+          expect(@result.data.order.offers.edges.last.node.from_participant).to eq 'BUYER'
         end
       end
     end
@@ -102,7 +105,7 @@ describe Api::GraphqlController, type: :request do
 
     context 'partner accessing order' do
       let(:buyer_id) { 'someone-else-id' }
-      let(:seller_id) { jwt_user_id }
+      let(:seller_user_id) { jwt_user_id }
       before do
         buyer_offer1
         buyer_offer2

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -246,7 +246,7 @@ describe Api::GraphqlController, type: :request do
           expect(result.data.order.offers.edges.map(&:node).map(&:amount_cents)).to match_array [200, 300]
           expect(result.data.order.offers.edges.map(&:node).map(&:from).map(&:id)).to match_array [user_id, partner_id]
           expect(result.data.order.offers.edges.map(&:node).map(&:from).map(&:__typename)).to match_array %w[User Partner]
-          expect(result.data.order.offers.edges.first.node.submitted_at).to eq '2018-01-01T00:00:00Z'
+          expect(result.data.order.offers.edges.first.node.submitted_at).to eq '2018-01-02T00:00:00Z'
         end
         it 'includes last_offer' do
           result = client.execute(query, id: user1_order1.id)

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe Offer, type: :model do
       end
     end
   end
+
+  describe '#from_participant' do
+    let(:order) { Fabricate(:order, buyer_id: 'buyer1', buyer_type: 'user', seller_id: 'seller1', seller_type: 'gallery') }
+    let(:seller_offer) { Fabricate(:offer, order: order, from_id: 'seller1', from_type: 'gallery') }
+    let(:buyer_offer) { Fabricate(:offer, order: order, from_id: 'buyer1', from_type: 'user') }
+    let(:ufo_offer) { Fabricate(:offer, order: order, from_id: 'marse', from_type: 'ufo') }
+    it 'returns buyer for buyer_offer' do
+      expect(buyer_offer.from_participant).to eq Order::BUYER
+    end
+    it 'returns seller for seller_offer' do
+      expect(seller_offer.from_participant).to eq Order::SELLER
+    end
+    it 'returns nil for ufo_offer' do
+      expect(ufo_offer.from_participant).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-664

We want to be able to show if an offer is from `Buyer` or `Seller`.

# Solution
We already had a logic to detect this so we can return `awaiting_response_from` on `OrderType`. We added `from_participant` helper to `Offer`, we updated `awaiting_response_from` to also use this newly added method and exposed the new field in `OfferType`.

# GraphQL Changes
- Added `from_participant` to `Offer`.