### PR TITLE
Add an admin cancel state reason

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -42,6 +42,7 @@ class Order < ApplicationRecord
       seller_rejected_artwork_unavailable: 'seller_rejected_artwork_unavailable'.freeze,
       seller_rejected_other: 'seller_rejected_other'.freeze,
       seller_rejected: 'seller_rejected'.freeze,
+      admin_canceled: 'admin_canceled'.freeze,
       buyer_rejected: 'buyer_rejected'.freeze
     }
   }.freeze


### PR DESCRIPTION
I just noticed that we have a state reason called `seller_rejected_other` that can be used in one of two ways:

1. the seller rejects an offer in CMS, but picks “other” as the reason
2. the seller contacts Artsy and an admin canceled the order on their behalf

I believe we should create a new state reason just for this second case so that it's clear when it's being used.

In terms of production data, we have none of the former because MO hasn’t launched, but we have 2 of latter. Once this is merged and deployed, we'd want to do a migration of those 2 over to this new `state_reason` value.