### PR TITLE
Rename offer module to offers

### DIFF
--- a/app/graphql/mutations/offers/add_initial_offer_to_order.rb
+++ b/app/graphql/mutations/offers/add_initial_offer_to_order.rb
@@ -1,4 +1,4 @@
-class Mutations::AddInitialOfferToOrder < Mutations::BaseMutation
+class Mutations::Offers::AddInitialOfferToOrder < Mutations::BaseMutation
   argument :order_id, ID, required: true
   argument :amount_cents, Integer, required: true
 

--- a/app/graphql/mutations/offers/base_accept_offer.rb
+++ b/app/graphql/mutations/offers/base_accept_offer.rb
@@ -1,4 +1,4 @@
-class Mutations::Offer::BaseAcceptOffer < Mutations::BaseMutation
+class Mutations::Offers::BaseAcceptOffer < Mutations::BaseMutation
   null true
 
   argument :offer_id, ID, required: true

--- a/app/graphql/mutations/offers/buyer_accept_offer.rb
+++ b/app/graphql/mutations/offers/buyer_accept_offer.rb
@@ -1,4 +1,4 @@
-class Mutations::Offer::BuyerAcceptOffer < Mutations::Offer::BaseAcceptOffer
+class Mutations::Offers::BuyerAcceptOffer < Mutations::Offers::BaseAcceptOffer
   alias authorize! authorize_buyer_request!
   def waiting_for_accept?(offer)
     offer.from_participant != Order::BUYER

--- a/app/graphql/mutations/offers/seller_accept_offer.rb
+++ b/app/graphql/mutations/offers/seller_accept_offer.rb
@@ -1,4 +1,4 @@
-class Mutations::Offer::SellerAcceptOffer < Mutations::Offer::BaseAcceptOffer
+class Mutations::Offers::SellerAcceptOffer < Mutations::Offers::BaseAcceptOffer
   alias authorize! authorize_seller_request!
   def waiting_for_accept?(offer)
     offer.from_participant != Order::SELLER

--- a/app/graphql/mutations/offers/seller_counter_offer.rb
+++ b/app/graphql/mutations/offers/seller_counter_offer.rb
@@ -1,4 +1,4 @@
-class Mutations::Offer::SellerCounterOffer < Mutations::BaseMutation
+class Mutations::Offers::SellerCounterOffer < Mutations::BaseMutation
   null true
 
   argument :offer_id, ID, required: true

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,14 +5,14 @@ class Types::MutationType < Types::BaseObject
   field :set_shipping, mutation: Mutations::SetShipping
   field :set_payment, mutation: Mutations::SetPayment
   field :submit_order, mutation: Mutations::SubmitOrder
-  field :buyer_accept_offer, mutation: Mutations::Offer::BuyerAcceptOffer
-  field :add_initial_offer_to_order, mutation: Mutations::AddInitialOfferToOrder
+  field :buyer_accept_offer, mutation: Mutations::Offers::BuyerAcceptOffer
+  field :add_initial_offer_to_order, mutation: Mutations::Offers::AddInitialOfferToOrder
   field :submit_order_with_offer, mutation: Mutations::SubmitOrderWithOffer
 
   # Seller
   field :approve_order, mutation: Mutations::ApproveOrder
-  field :seller_accept_offer, mutation: Mutations::Offer::SellerAcceptOffer
-  field :seller_counter_offer, mutation: Mutations::Offer::SellerCounterOffer
+  field :seller_accept_offer, mutation: Mutations::Offers::SellerAcceptOffer
+  field :seller_counter_offer, mutation: Mutations::Offers::SellerCounterOffer
   field :seller_reject_offer, mutation: Mutations::SellerRejectOffer
   field :reject_order, mutation: Mutations::RejectOrder
   field :fulfill_at_once, mutation: Mutations::FulfillAtOnce


### PR DESCRIPTION
# Problem
Because we have `Mutation::Offer` as the module name, accessing `Offer` from within this modules currently fails because its trying to find `Offer` scoped to current module.

# Solution
Rename `Offer` module to `Offers`.