### PR TITLE
Add `creator_id` to AddPendingOfferService 

### DIFF
--- a/app/graphql/mutations/offer/seller_counter_offer.rb
+++ b/app/graphql/mutations/offer/seller_counter_offer.rb
@@ -9,9 +9,10 @@ class Mutations::Offer::SellerCounterOffer < Mutations::BaseMutation
   def resolve(offer_id:, amount_cents:)
     offer = Offer.find(offer_id)
     order = offer.order
-    from_id = context[:current_user][:id]
+    from_id = order.seller_id
+    creator_id = context[:current_user][:id]
     authorize_seller_request!(order)
-    add_service = Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: amount_cents, from_type: Order::PARTNER, from_id: from_id)
+    add_service = Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: amount_cents, from_type: Order::PARTNER, from_id: from_id, creator_id: creator_id)
     pending_offer = add_service.process!
 
     submit_service = Offers::SubmitCounterOfferService.new(pending_offer: pending_offer, from_id: from_id)

--- a/app/services/offers/add_pending_counter_offer_service.rb
+++ b/app/services/offers/add_pending_counter_offer_service.rb
@@ -1,11 +1,12 @@
 module Offers
   class AddPendingCounterOfferService
     include OfferValidationService
-    def initialize(offer:, amount_cents:, from_id:, from_type:)
+    def initialize(offer:, amount_cents:, from_id:, creator_id:, from_type:)
       @offer = offer
       @order = offer.order
       @amount_cents = amount_cents
       @from_id = from_id
+      @creator_id = creator_id
       @from_type = from_type
     end
 
@@ -18,7 +19,7 @@ module Offers
         amount_cents: @amount_cents,
         from_id: @from_id,
         from_type: @from_type,
-        creator_id: @from_id,
+        creator_id: @creator_id,
         responds_to: @offer
       )
       totals_service = OfferTotalUpdaterService.new(offer: @pending_offer)

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -144,6 +144,9 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.last_offer.should_remit_sales_tax).to eq(false)
           expect(order.reload.last_offer.amount_cents).to eq(10000)
           expect(order.reload.last_offer.submitted_at).not_to eq(nil)
+          # for partner counte offer creator_id and from_id are different
+          expect(order.reload.last_offer.creator_id).to eq(user_id)
+          expect(order.reload.last_offer.from_id).to eq(partner_id)
           # shouldn't update order amounts until offer is accepted
           expect(order.reload.items_total_cents).to eq(0)
         end.to change { order.reload.offers.count }.from(1).to(2)

--- a/spec/services/offers/add_pending_counter_offer_service_spec.rb
+++ b/spec/services/offers/add_pending_counter_offer_service_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 describe Offers::AddPendingCounterOfferService, type: :services do
   describe '#process!' do
-    let(:offer_from_id) { 'user-id' }
+    let(:offer_creator_id) { 'user-id' }
+    let(:offer_from_id) { 'partner-id' }
     let(:offer_from_type) { Order::PARTNER }
     let(:order) { Fabricate(:order, state: Order::SUBMITTED) }
     let(:offer) { Fabricate(:offer, order: order, amount_cents: 10000, submitted_at: 1.day.ago) }
-    let(:service) { Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: 20000, from_id: offer_from_id, from_type: offer_from_type) }
+    let(:service) { Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: 20000, from_id: offer_from_id, creator_id: offer_creator_id, from_type: offer_from_type) }
     let(:offer_totol_updater_service) { double }
 
     before do
@@ -27,6 +28,7 @@ describe Offers::AddPendingCounterOfferService, type: :services do
         expect(pending_offer.amount_cents).to eq(20000)
         expect(pending_offer.responds_to).to eq(offer)
         expect(pending_offer.from_id).to eq(offer_from_id)
+        expect(pending_offer.creator_id).to eq(offer_creator_id)
         expect(pending_offer.from_type).to eq(offer_from_type)
         expect(pending_offer.submitted_at).to be_nil
       end


### PR DESCRIPTION
and `sellerCounterOffer` mutation

Realized `from_id` of an offer, when submitted from the seller side is the `partner_id` not` user_id`.

In case of a buyer offer they are the same though.