### PR TITLE
Add Papertrail to few other models

### DIFF
--- a/app/models/fulfillment.rb
+++ b/app/models/fulfillment.rb
@@ -1,4 +1,6 @@
 class Fulfillment < ApplicationRecord
+  has_paper_trail
+
   has_many :line_item_fulfillments, dependent: :destroy
   has_many :line_items, through: :line_item_fulfillments
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,4 +1,6 @@
 class LineItem < ApplicationRecord
+  has_paper_trail
+
   belongs_to :order
   has_many :line_item_fulfillments, dependent: :destroy
   has_many :fulfillments, through: :line_item_fulfillments

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,4 +1,6 @@
 class Offer < ApplicationRecord
+  has_paper_trail
+
   belongs_to :order
   belongs_to :responds_to, class_name: 'Offer', optional: true
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,6 @@
 class Transaction < ApplicationRecord
+  has_paper_trail
+
   belongs_to :order
 
   TYPES = [


### PR DESCRIPTION
# Change
Add `has_papertrail` to few other models, they will be less useful since these models don't technically get updated and are mostly created but still good to have them.