### PR TITLE
Specify artsy/exchange as the `git-remote` for Hokusai

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,3 +1,4 @@
 ---
 project-name: exchange
 pre-deploy: 'bundle exec rake db:migrate'
+git-remote: git@github.com:artsy/exchange.git


### PR DESCRIPTION
This should ensure that running a `hokusai pipeline promote` pushes Git
tags even if not specified in as a command line argument. See [hokusai
docs][0] for more information.

[0]:
https://github.com/artsy/hokusai/blob/master/docs/Configuration_Options.md#project-configuration