### PR TITLE
Add last_offer to order event

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -57,6 +57,7 @@ class OrderEvent < Events::BaseEvent
 
     last_offer = @object.last_offer
     {
+      id: last_offer.id,
       amount_cents: last_offer.amount_cents,
       shipping_total_cents: last_offer.shipping_total_cents,
       tax_total_cents: last_offer.tax_total_cents,

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -43,13 +43,27 @@ class OrderEvent < Events::BaseEvent
   end
 
   def properties
-    PROPERTIES_ATTRS.map { |att| [att, @object.send(att)] }.to_h.merge(line_items: line_items_details)
+    PROPERTIES_ATTRS.map { |att| [att, @object.send(att)] }.to_h.merge(line_items: line_items_details, last_offer: last_offer)
   end
 
   private
 
   def line_items_details
     @object.line_items.map { |li| line_item_detail(li) }
+  end
+
+  def last_offer
+    return unless @object.last_offer
+
+    last_offer = @object.last_offer
+    {
+      amount_cents: last_offer.amount_cents,
+      shipping_total_cents: last_offer.shipping_total_cents,
+      tax_total_cents: last_offer.tax_total_cents,
+      from_participant: last_offer.from_participant,
+      creator_id: last_offer.creator_id,
+      responds_to: last_offer.responds_to_id
+    }
   end
 
   def line_item_detail(line_item)

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -118,6 +118,7 @@ describe OrderEvent, type: :events do
         order.update!(last_offer: offer)
       end
       it 'includes last_offer' do
+        expect(event.properties[:last_offer][:id]).to eq offer.id
         expect(event.properties[:last_offer][:amount_cents]).to eq 200_00
         expect(event.properties[:last_offer][:shipping_total_cents]).to eq 100_00
         expect(event.properties[:last_offer][:tax_total_cents]).to eq 40_00

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -80,34 +80,51 @@ describe OrderEvent, type: :events do
   end
 
   describe '#properties' do
-    it 'returns correct properties for a submitted order' do
-      expect(event.properties[:mode]).to eq Order::BUY
-      expect(event.properties[:code]).to eq order.code
-      expect(event.properties[:currency_code]).to eq 'USD'
-      expect(event.properties[:state]).to eq 'submitted'
-      expect(event.properties[:buyer_id]).to eq user_id
-      expect(event.properties[:buyer_type]).to eq Order::USER
-      expect(event.properties[:fulfillment_type]).to eq Order::SHIP
-      expect(event.properties[:seller_id]).to eq seller_id
-      expect(event.properties[:seller_type]).to eq 'gallery'
-      expect(event.properties[:items_total_cents]).to eq 300
-      expect(event.properties[:shipping_total_cents]).to eq 50
-      expect(event.properties[:tax_total_cents]).to eq 30
-      expect(event.properties[:buyer_total_cents]).to eq 380
-      expect(event.properties[:updated_at]).not_to be_nil
-      expect(event.properties[:created_at]).not_to be_nil
-      expect(event.properties[:line_items].count).to eq 2
-      expect(event.properties[:line_items]).to match_array(expected_line_item_properties)
-      expect(event.properties[:shipping_name]).to eq 'Fname Lname'
-      expect(event.properties[:shipping_address_line1]).to eq '123 Main St'
-      expect(event.properties[:shipping_address_line2]).to eq 'Apt 2'
-      expect(event.properties[:shipping_city]).to eq 'Chicago'
-      expect(event.properties[:shipping_country]).to eq 'USA'
-      expect(event.properties[:shipping_postal_code]).to eq '60618'
-      expect(event.properties[:buyer_phone_number]).to eq '00123459876'
-      expect(event.properties[:shipping_region]).to eq 'IL'
-      expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
-      expect(event.properties[:total_list_price_cents]).to eq(400)
+    context 'without last_offer' do
+      it 'returns correct properties for a submitted order' do
+        expect(event.properties[:mode]).to eq Order::BUY
+        expect(event.properties[:code]).to eq order.code
+        expect(event.properties[:currency_code]).to eq 'USD'
+        expect(event.properties[:state]).to eq 'submitted'
+        expect(event.properties[:buyer_id]).to eq user_id
+        expect(event.properties[:buyer_type]).to eq Order::USER
+        expect(event.properties[:fulfillment_type]).to eq Order::SHIP
+        expect(event.properties[:seller_id]).to eq seller_id
+        expect(event.properties[:seller_type]).to eq 'gallery'
+        expect(event.properties[:items_total_cents]).to eq 300
+        expect(event.properties[:shipping_total_cents]).to eq 50
+        expect(event.properties[:tax_total_cents]).to eq 30
+        expect(event.properties[:buyer_total_cents]).to eq 380
+        expect(event.properties[:updated_at]).not_to be_nil
+        expect(event.properties[:created_at]).not_to be_nil
+        expect(event.properties[:line_items].count).to eq 2
+        expect(event.properties[:line_items]).to match_array(expected_line_item_properties)
+        expect(event.properties[:shipping_name]).to eq 'Fname Lname'
+        expect(event.properties[:shipping_address_line1]).to eq '123 Main St'
+        expect(event.properties[:shipping_address_line2]).to eq 'Apt 2'
+        expect(event.properties[:shipping_city]).to eq 'Chicago'
+        expect(event.properties[:shipping_country]).to eq 'USA'
+        expect(event.properties[:shipping_postal_code]).to eq '60618'
+        expect(event.properties[:buyer_phone_number]).to eq '00123459876'
+        expect(event.properties[:shipping_region]).to eq 'IL'
+        expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
+        expect(event.properties[:total_list_price_cents]).to eq(400)
+        expect(event.properties[:last_offer]).to be_nil
+      end
+    end
+    context 'with last_offer' do
+      let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin') }
+      before do
+        order.update!(last_offer: offer)
+      end
+      it 'includes last_offer' do
+        expect(event.properties[:last_offer][:amount_cents]).to eq 200_00
+        expect(event.properties[:last_offer][:shipping_total_cents]).to eq 100_00
+        expect(event.properties[:last_offer][:tax_total_cents]).to eq 40_00
+        expect(event.properties[:last_offer][:from_participant]).to eq 'seller'
+        expect(event.properties[:last_offer][:creator_id]).to eq 'partner-admin'
+        expect(event.properties[:last_offer][:responds_to_id]).to be_nil
+      end
     end
   end
   it 'returns state_reason when available' do


### PR DESCRIPTION
# Problem
We want to know who made `last_offer` in case of offers and also details about it when sending out emails from Pulse.

# Solution
Add `last_offer` to `order_event`'s `properties`.