### PR TITLE
AcceptOfferService deducts inventory and charges the buyer

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -49,7 +49,6 @@ module Errors
       artwork_version_mismatch
       capture_failed
       charge_authorization_failed
-      charge_failed
       insufficient_inventory
       refund_failed
       tax_recording_failure

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -38,6 +38,7 @@ module Errors
       not_offerable
       offer_more_than_one_line_item
       offer_not_from_buyer
+      uncommittable_action
       unknown_artwork
       unknown_edition_set
       unknown_partner

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -49,6 +49,7 @@ module Errors
       artwork_version_mismatch
       capture_failed
       charge_authorization_failed
+      charge_failed
       insufficient_inventory
       refund_failed
       tax_recording_failure

--- a/app/graphql/mutations/offer/base_accept_offer.rb
+++ b/app/graphql/mutations/offer/base_accept_offer.rb
@@ -12,7 +12,7 @@ class Mutations::Offer::BaseAcceptOffer < Mutations::BaseMutation
     authorize!(order)
     raise Errors::ValidationError, :cannot_accept_offer unless waiting_for_accept?(offer)
 
-    Offers::AcceptService.new(
+    Offers::AcceptOfferService.new(
       offer: offer,
       order: order,
       user_id: current_user_id

--- a/app/graphql/mutations/seller_reject_offer.rb
+++ b/app/graphql/mutations/seller_reject_offer.rb
@@ -11,8 +11,7 @@ class Mutations::SellerRejectOffer < Mutations::BaseMutation
     order = offer.order
 
     authorize_seller_request!(order)
-
-    Offers::RejectOfferService.new(offer: offer, reject_reason: reject_reason).process!
+    Offers::AcceptOfferService.new(offer: offer, order: order).process!
 
     { order_or_error: { order: order.reload } }
   rescue Errors::ApplicationError => e

--- a/app/graphql/mutations/seller_reject_offer.rb
+++ b/app/graphql/mutations/seller_reject_offer.rb
@@ -11,7 +11,7 @@ class Mutations::SellerRejectOffer < Mutations::BaseMutation
     order = offer.order
 
     authorize_seller_request!(order)
-    Offers::AcceptOfferService.new(offer: offer, order: order).process!
+    Offers::RejectOfferService.new(offer: offer, reject_reason: reject_reason).process!
 
     { order_or_error: { order: order.reload } }
   rescue Errors::ApplicationError => e

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -159,7 +159,7 @@ class Order < ApplicationRecord
     line_items.map(&:total_list_price_cents).sum
   end
 
-  def can_submit?
+  def can_commit?
     shipping_info? && payment_info?
   end
 

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -1,0 +1,113 @@
+class CommitOrderService
+  def self.call!(order, order_state_action:, by: nil)
+    new(order, order_state_action, by).process!
+  end
+
+  attr_accessor :order, :credit_card, :merchant_account, :partner
+  def initialize(order, by, order_state_action)
+    @order = order
+    @by = by
+    @order_state_action = order_state_action
+    @credit_card = nil
+    @merchant_account = nil
+    @partner = nil
+    @transaction = nil
+    @deducted_inventory = []
+  end
+
+  def process!
+    pre_process!
+    commit_order!
+    post_process!
+    @order
+  rescue Errors::ValidationError, Errors::ProcessingError => e
+    undeduct_inventory
+    raise e
+  ensure
+    if @transaction.present?
+      @order.transactions << @transaction
+      notify_failed_charge if @transaction.failed?
+    end
+  end
+  
+  protected
+
+  def commit_order!
+    @order.send(@order_state_action) do
+      deduct_inventory
+      process_payment
+    end
+  end
+
+  def undeduct_inventory
+    @deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
+    @deducted_inventory = []
+  end
+
+  def deduct_inventory
+      # Try holding artwork and deduct inventory
+      @order.line_items.each do |li|
+        GravityService.deduct_inventory(li)
+        @deducted_inventory << li
+      end
+  end
+  
+  def process_payment
+  end
+
+  def pre_process!
+    @order.line_items.map do |li|
+      artwork = GravityService.get_artwork(li[:artwork_id])
+      Exchange.dogstatsd.increment 'submit.artwork_version_mismatch'
+      raise Errors::ProcessingError, :artwork_version_mismatch if artwork[:current_version_id] != li[:artwork_version_id]
+    end
+    @credit_card = GravityService.get_credit_card(@order.credit_card_id)
+    assert_credit_card!
+    @partner = GravityService.fetch_partner(@order.seller_id)
+    raise Errors::ValidationError.new(:missing_commission_rate, partner_id: @partner[:id]) if @partner[:effective_commission_rate].blank?
+
+    @merchant_account = GravityService.get_merchant_account(@order.seller_id)
+    OrderTotalUpdaterService.new(@order, @partner[:effective_commission_rate]).update_totals!
+  end
+
+  def post_process!
+    @order.update!(external_charge_id: @transaction.external_id)
+  end
+
+  def notify_failed_charge
+    PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::CREATED, @by)
+  end
+
+  def construct_charge_params
+    {
+      credit_card: @credit_card,
+      buyer_amount: @order.buyer_total_cents,
+      merchant_account: @merchant_account,
+      seller_amount: @order.seller_total_cents,
+      currency_code: @order.currency_code,
+      metadata: charge_metadata,
+      description: charge_description
+    }
+  end
+
+  def assert_credit_card!
+    raise Errors::ValidationError.new(:credit_card_missing_external_id, credit_card_id: @credit_card[:id]) if @credit_card[:external_id].blank?
+    raise Errors::ValidationError.new(:credit_card_missing_customer, credit_card_id: @credit_card[:id]) if @credit_card.dig(:customer_account, :external_id).blank?
+    raise Errors::ValidationError.new(:credit_card_deactivated, credit_card_id: @credit_card[:id]) unless @credit_card[:deactivated_at].nil?
+  end
+
+  def charge_description
+    "#{(@partner[:name] || '').parameterize[0...12].upcase} via Artsy"
+  end
+
+  def charge_metadata
+    {
+      exchange_order_id: @order.id,
+      buyer_id: @order.buyer_id,
+      buyer_type: @order.buyer_type,
+      seller_id: @order.seller_id,
+      seller_type: @order.seller_type,
+      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo'
+    }
+  end
+end

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -78,6 +78,7 @@ class CommitOrderService
 
   def post_process!
     @order.update!(external_charge_id: @transaction.external_id)
+    Exchange.dogstatsd.increment "order.#{@action}"
   end
 
   def notify_failed_charge

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -23,7 +23,7 @@ class CommitOrderService
     handle_transaction
   end
 
-  protected
+  private
 
   def handle_transaction
     return if @transaction.blank?

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -8,9 +8,6 @@ class CommitOrderService
     @order = order
     @action = action
     @user_id = user_id
-    @credit_card = nil
-    @merchant_account = nil
-    @partner = nil
     @transaction = nil
     @deducted_inventory = []
   end
@@ -56,24 +53,39 @@ class CommitOrderService
   end
   
   def process_payment
-    raise UnimplementedError
+    raise NotImplementedError
   end
 
   def pre_process!
     raise Errors::ValidationError, :uncommittable_action unless COMMITTABLE_ACTIONS.include? @action
 
-    @order.line_items.map do |li|
-      artwork = GravityService.get_artwork(li[:artwork_id])
-      Exchange.dogstatsd.increment 'submit.artwork_version_mismatch'
-      raise Errors::ProcessingError, :artwork_version_mismatch if artwork[:current_version_id] != li[:artwork_version_id]
-    end
-    @credit_card = GravityService.get_credit_card(@order.credit_card_id)
+    validate_artwork_versions!
     assert_credit_card!
-    @partner = GravityService.fetch_partner(@order.seller_id)
-    raise Errors::ValidationError.new(:missing_commission_rate, partner_id: @partner[:id]) if @partner[:effective_commission_rate].blank?
+    raise Errors::ValidationError.new(:missing_commission_rate, partner_id: partner[:id]) if partner[:effective_commission_rate].blank?
 
-    @merchant_account = GravityService.get_merchant_account(@order.seller_id)
-    OrderTotalUpdaterService.new(@order, @partner[:effective_commission_rate]).update_totals!
+    OrderTotalUpdaterService.new(@order, partner[:effective_commission_rate]).update_totals!
+  end
+
+  def validate_artwork_versions!
+    @order.line_items.each do |li|
+      artwork = GravityService.get_artwork(line_item[:artwork_id])
+      if artwork[:current_version_id] != line_item[:artwork_version_id]
+        Exchange.dogstatsd.increment 'submit.artwork_version_mismatch'
+        raise Errors::ProcessingError, :artwork_version_mismatch
+      end  
+    end
+  end
+
+  def credit_card
+    @credit_card ||= GravityService.get_credit_card(@order.credit_card_id)
+  end
+
+  def partner
+    @partner ||= GravityService.fetch_partner(@order.seller_id)
+  end
+
+  def merchant_account
+    @merchant_account ||= GravityService.get_merchant_account(@order.seller_id)
   end
 
   def post_process!
@@ -87,9 +99,9 @@ class CommitOrderService
 
   def construct_charge_params
     {
-      credit_card: @credit_card,
+      credit_card: credit_card,
       buyer_amount: @order.buyer_total_cents,
-      merchant_account: @merchant_account,
+      merchant_account: merchant_account,
       seller_amount: @order.seller_total_cents,
       currency_code: @order.currency_code,
       metadata: charge_metadata,
@@ -99,14 +111,14 @@ class CommitOrderService
 
   def assert_credit_card!
     error_type = nil
-    error_type = :credit_card_missing_external_id if @credit_card[:external_id].blank?
-    error_type = :credit_card_missing_customer if @credit_card.dig(:customer_account, :external_id).blank?
-    error_type = :credit_card_deactivated unless @credit_card[:deactivated_at].nil?
-    raise Errors::ValidationError.new(error_type, credit_card_id: @credit_card[:id]) if error_type
+    error_type = :credit_card_missing_external_id if credit_card[:external_id].blank?
+    error_type = :credit_card_missing_customer if credit_card.dig(:customer_account, :external_id).blank?
+    error_type = :credit_card_deactivated unless credit_card[:deactivated_at].nil?
+    raise Errors::ValidationError.new(error_type, credit_card_id: credit_card[:id]) if error_type
   end
 
   def charge_description
-    partner_name = (@partner[:name] || '').parameterize[0...12].upcase
+    partner_name = (partner[:name] || '').parameterize[0...12].upcase
     "#{partner_name} via Artsy"
   end
 

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -60,7 +60,7 @@ class CommitOrderService
   end
 
   def pre_process!
-    raise Errors::ValidationError, :uncommittable_action unless COMMITTABLE_ACTIONS.include? action
+    raise Errors::ValidationError, :uncommittable_action unless COMMITTABLE_ACTIONS.include? @action
 
     @order.line_items.map do |li|
       artwork = GravityService.get_artwork(li[:artwork_id])
@@ -106,7 +106,7 @@ class CommitOrderService
   end
 
   def charge_description
-    partner_name = (@partner[:name] || '').parameterize[0...12].upcase}
+    partner_name = (@partner[:name] || '').parameterize[0...12].upcase
     "#{partner_name} via Artsy"
   end
 

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -4,10 +4,10 @@ class CommitOrderService
   end
 
   attr_accessor :order, :credit_card, :merchant_account, :partner
-  def initialize(order, by, order_state_action)
+  def initialize(order, order_state_action, by)
     @order = order
-    @by = by
     @order_state_action = order_state_action
+    @by = by
     @credit_card = nil
     @merchant_account = nil
     @partner = nil
@@ -78,7 +78,7 @@ class CommitOrderService
     PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::CREATED, @by)
   end
 
-  def construct_charge_params
+  def construct_charge_params(capture:)
     {
       credit_card: @credit_card,
       buyer_amount: @order.buyer_total_cents,
@@ -86,7 +86,8 @@ class CommitOrderService
       seller_amount: @order.seller_total_cents,
       currency_code: @order.currency_code,
       metadata: charge_metadata,
-      description: charge_description
+      description: charge_description,
+      capture: capture
     }
   end
 

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -58,6 +58,7 @@ class CommitOrderService
 
   def pre_process!
     raise Errors::ValidationError, :uncommittable_action unless COMMITTABLE_ACTIONS.include? @action
+    raise Errors::ValidationError, :missing_required_info unless @order.can_commit?
 
     validate_artwork_versions!
     validate_credit_card!

--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -78,7 +78,7 @@ class CommitOrderService
     PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::CREATED, @by)
   end
 
-  def construct_charge_params(capture:)
+  def construct_charge_params
     {
       credit_card: @credit_card,
       buyer_amount: @order.buyer_total_cents,
@@ -87,7 +87,6 @@ class CommitOrderService
       currency_code: @order.currency_code,
       metadata: charge_metadata,
       description: charge_description,
-      capture: capture
     }
   end
 

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -8,7 +8,7 @@ module Offers
     end
 
     private
-    
+
     def process_payment
       @transaction = PaymentService.create_and_capture_charge(construct_charge_params)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -17,7 +17,8 @@ module Offers
 
     def pre_process!
       super
-      validate_is_last_offer!
+      validate_is_last_offer!(@offer)
+      validate_offer_is_from_buyer!(@offer)
     end
 
     def post_process!

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -3,7 +3,7 @@ module Offers
     include OfferValidationService
     attr_reader :order, :offer, user_id
     def initialize(offer:, order:, user_id: nil)
-      super(order, :approve!, user_id)
+      super(order, :approve, user_id)
       @offer = offer
     end
 

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -18,5 +18,10 @@ module Offers
       super
       validate_is_last_offer!(@offer)
     end
+
+    def post_process!
+      super
+      PostOrderNotificationJob.perform_later(@order.id, Order::APPROVED, @user_id)
+    end
   end
 end

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -1,7 +1,7 @@
 module Offers
   class AcceptOfferService < CommitOrderService
     include OfferValidationService
-    attr_reader :order, :offer, user_id
+    attr_reader :order, :offer, :user_id
     def initialize(offer:, order:, user_id: nil)
       super(order, :approve, user_id)
       @offer = offer
@@ -10,7 +10,6 @@ module Offers
     private
     
     def process_payment
-      super
       @transaction = PaymentService.create_and_capture_charge(construct_charge_params)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?
     end

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -11,8 +11,8 @@ module Offers
     
     def process_payment
       super
-      @transaction = PaymentService.create_charge(construct_charge_params(capture: true))
-      raise Errors::ProcessingError.new(:charge_failed, @transaction.failure_data) if @transaction.failed?
+      @transaction = PaymentService.create_and_capture_charge(construct_charge_params)
+      raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?
     end
 
     def pre_process!

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -20,14 +20,5 @@ module Offers
       validate_is_last_offer!(@offer)
       validate_offer_is_from_buyer!(@offer)
     end
-
-    def post_process!
-      super
-      instrument_order_approved
-    end
-
-    def instrument_order_approved
-      Exchange.dogstatsd.increment 'order.approve'
-    end
   end
 end

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -18,7 +18,6 @@ module Offers
     def pre_process!
       super
       validate_is_last_offer!(@offer)
-      validate_offer_is_from_buyer!(@offer)
     end
   end
 end

--- a/app/services/offers/accept_offer_service.rb
+++ b/app/services/offers/accept_offer_service.rb
@@ -1,5 +1,6 @@
 module Offers
-  class AcceptService < BaseOfferService
+  class AcceptOfferService
+    include OfferValidationService
     def initialize(offer:, order:, user_id:)
       @offer = offer
       @order = order
@@ -7,6 +8,8 @@ module Offers
     end
 
     def process!
+      # Deduct artwork from inventory
+      # Charge buyer
       validate_is_last_offer!
 
       order.approve!

--- a/app/services/offers/offer_validation_service.rb
+++ b/app/services/offers/offer_validation_service.rb
@@ -1,10 +1,10 @@
 module Offers
-  class BaseOfferService
-    def validate_is_last_offer!
+  module OfferValidationService
+    def validate_is_last_offer!(offer)
       raise Errors::ValidationError.new(:not_last_offer, offer) unless offer.last_offer?
     end
 
-    def validate_offer_is_from_buyer!
+    def validate_offer_is_from_buyer!(offer)
       raise Errors::ValidationError.new(:offer_not_from_buyer, offer) unless offer.from_type == Order::USER
     end
   end

--- a/app/services/offers/reject_offer_service.rb
+++ b/app/services/offers/reject_offer_service.rb
@@ -1,13 +1,14 @@
 module Offers
-  class RejectOfferService < BaseOfferService
+  class RejectOfferService
+    include OfferValidationService
     def initialize(offer:, reject_reason:)
       @offer = offer
       @reject_reason = reject_reason
     end
 
     def process!
-      validate_is_last_offer!
-      validate_offer_is_from_buyer!
+      validate_is_last_offer!(@offer)
+      validate_offer_is_from_buyer!(@offer)
 
       @offer.order.reject!(@reject_reason)
       instrument_offer_reject

--- a/app/services/offers/submit_order_service.rb
+++ b/app/services/offers/submit_order_service.rb
@@ -46,7 +46,7 @@ module Offers
 
     def assert_can_submit!
       raise Errors::ValidationError, :cant_submit unless @order.mode == Order::OFFER
-      raise Errors::ValidationError, :missing_required_info unless @order.can_submit?
+      raise Errors::ValidationError, :missing_required_info unless @order.can_commit?
       raise Errors::ValidationError, :invalid_offer if @offer.submitted?
     end
 

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -9,7 +9,7 @@ class OrderApproveService
 
   def process!
     @order.approve! do
-      @transaction = PaymentService.capture_charge(@order.external_charge_id)
+      @transaction = PaymentService.capture_authorized_charge(@order.external_charge_id)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?
     end
     post_process

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -11,7 +11,7 @@ class OrderSubmitService < CommitOrderService
   
   def process_payment
     super
-    @transaction = PaymentService.create_charge(construct_charge_params(capture: false))
+    @transaction = PaymentService.create_and_authorize_charge(construct_charge_params)
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
   end
 

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -4,7 +4,7 @@ class OrderSubmitService < CommitOrderService
   end
 
   def initialize(order, user_id)
-    super(order, :submit!, user_id)
+    super(order, :submit, user_id)
   end
 
   private
@@ -22,7 +22,6 @@ class OrderSubmitService < CommitOrderService
 
   def post_process!
     super
-    Exchange.dogstatsd.increment 'order.submit'
     PostOrderNotificationJob.perform_later(@order.id, Order::SUBMITTED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
     ReminderFollowUpJob.set(wait_until: @order.state_expires_at - 2.hours).perform_later(@order.id, @order.state)

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -11,7 +11,7 @@ class OrderSubmitService < CommitOrderService
   
   def process_payment
     super
-    @transaction = PaymentService.authorize_charge(construct_charge_params(capture: false))
+    @transaction = PaymentService.create_charge(construct_charge_params(capture: false))
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
   end
 

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -14,11 +14,6 @@ class OrderSubmitService < CommitOrderService
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
   end
 
-  def pre_process!
-    super
-    raise Errors::ValidationError, :missing_required_info unless @order.can_submit?
-  end
-
   def post_process!
     super
     PostOrderNotificationJob.perform_later(@order.id, Order::SUBMITTED, @user_id)

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -1,104 +1,30 @@
-class OrderSubmitService
+class OrderSubmitService < CommitOrderService
   def self.call!(order, user_id: nil)
     new(order, user_id).process!
   end
 
-  attr_accessor :order, :credit_card, :merchant_account, :partner
   def initialize(order, user_id)
-    @order = order
-    @user_id = user_id
-    @credit_card = nil
-    @merchant_account = nil
-    @partner = nil
-    @transaction = nil
-  end
-
-  def process!
-    deducted_inventory = []
-    pre_process!
-    @order.submit! do
-      # Try holding artwork and deduct inventory
-      @order.line_items.each do |li|
-        GravityService.deduct_inventory(li)
-        deducted_inventory << li
-      end
-      @transaction = PaymentService.authorize_charge(construct_charge_params)
-      raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
-    end
-    @order.update!(external_charge_id: @transaction.external_id)
-    post_process!
-    @order
-  rescue Errors::ValidationError, Errors::ProcessingError => e
-    # undeduct all already deducted inventory
-    deducted_inventory.each { |li| GravityService.undeduct_inventory(li) }
-    raise e
-  ensure
-    if @transaction.present?
-      @order.transactions << @transaction
-      notify_failed_charge if @transaction.failed?
-    end
+    super(order, :submit!, user_id)
   end
 
   private
+  
+  def process_payment
+    super
+    @transaction = PaymentService.authorize_charge(construct_charge_params(capture: false))
+    raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
+  end
 
   def pre_process!
+    super
     raise Errors::ValidationError, :missing_required_info unless @order.can_submit?
-
-    @order.line_items.map do |li|
-      artwork = GravityService.get_artwork(li[:artwork_id])
-      Exchange.dogstatsd.increment 'submit.artwork_version_mismatch'
-      raise Errors::ProcessingError, :artwork_version_mismatch if artwork[:current_version_id] != li[:artwork_version_id]
-    end
-    @credit_card = GravityService.get_credit_card(@order.credit_card_id)
-    assert_credit_card!
-    @partner = GravityService.fetch_partner(@order.seller_id)
-    raise Errors::ValidationError.new(:missing_commission_rate, partner_id: @partner[:id]) if @partner[:effective_commission_rate].blank?
-
-    @merchant_account = GravityService.get_merchant_account(@order.seller_id)
-    OrderTotalUpdaterService.new(@order, @partner[:effective_commission_rate]).update_totals!
   end
 
   def post_process!
+    super
     Exchange.dogstatsd.increment 'order.submit'
     PostOrderNotificationJob.perform_later(@order.id, Order::SUBMITTED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
     ReminderFollowUpJob.set(wait_until: @order.state_expires_at - 2.hours).perform_later(@order.id, @order.state)
-  end
-
-  def notify_failed_charge
-    PostTransactionNotificationJob.perform_later(@transaction.id, TransactionEvent::CREATED, @user_id)
-  end
-
-  def construct_charge_params
-    {
-      credit_card: @credit_card,
-      buyer_amount: @order.buyer_total_cents,
-      merchant_account: @merchant_account,
-      seller_amount: @order.seller_total_cents,
-      currency_code: @order.currency_code,
-      metadata: charge_metadata,
-      description: charge_description
-    }
-  end
-
-  def assert_credit_card!
-    raise Errors::ValidationError.new(:credit_card_missing_external_id, credit_card_id: @credit_card[:id]) if @credit_card[:external_id].blank?
-    raise Errors::ValidationError.new(:credit_card_missing_customer, credit_card_id: @credit_card[:id]) if @credit_card.dig(:customer_account, :external_id).blank?
-    raise Errors::ValidationError.new(:credit_card_deactivated, credit_card_id: @credit_card[:id]) unless @credit_card[:deactivated_at].nil?
-  end
-
-  def charge_description
-    "#{(@partner[:name] || '').parameterize[0...12].upcase} via Artsy"
-  end
-
-  def charge_metadata
-    {
-      exchange_order_id: @order.id,
-      buyer_id: @order.buyer_id,
-      buyer_type: @order.buyer_type,
-      seller_id: @order.seller_id,
-      seller_type: @order.seller_type,
-      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo'
-    }
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -10,7 +10,6 @@ class OrderSubmitService < CommitOrderService
   private
   
   def process_payment
-    super
     @transaction = PaymentService.create_and_authorize_charge(construct_charge_params)
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
   end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -8,7 +8,7 @@ class OrderSubmitService < CommitOrderService
   end
 
   private
-  
+
   def process_payment
     @transaction = PaymentService.create_and_authorize_charge(construct_charge_params)
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -19,7 +19,15 @@ module PaymentService
     generate_transaction_from_exception(e, transaction_type, credit_card: credit_card, merchant_account: merchant_account, buyer_amount: buyer_amount)
   end
 
-  def self.capture_charge(charge_id)
+  def self.create_and_authorize_charge(charge_params)
+    create_charge(charge_params.merge(capture: false))
+  end
+
+  def self.create_and_capture_charge(charge_params)
+    create_charge(charge_params.merge(capture: true))
+  end
+
+  def self.capture_authorized_charge(charge_id)
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
     Transaction.new(external_id: charge.id, source_id: charge.source, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,5 +1,5 @@
 module PaymentService
-  def self.authorize_charge(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {})
+  def self.authorize_charge(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {}, capture:)
     charge = Stripe::Charge.create(
       amount: buyer_amount,
       currency: currency_code,
@@ -11,7 +11,7 @@ module PaymentService
         amount: seller_amount
       },
       metadata: metadata,
-      capture: false
+      capture: capture
     )
     Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::HOLD, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -79,7 +79,7 @@ describe Api::GraphqlController, type: :request do
 
       it "returns invalid state transition error and doesn't change the order state" do
         mock_pre_process_calls
-        
+
         response = client.execute(mutation, buyer_accept_offer_input)
 
         expect(response.data.buyer_accept_offer.order_or_error.error.type).to eq 'validation'

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -2,13 +2,41 @@ require 'rails_helper'
 require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
   describe 'buyer_accept_offer mutation' do
     include_context 'GraphQL Client'
+    let(:partner) { { effective_commission_rate: 0.1 } }
     let(:order_seller_id) { jwt_partner_ids.first }
     let(:order_buyer_id) { jwt_user_id }
-    let(:order) { Fabricate(:order, state: order_state, seller_id: order_seller_id, seller_type: 'gallery', buyer_id: order_buyer_id) }
-    let(:offer) { Fabricate(:offer, order: order, from_id: order_seller_id, from_type: 'gallery') }
     let(:order_state) { Order::SUBMITTED }
+    let(:credit_card_id) { 'cc-1' }
+    let(:merchant_account) { { external_id: 'ma-1' } }
+    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:order) do
+      Fabricate(
+        :order,
+        state: order_state,
+        seller_id: order_seller_id,
+        buyer_id: order_buyer_id,
+        credit_card_id: credit_card_id,
+        shipping_name: 'Fname Lname',
+        shipping_address_line1: '12 Vanak St',
+        shipping_address_line2: 'P 80',
+        shipping_city: 'Tehran',
+        shipping_postal_code: '02198',
+        buyer_phone_number: '00123456',
+        shipping_country: 'IR',
+        fulfillment_type: Order::SHIP,
+        items_total_cents: 1000_00,
+        seller_type: 'gallery',
+        buyer_type: 'user'
+      )
+    end
+    let!(:line_item) do
+      Fabricate(:line_item, order: order, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
+    end
+    let(:offer) { Fabricate(:offer, order: order, from_id: order_seller_id, from_type: 'gallery', amount_cents: 800_00) }
+    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
 
     let(:mutation) do
       <<-GRAPHQL
@@ -50,6 +78,8 @@ describe Api::GraphqlController, type: :request do
       let(:order_state) { Order::PENDING }
 
       it "returns invalid state transition error and doesn't change the order state" do
+        mock_pre_process_calls
+        
         response = client.execute(mutation, buyer_accept_offer_input)
 
         expect(response.data.buyer_accept_offer.order_or_error.error.type).to eq 'validation'
@@ -60,6 +90,8 @@ describe Api::GraphqlController, type: :request do
 
     context 'when attempting to accept not the last offer' do
       it 'returns a validation error and does not change the order state' do
+        mock_pre_process_calls
+
         create_order_and_original_offer
         create_another_offer
 
@@ -76,8 +108,21 @@ describe Api::GraphqlController, type: :request do
 
       it 'returns permission error' do
         response = client.execute(mutation, buyer_accept_offer_input)
+
         expect(response.data.buyer_accept_offer.order_or_error.error.type).to eq 'validation'
         expect(response.data.buyer_accept_offer.order_or_error.error.code).to eq 'not_found'
+        expect(order.reload.state).to eq Order::SUBMITTED
+      end
+    end
+
+    context 'offer from buyer' do
+      let(:offer) { Fabricate(:offer, order: order, from_id: order_buyer_id, from_type: 'user') }
+
+      it 'returns permission error' do
+        response = client.execute(mutation, buyer_accept_offer_input)
+
+        expect(response.data.buyer_accept_offer.order_or_error.error.type).to eq 'validation'
+        expect(response.data.buyer_accept_offer.order_or_error.error.code).to eq 'cannot_accept_offer'
         expect(order.reload.state).to eq Order::SUBMITTED
       end
     end
@@ -99,10 +144,29 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      it 'accepts the offer' do
-        expect do
-          client.execute(mutation, buyer_accept_offer_input)
-        end.to change { order.reload.state }.from(Order::SUBMITTED).to(Order::APPROVED)
+      it 'approves the order' do
+        inventory_request = stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json)
+        expect(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
+        expect(GravityService).to receive(:get_credit_card).and_return(credit_card)
+        expect(GravityService).to receive(:get_artwork).and_return(artwork)
+        expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
+        response = client.execute(mutation, buyer_accept_offer_input)
+
+        expect(inventory_request).to have_been_requested
+
+        expect(response.data.buyer_accept_offer.order_or_error).to respond_to(:order)
+        expect(response.data.buyer_accept_offer.order_or_error.order).not_to be_nil
+
+        response_order = response.data.buyer_accept_offer.order_or_error.order
+        expect(response_order.id).to eq order.id.to_s
+        expect(response_order.state).to eq Order::APPROVED.upcase
+
+        expect(response.data.buyer_accept_offer.order_or_error).not_to respond_to(:error)
+        expect(order.reload.state).to eq Order::APPROVED
+        expect(order.state_updated_at).not_to be_nil
+        expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
+        expect(order.reload.transactions.last.external_id).not_to be_nil
+        expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
       end
     end
   end
@@ -115,5 +179,12 @@ describe Api::GraphqlController, type: :request do
   def create_another_offer
     another_offer = Fabricate(:offer, order: order)
     order.update!(last_offer: another_offer)
+  end
+
+  def mock_pre_process_calls
+    allow(GravityService).to receive(:get_artwork).and_return(artwork)
+    allow(GravityService).to receive(:get_merchant_account).and_return(merchant_account)
+    allow(GravityService).to receive(:get_credit_card).and_return(credit_card)
+    allow(GravityService).to receive(:fetch_partner).and_return(partner)
   end
 end

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -2,11 +2,15 @@ require 'rails_helper'
 require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
   describe 'seller_accept_offer mutation' do
     include_context 'GraphQL Client'
     let(:order_seller_id) { jwt_partner_ids.first }
     let(:order_buyer_id) { jwt_user_id }
     let(:order_state) { Order::SUBMITTED }
+    let(:credit_card_id) { 'cc-1' }
+    let(:merchant_account) { { external_id: 'ma-1' } }
+    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
     let(:order) do
       Fabricate(
         :order,
@@ -31,6 +35,7 @@ describe Api::GraphqlController, type: :request do
       Fabricate(:line_item, order: order, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
     end
     let(:offer) { Fabricate(:offer, order: order, from_id: order_buyer_id, from_type: 'user', amount_cents: 800_00) }
+    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
 
     let(:mutation) do
       <<-GRAPHQL

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -79,7 +79,7 @@ describe Api::GraphqlController, type: :request do
 
       it "returns invalid state transition error and doesn't change the order state" do
         mock_pre_process_calls
-        
+
         response = client.execute(mutation, seller_accept_offer_input)
 
         expect(response.data.seller_accept_offer.order_or_error.error.type).to eq 'validation'

--- a/spec/services/commit_order_service_spec.rb
+++ b/spec/services/commit_order_service_spec.rb
@@ -5,8 +5,8 @@ describe CommitOrderService, type: :services do
   include_context 'use stripe mock'
 
   let(:partner_id) { 'partner-1' }
-  let(:partner) { { id: partner_id, effective_commission_rate: 0.01} }
-  let(:partner_missing_commission_rate) { { id: partner_id, effective_commission_rate: nil} }
+  let(:partner) { { id: partner_id, effective_commission_rate: 0.01 } }
+  let(:partner_missing_commission_rate) { { id: partner_id, effective_commission_rate: nil } }
   let(:credit_card_id) { 'cc-1' }
   let(:user_id) { 'dr-collector' }
   let(:order) do
@@ -43,8 +43,7 @@ describe CommitOrderService, type: :services do
   let(:edition_set_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: 200, body: {}.to_json) }
   let(:service) { CommitOrderService.new(order, :submit, user_id) }
   let(:transaction) { Fabricate(:transaction, status: Transaction::SUCCESS) }
-  let(:failed_transaction) { Fabricate(:transaction, status: Transaction::FAILURE)}
-
+  let(:failed_transaction) { Fabricate(:transaction, status: Transaction::FAILURE) }
 
   describe '#pre_process!' do
     context 'with an uncommittable action' do
@@ -100,7 +99,7 @@ describe CommitOrderService, type: :services do
         expect(GravityService).to receive(:deduct_inventory).with(li)
       end
       service.send(:deduct_inventory)
-      expect(service.instance_variable_get("@deducted_inventory").count).to eq line_items.count
+      expect(service.instance_variable_get('@deducted_inventory').count).to eq line_items.count
     end
   end
 
@@ -154,7 +153,6 @@ describe CommitOrderService, type: :services do
       service.send(:undeduct_inventory)
     end
   end
-
 
   describe '#validate_credit_card!' do
     it 'raises an error if the credit card does not have an external id' do

--- a/spec/services/commit_order_service_spec.rb
+++ b/spec/services/commit_order_service_spec.rb
@@ -156,7 +156,7 @@ describe CommitOrderService, type: :services do
 
   describe '#validate_credit_card!' do
     it 'raises an error if the credit card does not have an external id' do
-      service.credit_card = { id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil }
+      allow(GravityService).to receive(:get_credit_card).and_return(id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil)
       expect { service.send(:validate_credit_card!) }.to raise_error do |error|
         expect(error).to be_a(Errors::ValidationError)
         expect(error.code).to eq :credit_card_missing_external_id
@@ -165,7 +165,7 @@ describe CommitOrderService, type: :services do
     end
 
     it 'raises an error if the credit card does not have a customer account' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1' }
+      allow(GravityService).to receive(:get_credit_card).and_return(id: 'cc-1', external_id: 'cc-1')
       expect { service.send(:validate_credit_card!) }.to raise_error do |error|
         expect(error).to be_a(Errors::ValidationError)
         expect(error.code).to eq :credit_card_missing_customer
@@ -174,7 +174,7 @@ describe CommitOrderService, type: :services do
     end
 
     it 'raises an error if the credit card does not have a customer account external id' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil }
+      allow(GravityService).to receive(:get_credit_card).and_return(id: 'cc-1', external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil)
       expect { service.send(:validate_credit_card!) }.to raise_error do |error|
         expect(error).to be_a(Errors::ValidationError)
         expect(error.code).to eq :credit_card_missing_customer
@@ -183,7 +183,7 @@ describe CommitOrderService, type: :services do
     end
 
     it 'raises an error if the card is deactivated' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 2.days.ago }
+      allow(GravityService).to receive(:get_credit_card).and_return(id: 'cc-1', external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 2.days.ago)
       expect { service.send(:validate_credit_card!) }.to raise_error do |error|
         expect(error).to be_a(Errors::ValidationError)
         expect(error.code).to eq :credit_card_deactivated

--- a/spec/services/commit_order_service_spec.rb
+++ b/spec/services/commit_order_service_spec.rb
@@ -1,0 +1,224 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe CommitOrderService, type: :services do
+  include_context 'use stripe mock'
+
+  let(:partner_id) { 'partner-1' }
+  let(:partner) { { id: partner_id, effective_commission_rate: 0.01} }
+  let(:partner_missing_commission_rate) { { id: partner_id, effective_commission_rate: nil} }
+  let(:credit_card_id) { 'cc-1' }
+  let(:user_id) { 'dr-collector' }
+  let(:order) do
+    Fabricate(
+      :order,
+      seller_id: partner_id,
+      credit_card_id: credit_card_id,
+      fulfillment_type: Order::PICKUP
+    )
+  end
+  let(:artwork1) { { _id: 'a-1', current_version_id: '1' } }
+  let(:artwork2) { { _id: 'a-2', current_version_id: '1' } }
+  let!(:line_items) do
+    [
+      Fabricate(:line_item, order: order, list_price_cents: 2000_00, artwork_id: artwork1[:_id], artwork_version_id: artwork1[:current_version_id], quantity: 1),
+      Fabricate(:line_item, order: order, list_price_cents: 8000_00, artwork_id: artwork2[:_id], artwork_version_id: artwork2[:current_version_id], edition_set_id: 'es-1', quantity: 2)
+    ]
+  end
+  let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id }, deactivated_at: nil } }
+  let(:merchant_account_id) { 'ma-1' }
+  let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
+  let(:create_charge_params) do
+    {
+      source_id: credit_card[:external_id],
+      destination_id: merchant_account_id,
+      customer_id: credit_card[:customer_account][:external_id],
+      amount: order.buyer_total_cents,
+      currency_code: order.currency_code
+    }
+  end
+  let(:artwork_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json) }
+  let(:edition_set_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { deduct: 2 }).to_return(status: 200, body: {}.to_json) }
+  let(:artwork_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: 200, body: {}.to_json) }
+  let(:edition_set_inventory_undeduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { undeduct: 2 }).to_return(status: 200, body: {}.to_json) }
+  let(:service) { CommitOrderService.new(order, :submit, user_id) }
+  let(:transaction) { Fabricate(:transaction, status: Transaction::SUCCESS) }
+  let(:failed_transaction) { Fabricate(:transaction, status: Transaction::FAILURE)}
+
+
+  describe '#pre_process!' do
+    context 'with an uncommittable action' do
+      it 'raises an error' do
+        error_service = CommitOrderService.new(order, :reject, user_id)
+        expect { error_service.send(:pre_process!) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ValidationError)
+          expect(error.code).to eq :uncommittable_action
+        end
+      end
+    end
+    context 'with correctly validated data' do
+      it 'updates order totals with the partner commission rate' do
+        allow(GravityService).to receive(:get_credit_card).and_return(credit_card)
+        allow(GravityService).to receive(:get_artwork).and_return(artwork1)
+        allow(GravityService).to receive(:get_artwork).and_return(artwork2)
+        expect(GravityService).to receive(:fetch_partner).with(partner_id).and_return(partner)
+        service.send(:pre_process!)
+        expect(order.reload.commission_rate).to eq partner[:effective_commission_rate]
+      end
+    end
+  end
+
+  describe '#validate_commission_rate!' do
+    context 'with a partner with missing commission rate' do
+      it 'raises an error' do
+        allow(GravityService).to receive(:fetch_partner).and_return(partner_missing_commission_rate)
+        expect { service.send(:validate_commission_rate!) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ValidationError)
+          expect(error.code).to eq :missing_commission_rate
+          expect(error.data).to match(partner_id: partner_id)
+        end
+      end
+    end
+  end
+
+  describe '#validate_artwork_versions!' do
+    context 'with mismatched artwork versions' do
+      it 'raises an error and records the artwork mismatch in DataDog' do
+        expect(GravityService).to receive(:get_artwork).with(artwork1[:_id]).and_return(artwork1.merge(current_version_id: 2))
+        expect(Exchange).to receive_message_chain(:dogstatsd, :increment).with('submit.artwork_version_mismatch')
+        expect { service.send(:validate_artwork_versions!) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ProcessingError)
+          expect(error.code).to eq :artwork_version_mismatch
+        end
+      end
+    end
+  end
+
+  describe '#deduct_inventory' do
+    it 'deducts inventory for each line item' do
+      order.line_items.each do |li|
+        expect(GravityService).to receive(:deduct_inventory).with(li)
+      end
+      service.send(:deduct_inventory)
+      expect(service.instance_variable_get("@deducted_inventory").count).to eq line_items.count
+    end
+    context 'with failed artwork inventory deduct' do
+      let(:artwork_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 400, body: { message: 'could not deduct' }.to_json) }
+      before do
+        artwork_inventory_deduct_request
+        edition_set_inventory_deduct_request
+        artwork_inventory_undeduct_request
+        edition_set_inventory_undeduct_request
+      end
+      it 'raises proper error response' do
+        expect do
+          service.send(:deduct_inventory)
+        end.to raise_error do |error|
+          expect(error).to be_a(Errors::ProcessingError)
+          expect(error.type).to eq :processing
+          expect(error.code).to eq :insufficient_inventory
+          expect(line_items.pluck(:id)).to include error.data[:line_item_id]
+        end
+      end
+      it 'does not call to update edition set inventory' do
+        expect do
+          service.send(:deduct_inventory)
+        end.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(0)
+        expect(artwork_inventory_deduct_request).to have_been_requested
+        expect(edition_set_inventory_deduct_request).to_not have_been_requested
+        expect(artwork_inventory_undeduct_request).not_to have_been_requested
+        expect(edition_set_inventory_undeduct_request).not_to have_been_requested
+      end
+    end
+  end
+
+  describe '#post_process!' do
+    before do
+      service.instance_variable_set('@transaction', transaction)
+    end
+    it 'updates the external_charge_id on the order with the external_id of the transaction' do
+      service.send(:post_process!)
+      expect(order.reload.external_charge_id).to eq transaction.external_id
+    end
+
+    it 'records the order action in DataDog' do
+      expect(Exchange).to receive_message_chain(:dogstatsd, :increment).with('order.submit')
+      service.send(:post_process!)
+    end
+  end
+
+  describe '#handle_transaction' do
+    context 'with a transaction present' do
+      before do
+        ActiveJob::Base.queue_adapter = :test
+      end
+      it "adds the transaction to the order's transaction list" do
+        service.instance_variable_set('@transaction', transaction)
+        expect { service.send(:handle_transaction) }.to change(order.transactions, :count).by(1)
+      end
+      context 'with a failed transaction' do
+        it 'sends a notification about the failed charge' do
+          service.instance_variable_set('@transaction', failed_transaction)
+          service.send(:handle_transaction)
+          expect(PostTransactionNotificationJob).to have_been_enqueued.with(failed_transaction.id, TransactionEvent::CREATED, user_id)
+        end
+      end
+    end
+    context 'without a transaction' do
+      it 'does nothing' do
+        service.instance_variable_set('@transaction', nil)
+        expect { service.send(:handle_transaction) }.not_to change(order.transactions, :count)
+        expect(PostTransactionNotificationJob).not_to have_been_enqueued
+      end
+    end
+  end
+
+  describe '#undeduct_inventory' do
+    it 'undeducts deducted inventory' do
+      service.instance_variable_set('@deducted_inventory', line_items)
+      line_items.each do |li|
+        expect(GravityService).to receive(:undeduct_inventory).with(li)
+      end
+      service.send(:undeduct_inventory)
+    end
+  end
+
+
+  describe '#validate_credit_card!' do
+    it 'raises an error if the credit card does not have an external id' do
+      service.credit_card = { id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil }
+      expect { service.send(:validate_credit_card!) }.to raise_error do |error|
+        expect(error).to be_a(Errors::ValidationError)
+        expect(error.code).to eq :credit_card_missing_external_id
+        expect(error.data).to match(credit_card_id: 'cc-1')
+      end
+    end
+
+    it 'raises an error if the credit card does not have a customer account' do
+      service.credit_card = { id: 'cc-1', external_id: 'cc-1' }
+      expect { service.send(:validate_credit_card!) }.to raise_error do |error|
+        expect(error).to be_a(Errors::ValidationError)
+        expect(error.code).to eq :credit_card_missing_customer
+        expect(error.data).to match(credit_card_id: 'cc-1')
+      end
+    end
+
+    it 'raises an error if the credit card does not have a customer account external id' do
+      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil }
+      expect { service.send(:validate_credit_card!) }.to raise_error do |error|
+        expect(error).to be_a(Errors::ValidationError)
+        expect(error.code).to eq :credit_card_missing_customer
+        expect(error.data).to match(credit_card_id: 'cc-1')
+      end
+    end
+
+    it 'raises an error if the card is deactivated' do
+      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 2.days.ago }
+      expect { service.send(:validate_credit_card!) }.to raise_error do |error|
+        expect(error).to be_a(Errors::ValidationError)
+        expect(error.code).to eq :credit_card_deactivated
+        expect(error.data).to match(credit_card_id: 'cc-1')
+      end
+    end
+  end
+end

--- a/spec/services/offers/accept_offer_service_spec.rb
+++ b/spec/services/offers/accept_offer_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Offers::AcceptService, type: :services do
+describe Offers::AcceptOfferService, type: :services do
   describe '#process!' do
     subject(:call_service) do
       described_class.new(

--- a/spec/services/offers/accept_offer_service_spec.rb
+++ b/spec/services/offers/accept_offer_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Offers::AcceptOfferService, type: :services do
-  include_context 'use stripe mock'  
+  include_context 'use stripe mock'
   describe '#process!' do
     subject(:call_service) do
       described_class.new(
@@ -22,7 +22,7 @@ describe Offers::AcceptOfferService, type: :services do
         fulfillment_type: Order::PICKUP,
         items_total_cents: 18000_00,
         tax_total_cents: 200_00,
-        shipping_total_cents: 100_00        
+        shipping_total_cents: 100_00
       )
     end
     let(:artwork1) { { _id: 'a-1', current_version_id: '1' } }

--- a/spec/services/offers/accept_offer_service_spec.rb
+++ b/spec/services/offers/accept_offer_service_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe Offers::AcceptOfferService, type: :services do
+  include_context 'use stripe mock'  
   describe '#process!' do
     subject(:call_service) do
       described_class.new(
@@ -9,14 +10,58 @@ describe Offers::AcceptOfferService, type: :services do
         user_id: current_user_id
       ).process!
     end
-    let!(:order) { Fabricate(:order, state: Order::SUBMITTED) }
+    let(:partner_id) { 'partner-1' }
+    let(:credit_card_id) { 'cc-1' }
+    let(:user_id) { 'dr-collector' }
+    let(:order) do
+      Fabricate(
+        :order,
+        state: Order::SUBMITTED,
+        seller_id: partner_id,
+        credit_card_id: credit_card_id,
+        fulfillment_type: Order::PICKUP,
+        items_total_cents: 18000_00,
+        tax_total_cents: 200_00,
+        shipping_total_cents: 100_00        
+      )
+    end
+    let(:artwork1) { { _id: 'a-1', current_version_id: '1' } }
+    let(:artwork2) { { _id: 'a-2', current_version_id: '1' } }
+    let!(:line_items) do
+      [
+        Fabricate(:line_item, order: order, list_price_cents: 2000_00, artwork_id: artwork1[:_id], artwork_version_id: artwork1[:current_version_id], quantity: 1),
+        Fabricate(:line_item, order: order, list_price_cents: 8000_00, artwork_id: artwork2[:_id], artwork_version_id: artwork2[:current_version_id], edition_set_id: 'es-1', quantity: 2)
+      ]
+    end
+    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id }, deactivated_at: nil } }
+    let(:merchant_account_id) { 'ma-1' }
+    let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
+    let(:create_charge_params) do
+      {
+        source_id: credit_card[:external_id],
+        destination_id: merchant_account_id,
+        customer_id: credit_card[:customer_account][:external_id],
+        amount: order.buyer_total_cents,
+        currency_code: order.currency_code
+      }
+    end
     let!(:offer) { Fabricate(:offer, order: order) }
     let(:current_user_id) { 'user-id-123' }
+    let(:artwork_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json) }
+    let(:edition_set_inventory_deduct_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-2/edition_set/es-1/inventory").with(body: { deduct: 2 }).to_return(status: 200, body: {}.to_json) }
 
     before do
       # last_offer is set in Orders::InitialOffer. "Stubbing" out the
       # dependent behavior of this class to by setting last_offer directly
       order.update!(last_offer: offer)
+      allow(GravityService).to receive(:get_merchant_account).with(partner_id).and_return(partner_merchant_accounts.first)
+      allow(GravityService).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
+      allow(GravityService).to receive(:get_artwork).with(artwork1[:_id]).and_return(artwork1)
+      allow(GravityService).to receive(:get_artwork).with(artwork2[:_id]).and_return(artwork2)
+      allow(Adapters::GravityV1).to receive(:get).with("/partner/#{partner_id}/all").and_return(gravity_v1_partner)
+      line_items.each do |li|
+        allow(GravityService).to receive(:deduct_inventory).with(li)
+      end
     end
 
     context 'with a approve-able order' do
@@ -43,11 +88,40 @@ describe Offers::AcceptOfferService, type: :services do
         expect(PostOrderNotificationJob).to have_received(:perform_later)
           .with(order.id, Order::APPROVED, current_user_id)
       end
+
+      describe 'Stripe call' do
+        it 'calls stripe with expected params' do
+          expect(Stripe::Charge).to receive(:create).with(
+            amount: 18300_00,
+            currency: 'USD',
+            description: 'INVOICING-DE via Artsy',
+            source: stripe_customer.default_source,
+            customer: stripe_customer.id,
+            metadata: {
+              exchange_order_id: order.id,
+              buyer_id: order.buyer_id,
+              buyer_type: 'user',
+              seller_id: 'partner-1',
+              seller_type: 'gallery',
+              type: 'bn-mo'
+            },
+            destination: {
+              account: 'ma-1',
+              amount: 3369_00
+            },
+            capture: true
+          ).and_return(captured_charge)
+          artwork_inventory_deduct_request
+          edition_set_inventory_deduct_request
+          call_service
+        end
+      end
     end
 
     context "when we can't approve the order" do
-      let(:order) { Fabricate(:order, state: Order::PENDING) }
-      let(:offer) { Fabricate(:offer, order: order) }
+      before do
+        order.update!(state: Order::PENDING)
+      end
 
       it "doesn't instrument" do
         dd_statsd = stub_ddstatsd_instance

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -223,7 +223,7 @@ describe OrderSubmitService, type: :services do
               amount: 3369_00
             },
             capture: false
-          ).and_return(captured_charge)
+          ).and_return(uncaptured_charge)
           artwork_inventory_deduct_request
           edition_set_inventory_deduct_request
           service.process!
@@ -250,7 +250,7 @@ describe OrderSubmitService, type: :services do
                 amount: 3369_00
               },
               capture: false
-            ).and_return(captured_charge)
+            ).and_return(uncaptured_charge)
             artwork_inventory_deduct_request
             edition_set_inventory_deduct_request
             service.process!

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -26,7 +26,7 @@ describe OrderSubmitService, type: :services do
   let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id }, deactivated_at: nil } }
   let(:merchant_account_id) { 'ma-1' }
   let(:partner_merchant_accounts) { [{ external_id: 'ma-1' }, { external_id: 'some_account' }] }
-  let(:authorize_charge_params) do
+  let(:create_charge_params) do
     {
       source_id: credit_card[:external_id],
       destination_id: merchant_account_id,

--- a/spec/services/order_submit_service_spec.rb
+++ b/spec/services/order_submit_service_spec.rb
@@ -259,42 +259,4 @@ describe OrderSubmitService, type: :services do
       end
     end
   end
-
-  describe '#assert_credit_card!' do
-    it 'raises an error if the credit card does not have an external id' do
-      service.credit_card = { id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: nil }
-      expect { service.send(:assert_credit_card!) }.to raise_error do |error|
-        expect(error).to be_a(Errors::ValidationError)
-        expect(error.code).to eq :credit_card_missing_external_id
-        expect(error.data).to match(credit_card_id: 'cc-1')
-      end
-    end
-
-    it 'raises an error if the credit card does not have a customer account' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1' }
-      expect { service.send(:assert_credit_card!) }.to raise_error do |error|
-        expect(error).to be_a(Errors::ValidationError)
-        expect(error.code).to eq :credit_card_missing_customer
-        expect(error.data).to match(credit_card_id: 'cc-1')
-      end
-    end
-
-    it 'raises an error if the credit card does not have a customer account external id' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { some_prop: 'some_val' }, deactivated_at: nil }
-      expect { service.send(:assert_credit_card!) }.to raise_error do |error|
-        expect(error).to be_a(Errors::ValidationError)
-        expect(error.code).to eq :credit_card_missing_customer
-        expect(error.data).to match(credit_card_id: 'cc-1')
-      end
-    end
-
-    it 'raises an error if the card is deactivated' do
-      service.credit_card = { id: 'cc-1', external_id: 'cc-1', customer_account: { external_id: 'cust-1' }, deactivated_at: 2.days.ago }
-      expect { service.send(:assert_credit_card!) }.to raise_error do |error|
-        expect(error).to be_a(Errors::ValidationError)
-        expect(error.code).to eq :credit_card_deactivated
-        expect(error.data).to match(credit_card_id: 'cc-1')
-      end
-    end
-  end
 end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -22,9 +22,9 @@ describe PaymentService, type: :services do
     }
   end
 
-  describe '#create_charge' do
+  describe '#create_and_authorize_charge' do
     it "authorizes a charge on the user's credit card" do
-      transaction = PaymentService.create_charge(params)
+      transaction = PaymentService.create_and_authorize_charge(params)
       expect(transaction.amount_cents).to eq(20_00)
       expect(transaction.source_id).to eq(stripe_customer.default_source)
       expect(transaction.status).to eq(Transaction::SUCCESS)
@@ -34,7 +34,7 @@ describe PaymentService, type: :services do
     end
     it 'catches Stripe errors and returns a failed transaction' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
-      transaction = PaymentService.create_charge(params)
+      transaction = PaymentService.create_and_authorize_charge(params)
       expect(transaction.amount_cents).to eq buyer_amount
       expect(transaction.source_id).to eq stripe_customer.default_source
       expect(transaction.destination_id).to eq 'ma-1'
@@ -45,16 +45,16 @@ describe PaymentService, type: :services do
     end
   end
 
-  describe '#capture_charge' do
+  describe '#capture_authorized_charge' do
     it 'captures a charge' do
-      transaction = PaymentService.capture_charge(uncaptured_charge.id)
+      transaction = PaymentService.capture_authorized_charge(uncaptured_charge.id)
       expect(transaction.amount_cents).to eq(uncaptured_charge.amount)
       expect(transaction.transaction_type).to eq Transaction::CAPTURE
       expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and returns a failed transaction' do
       StripeMock.prepare_card_error(:card_declined, :capture_charge)
-      transaction = PaymentService.capture_charge(uncaptured_charge.id)
+      transaction = PaymentService.capture_authorized_charge(uncaptured_charge.id)
       expect(transaction.external_id).to eq uncaptured_charge.id
       expect(transaction.failure_code).to eq 'card_declined'
       expect(transaction.failure_message).to eq 'The card was declined'

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -22,9 +22,9 @@ describe PaymentService, type: :services do
     }
   end
 
-  describe '#authorize_charge' do
+  describe '#create_charge' do
     it "authorizes a charge on the user's credit card" do
-      transaction = PaymentService.authorize_charge(params)
+      transaction = PaymentService.create_charge(params)
       expect(transaction.amount_cents).to eq(20_00)
       expect(transaction.source_id).to eq(stripe_customer.default_source)
       expect(transaction.status).to eq(Transaction::SUCCESS)
@@ -34,7 +34,7 @@ describe PaymentService, type: :services do
     end
     it 'catches Stripe errors and returns a failed transaction' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
-      transaction = PaymentService.authorize_charge(params)
+      transaction = PaymentService.create_charge(params)
       expect(transaction.amount_cents).to eq buyer_amount
       expect(transaction.source_id).to eq stripe_customer.default_source
       expect(transaction.destination_id).to eq 'ma-1'


### PR DESCRIPTION
Addresses [PURCHASE-668](https://artsyproduct.atlassian.net/browse/PURCHASE-668).

This PR is for early feedback on creating our accept offer service layer.

 **Tests will be reorganized / added / fixed in future commits.**

### What Changed

- Submitting an order and accepting an offer are fairly similar to each other -- in both cases, we need to deduct inventory, charge the buyer and update the state of the order. So, I've created a new class `CommitOrderService` that represents this sequence of events. Child classes can specify the next state of the order and implement their own payment method. I chose the name "commit" because once the inventory is deducted nobody else can claim that artwork unless the order is rejected or refunded. I'm definitely open to other names, though!
- Right now `PaymentService` can only authorize charges and capture previously authorized charges. For an offer, though, we want to create a charge and capture it right away. This renames `PaymentService.authorize_charge` to `PaymentService.create_charge` and adds a `capture` parameter that specifies whether or not to immediately capture the charge. I also added two other methods `create_and_capture_charge` and `create_and_authorize_charge` to make the state of the funds very clear when we create a charge.
- We previously had a `BaseOfferService` containing some validation methods that `RejectOfferService` and `AcceptOfferService` both inherited from. I renamed this to `OfferValidationService` and converted it to a module so that we can use it as a class mixin and allow `AcceptOfferService` to inherit from `CommitOfferService` instead.
- `AcceptOfferService` now inherits from `CommitOfferService`.
- `OrderSubmitService` now inherits from `CommitOfferService`.