### PR TITLE
Update `state_expires_at` when counteroffer is submitted

### DIFF
--- a/app/services/offers/submit_counter_offer_service.rb
+++ b/app/services/offers/submit_counter_offer_service.rb
@@ -12,6 +12,7 @@ module Offers
       @order.with_lock do
         SubmitOfferService.new(@offer).process!
       end
+      @order.update!(state_expires_at: @order.state_expires_at + 2.days)
       post_process!
     end
 

--- a/app/services/offers/submit_counter_offer_service.rb
+++ b/app/services/offers/submit_counter_offer_service.rb
@@ -12,7 +12,7 @@ module Offers
       @order.with_lock do
         SubmitOfferService.new(@offer).process!
       end
-      @order.update!(state_expires_at: @order.state_expires_at + Order::STATE_EXPIRATIONS['submitted'])
+      @order.update!(state_expires_at: Time.now.utc + Order::STATE_EXPIRATIONS['submitted'])
       post_process!
     end
 

--- a/app/services/offers/submit_counter_offer_service.rb
+++ b/app/services/offers/submit_counter_offer_service.rb
@@ -12,7 +12,7 @@ module Offers
       @order.with_lock do
         SubmitOfferService.new(@offer).process!
       end
-      @order.update!(state_expires_at: @order.state_expires_at + 2.days)
+      @order.update!(state_expires_at: @order.state_expires_at + Order::STATE_EXPIRATIONS['submitted'])
       post_process!
     end
 

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -155,7 +155,6 @@ describe Api::GraphqlController, type: :request do
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
       end
       it 'counters the order' do
-        state_expiration_before = order.state_expires_at
         expect do
           response = client.execute(mutation, seller_counter_offer_input)
           expect(response.data.seller_counter_offer.order_or_error).not_to respond_to(:error)
@@ -171,7 +170,7 @@ describe Api::GraphqlController, type: :request do
           expect(last_offer.from_id).to eq(order_seller_id)
           # should update order amounts when offer is submitted
           expect(order.items_total_cents).to eq(400000)
-          expect(order.reload.state_expires_at.to_i).to eq((state_expiration_before + Order::STATE_EXPIRATIONS['submitted']).to_i)
+          expect(order.reload.state_expires_at.to_i).to eq((Time.now.utc + Order::STATE_EXPIRATIONS['submitted']).to_i)
         end.to change { order.reload.offers.count }.from(1).to(2)
       end
     end

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -171,7 +171,7 @@ describe Api::GraphqlController, type: :request do
           expect(last_offer.from_id).to eq(order_seller_id)
           # should update order amounts when offer is submitted
           expect(order.items_total_cents).to eq(400000)
-          expect(order.reload.state_expires_at.to_i).to eq((state_expiration_before + 2.days).to_i)
+          expect(order.reload.state_expires_at.to_i).to eq((state_expiration_before + Order::STATE_EXPIRATIONS['submitted']).to_i)
         end.to change { order.reload.offers.count }.from(1).to(2)
       end
     end

--- a/spec/services/offers/submit_counter_offer_service_spec.rb
+++ b/spec/services/offers/submit_counter_offer_service_spec.rb
@@ -21,12 +21,14 @@ describe Offers::SubmitCounterOfferService, type: :services do
 
     context 'with a submitted offer' do
       it 'submits the pending offer and updates last offer' do
+        state_expiration_before = order.state_expires_at
         service.process!
         expect(order.offers.count).to eq(2)
         expect(order.last_offer).to eq(pending_offer)
         expect(order.last_offer.amount_cents).to eq(20000)
         expect(order.last_offer.responds_to).to eq(offer)
         expect(pending_offer.submitted_at).not_to be_nil
+        expect(order.reload.state_expires_at.to_i).to eq((state_expiration_before + Order::STATE_EXPIRATIONS['submitted']).to_i)
       end
 
       it 'instruments a counter offer' do

--- a/spec/services/offers/submit_counter_offer_service_spec.rb
+++ b/spec/services/offers/submit_counter_offer_service_spec.rb
@@ -21,14 +21,13 @@ describe Offers::SubmitCounterOfferService, type: :services do
 
     context 'with a submitted offer' do
       it 'submits the pending offer and updates last offer' do
-        state_expiration_before = order.state_expires_at
         service.process!
         expect(order.offers.count).to eq(2)
         expect(order.last_offer).to eq(pending_offer)
         expect(order.last_offer.amount_cents).to eq(20000)
         expect(order.last_offer.responds_to).to eq(offer)
         expect(pending_offer.submitted_at).not_to be_nil
-        expect(order.reload.state_expires_at.to_i).to eq((state_expiration_before + Order::STATE_EXPIRATIONS['submitted']).to_i)
+        expect(order.reload.state_expires_at.to_i).to eq((Time.now.utc + Order::STATE_EXPIRATIONS['submitted']).to_i)
       end
 
       it 'instruments a counter offer' do


### PR DESCRIPTION
Notes:

* ~Wanted to add that `2.days` as a constant [here](https://github.com/artsy/exchange/blob/master/app/models/order.rb#L49-L53) but this is not really a 'state' expiration. If this sounds ok or have better suggestions let me know.~ Ended up reusing `Order::STATE_EXPIRATIONS['submitted']` since it would be easy to split it into two different state expiration values later if business logic changes.