### PR TITLE
Add responds_to hash to OrderEvent

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -56,6 +56,13 @@ class OrderEvent < Events::BaseEvent
     return unless @object.last_offer
 
     last_offer = @object.last_offer
+    responds_to = nil
+    if last_offer.responds_to
+      responds_to = { id: last_offer.responds_to.id,
+                      amount_cents: last_offer.responds_to.amount_cents,
+                      created_at: last_offer.responds_to.created_at,
+                      from_participant: last_offer.responds_to.from_participant }
+    end
     {
       id: last_offer.id,
       amount_cents: last_offer.amount_cents,
@@ -63,7 +70,7 @@ class OrderEvent < Events::BaseEvent
       tax_total_cents: last_offer.tax_total_cents,
       from_participant: last_offer.from_participant,
       creator_id: last_offer.creator_id,
-      responds_to: last_offer.responds_to_id
+      responds_to: responds_to
     }
   end
 

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -56,13 +56,14 @@ class OrderEvent < Events::BaseEvent
     return unless @object.last_offer
 
     last_offer = @object.last_offer
-    responds_to = nil
-    if last_offer.responds_to
-      responds_to = { id: last_offer.responds_to.id,
-                      amount_cents: last_offer.responds_to.amount_cents,
-                      created_at: last_offer.responds_to.created_at,
-                      from_participant: last_offer.responds_to.from_participant }
-    end
+    in_response_to = if last_offer.responds_to
+                       {
+                         id: last_offer.responds_to.id,
+                         amount_cents: last_offer.responds_to.amount_cents,
+                         created_at: last_offer.responds_to.created_at,
+                         from_participant: last_offer.responds_to.from_participant
+                       }
+                     end
     {
       id: last_offer.id,
       amount_cents: last_offer.amount_cents,
@@ -70,7 +71,7 @@ class OrderEvent < Events::BaseEvent
       tax_total_cents: last_offer.tax_total_cents,
       from_participant: last_offer.from_participant,
       creator_id: last_offer.creator_id,
-      responds_to: responds_to
+      in_response_to: in_response_to
     }
   end
 

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -134,10 +134,10 @@ describe OrderEvent, type: :events do
         order.update!(last_offer: offer)
       end
       it 'includes last_offer' do
-        expect(event.properties[:last_offer][:responds_to][:id]).to eq previous_offer.id
-        expect(event.properties[:last_offer][:responds_to][:amount_cents]).to eq previous_offer[:amount_cents]
-        expect(event.properties[:last_offer][:responds_to][:created_at]).to eq previous_offer[:created_at]
-        expect(event.properties[:last_offer][:responds_to][:from_participant]).to eq previous_offer.from_participant
+        expect(event.properties[:last_offer][:in_response_to][:id]).to eq previous_offer.id
+        expect(event.properties[:last_offer][:in_response_to][:amount_cents]).to eq previous_offer[:amount_cents]
+        expect(event.properties[:last_offer][:in_response_to][:created_at]).to eq previous_offer[:created_at]
+        expect(event.properties[:last_offer][:in_response_to][:from_participant]).to eq previous_offer.from_participant
       end
     end
   end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -124,7 +124,20 @@ describe OrderEvent, type: :events do
         expect(event.properties[:last_offer][:tax_total_cents]).to eq 40_00
         expect(event.properties[:last_offer][:from_participant]).to eq 'seller'
         expect(event.properties[:last_offer][:creator_id]).to eq 'partner-admin'
-        expect(event.properties[:last_offer][:responds_to_id]).to be_nil
+        expect(event.properties[:last_offer][:responds_to]).to be_nil
+      end
+    end
+    context 'with last_offer that responds to another offer' do
+      let(:previous_offer) { Fabricate(:offer, order: order, amount_cents: 100_00, shipping_total_cents: 50_00, tax_total_cents: 20_00, from_id: user_id, from_type: 'user', creator_id: user_id) }
+      let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin', responds_to: previous_offer) }
+      before do
+        order.update!(last_offer: offer)
+      end
+      it 'includes last_offer' do
+        expect(event.properties[:last_offer][:responds_to][:id]).to eq previous_offer.id
+        expect(event.properties[:last_offer][:responds_to][:amount_cents]).to eq previous_offer[:amount_cents]
+        expect(event.properties[:last_offer][:responds_to][:created_at]).to eq previous_offer[:created_at]
+        expect(event.properties[:last_offer][:responds_to][:from_participant]).to eq previous_offer.from_participant
       end
     end
   end


### PR DESCRIPTION
To be used in Buyer Counteroffer email sent to seller:

<img width="595" alt="screen shot 2018-12-11 at 4 40 06 pm" src="https://user-images.githubusercontent.com/687513/49877312-238b1d80-fdf3-11e8-8daa-c94d6ba05239.png">
