### PR TITLE
Make sure we don't call refund and un-deduct on Offer Orders

### DIFF
--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -7,7 +7,7 @@ class OrderCancellationService
 
   def seller_lapse!
     @order.seller_lapse! do
-      process_refund
+      process_refund if @order.mode == Order::BUY
     end
     PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED)
   ensure
@@ -16,7 +16,7 @@ class OrderCancellationService
 
   def reject!
     @order.reject! do
-      process_refund
+      process_refund if @order.mode == Order::BUY
     end
     PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED, @user_id)
   ensure

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
   let(:order_state) { Order::SUBMITTED }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state) }
+  let(:order_mode) { Order::BUY }
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state, mode: order_mode) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
@@ -59,47 +60,62 @@ describe OrderCancellationService, type: :services do
   end
 
   describe '#seller_lapse!' do
-    context 'with a successful refund' do
+    context 'Buy Order' do
+      context 'with a successful refund' do
+        before do
+          artwork_inventory_undeduct_request
+          edition_set_inventory_undeduct_request
+          service.seller_lapse!
+        end
+        it 'calls to undeduct inventory' do
+          expect(artwork_inventory_undeduct_request).to have_been_requested
+          expect(edition_set_inventory_undeduct_request).to have_been_requested
+        end
+        it 'records the transaction' do
+          expect(order.transactions.last.external_id).to_not eq nil
+          expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+          expect(order.transactions.last.status).to eq Transaction::SUCCESS
+        end
+        it 'updates the order state' do
+          expect(order.state).to eq Order::CANCELED
+          expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
+        end
+        it 'queues notification job' do
+          expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
+        end
+      end
+      context 'with an unsuccessful refund' do
+        before do
+          artwork_inventory_undeduct_request
+          edition_set_inventory_undeduct_request
+          allow(Stripe::Refund).to receive(:create)
+            .with(hash_including(charge: captured_charge.id))
+            .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+          expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
+        end
+        it 'raises a ProcessingError and records the transaction' do
+          expect(order.transactions.last.external_id).to eq captured_charge.id
+          expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+          expect(order.transactions.last.status).to eq Transaction::FAILURE
+        end
+        it 'does not undeduct inventory' do
+          expect(artwork_inventory_undeduct_request).not_to have_been_requested
+          expect(edition_set_inventory_undeduct_request).not_to have_been_requested
+        end
+      end
+    end
+    context 'Offer Order' do
+      let(:order_mode) { Order::OFFER }
+      let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
       before do
-        artwork_inventory_undeduct_request
-        edition_set_inventory_undeduct_request
         service.seller_lapse!
-      end
-      it 'calls to undeduct inventory' do
-        expect(artwork_inventory_undeduct_request).to have_been_requested
-        expect(edition_set_inventory_undeduct_request).to have_been_requested
-      end
-      it 'records the transaction' do
-        expect(order.transactions.last.external_id).to_not eq nil
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::SUCCESS
       end
       it 'updates the order state' do
         expect(order.state).to eq Order::CANCELED
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
       end
-
       it 'queues notification job' do
         expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
-      end
-    end
-    context 'with an unsuccessful refund' do
-      before do
-        artwork_inventory_undeduct_request
-        edition_set_inventory_undeduct_request
-        allow(Stripe::Refund).to receive(:create)
-          .with(hash_including(charge: captured_charge.id))
-          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
-        expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
-      end
-      it 'raises a ProcessingError and records the transaction' do
-        expect(order.transactions.last.external_id).to eq captured_charge.id
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::FAILURE
-      end
-      it 'does not undeduct inventory' do
-        expect(artwork_inventory_undeduct_request).not_to have_been_requested
-        expect(edition_set_inventory_undeduct_request).not_to have_been_requested
       end
     end
   end


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-712
We are getting errors when trying to expiring (abandoning) offer orders.

# Cause
In regular `OrderFollowUpJob` we call order cancelation's service's `seller_lapse` method which as part of it will try to refund the order by calling Stripe to release the hold charge and also tries to call Gravity to undeduct the inventory BUT for offer orders we don't have to call Stripe since we are not holding any charges yet and also we don't have to call Gravity since we haven't deducted the inventory yet. 
For offers, capturing the charge and deducting artwork inventory only happens when offer is accepted.

# Solution
Skip `process_refund` when `order.mode` is `offer`.