### PR TITLE
Papertrail Versions Followup

### DIFF
--- a/db/migrate/20181203203227_cleanup_old_versions.rb
+++ b/db/migrate/20181203203227_cleanup_old_versions.rb
@@ -1,0 +1,10 @@
+class CleanupOldVersions < ActiveRecord::Migration[5.2]
+  def up
+    ActiveRecord::Base.connection.execute("DELETE FROM versions WHERE NOT item_id ~ E'^[[:xdigit:]]{8}-([[:xdigit:]]{4}-){3}[[:xdigit:]]{12}$'")
+    change_column :versions, :item_id, 'uuid USING CAST(item_id AS uuid)'
+  end
+
+  def down
+    change_column :versions, :item_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_29_132032) do
+ActiveRecord::Schema.define(version: 2018_12_03_203227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 2018_11_29_132032) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.string "item_id", null: false
+    t.uuid "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.jsonb "object"


### PR DESCRIPTION
# Changes
This is follow up work on https://github.com/artsy/exchange/pull/299 to delete older invalid records and then update the column to be `uuid`.
This happens in a migration script where we:
- Delete older records not matching `uuid` format. This happens in the migration where we delete all records that don't match Postgres's uuid format.
- Change the `item_id` column to be `uuid`, for this to work we need to change column with 'uuid USING CAST(item_id AS uuid)'

# Where are my older version?!
we delete them from here, you can find old versions in RDS snapshot with name `exchange-before-deleting-old-papertrail-versions`