### PR TITLE
Expose the artwork version id

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -268,6 +268,7 @@ type FulfillmentEdge {
 # A Line Item
 type LineItem {
   artworkId: String!
+  artworkVersionId: String!
   commissionFeeCents: Int
   createdAt: DateTime!
   editionSetId: String

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -6,6 +6,7 @@ class Types::LineItemType < Types::BaseObject
   field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPriceCents'
   field :list_price_cents, Integer, null: false
   field :artwork_id, String, null: false
+  field :artwork_version_id, String, null: false
   field :edition_set_id, String, null: true
   field :quantity, Integer, null: false
   field :commission_fee_cents, Integer, null: true, seller_only: true


### PR DESCRIPTION
Once this is exposed, then I can update MP's schema and use it over there in the artwork version resolver.