### PR TITLE
Trim leading and trailing whitespace when parsing region

### DIFF
--- a/lib/address.rb
+++ b/lib/address.rb
@@ -48,6 +48,7 @@ class Address
   end
 
   def parse_region(country, region)
+    region = region&.strip
     return region unless country&.code == UNITED_STATES.code || country&.code == Carmen::Country.coded('CA').code
 
     parsed_region = country.subregions.named(region) || country.subregions.coded(region)

--- a/spec/lib/address_spec.rb
+++ b/spec/lib/address_spec.rb
@@ -40,6 +40,11 @@ describe Address do
     end
   end
   describe '#parse_region' do
+    let(:united_states) { Carmen::Country.coded('US') }
+    it 'strips trailing and leading whitespace from the region' do
+      region = ' New York   '
+      expect(address.send(:parse_region, united_states, region)).to eq 'NY'
+    end
     context 'with a country that is not US or CA' do
       it 'returns the region unmodified' do
         australia = Carmen::Country.coded('AU')
@@ -47,7 +52,6 @@ describe Address do
       end
     end
     context 'with a country that is US or CA' do
-      let(:united_states) { Carmen::Country.coded('US') }
       it 'returns the region code if the country is US or CA' do
         canada = Carmen::Country.coded('CA')
         expect(address.send(:parse_region, united_states, 'Florida')).to eq 'FL'


### PR DESCRIPTION
### Problem
State names must exactly match their corresponding name in Carmen in order to successfully be parsed into their abbreviation. A seller had a trailing space in their state name, which initially prevented an order from going through because we couldn't parse the state.

Addresses [PURCHASE-714](https://artsyproduct.atlassian.net/browse/PURCHASE-714).

### Solution
Trim leading and trailing whitespace when parsing the region in `Address`.