### PR TITLE
Fix seller counter offer mutation bug and raise error on unknown offer participant type

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -41,6 +41,7 @@ module Errors
       uncommittable_action
       unknown_artwork
       unknown_edition_set
+      unknown_participant_type
       unknown_partner
       unpublished_artwork
       unsupported_shipping_location

--- a/app/graphql/mutations/offers/seller_counter_offer.rb
+++ b/app/graphql/mutations/offers/seller_counter_offer.rb
@@ -12,7 +12,7 @@ class Mutations::Offers::SellerCounterOffer < Mutations::BaseMutation
     from_id = order.seller_id
     creator_id = context[:current_user][:id]
     authorize_seller_request!(order)
-    add_service = Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: amount_cents, from_type: Order::PARTNER, from_id: from_id, creator_id: creator_id)
+    add_service = Offers::AddPendingCounterOfferService.new(offer: offer, amount_cents: amount_cents, from_type: order.seller_type, from_id: from_id, creator_id: creator_id)
     pending_offer = add_service.process!
 
     submit_service = Offers::SubmitCounterOfferService.new(pending_offer: pending_offer, from_id: from_id)

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -20,6 +20,8 @@ class Offer < ApplicationRecord
       Order::SELLER
     elsif from_id == order.buyer_id && from_type == order.buyer_type
       Order::BUYER
+    else
+      raise Errors::ValidationError, :unknown_participant_type
     end
   end
 end

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -144,6 +144,7 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.last_offer.should_remit_sales_tax).to eq(false)
           expect(order.reload.last_offer.amount_cents).to eq(10000)
           expect(order.reload.last_offer.submitted_at).not_to eq(nil)
+          expect(order.reload.last_offer.from_type).to eq 'gallery'
           # for partner counte offer creator_id and from_id are different
           expect(order.reload.last_offer.creator_id).to eq(user_id)
           expect(order.reload.last_offer.from_id).to eq(partner_id)

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Offer, type: :model do
       expect(seller_offer.from_participant).to eq Order::SELLER
     end
     it 'raises error for offer that is not from a buyer or seller' do
-      expect{ ufo_offer.from_participant }.to raise_error do |error|
+      expect { ufo_offer.from_participant }.to raise_error do |error|
         expect(error.type).to eq :validation
         expect(error.code).to eq :unknown_participant_type
       end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -45,8 +45,11 @@ RSpec.describe Offer, type: :model do
     it 'returns seller for seller_offer' do
       expect(seller_offer.from_participant).to eq Order::SELLER
     end
-    it 'returns nil for ufo_offer' do
-      expect(ufo_offer.from_participant).to be_nil
+    it 'raises error for offer that is not from a buyer or seller' do
+      expect{ ufo_offer.from_participant }.to raise_error do |error|
+        expect(error.type).to eq :validation
+        expect(error.code).to eq :unknown_participant_type
+      end
     end
   end
 end


### PR DESCRIPTION
This PR addresses two issues:

1. In the seller counter offer mutation, `Order::PARTNER` is currently passed in as the `from_type` for every new pending offer created by `AddPendingCounterOfferService`. We should be using `order.seller_type` instead since the `seller_type` might not be "partner."
2. `Offer.from_participant` can currently return `nil` if, say, the offer `from_type` does not match the buyer or seller type. Since our UI depends on having this value not be null in some places (e.g., we use `Order.awaiting_response_from` in Reaction, which is defined by `Offer.from_participant`), this should  raise an error if we can't figure out the `from_type`.