### PR TITLE
Remove reference to old PostNotificationJob

### DIFF
--- a/app/jobs/post_order_notification_job.rb
+++ b/app/jobs/post_order_notification_job.rb
@@ -6,5 +6,3 @@ class PostOrderNotificationJob < ApplicationJob
     OrderEvent.post(order, action, user_id)
   end
 end
-
-PostNotificationJob = PostOrderNotificationJob


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-700

Now that the [commit][0] that refactored name of the job is on staging
and production and there are no scheduled jobs in Sidekiq with the name
PostNotificationJob, we are clear to remove this old alias.

[0]:aa470960628e0cc46636b3f947cd2c9f3152fe06