### PR TITLE
Suppress puma loading message in system spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,10 @@ RSpec.configure do |config|
 end
 
 RSpec.configure do |config|
+  config.before(:all, type: :system) do
+    Capybara.server = :puma, { Silent: true }
+  end
+
   config.before(:each, type: :system) do
     driven_by :rack_test
   end


### PR DESCRIPTION
Before this change:

```
dl@phoenix:~/src/exchange * (notify-when-offer-is-approved)
$ rspec spec/system/visiting_order_details_spec.rb

Randomized with seed 50253
Capybara starting Puma...
* Version 3.12.0 , codename: Llamas in Pajamas
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:60646
.
```

After this change:

```
dl@phoenix:~/src/exchange * (notify-when-offer-is-approved)
$ rspec spec/system/visiting_order_details_spec.rb

Randomized with seed 10582
.
```

References:

- https://github.com/rspec/rspec-rails/issues/1897#issuecomment-352923675