### PR TITLE
[WIP] Buyer lapse #dontmerge

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -157,6 +157,9 @@ type BuyerRejectOfferPayload {
 }
 
 enum CancelReasonTypeEnum {
+  # cancelation reason is: buyer_lapsed
+  BUYER_LAPSED
+
   # cancelation reason is: buyer_rejected
   BUYER_REJECTED
 

--- a/app/jobs/order_follow_up_job.rb
+++ b/app/jobs/order_follow_up_job.rb
@@ -9,11 +9,19 @@ class OrderFollowUpJob < ApplicationJob
     when Order::PENDING
       OrderService.abandon!(order)
     when Order::SUBMITTED
-      OrderCancellationService.new(order).seller_lapse!
+      cancel_submitted_order(order)
     when Order::APPROVED
       # Order was approved but has not yet fulfilled,
       # post an event so we can contact partner
       OrderEvent.post(order, 'unfulfilled', nil)
+    end
+  end
+
+  def cancel_submitted_order(order)
+    if order.mode == Order::OFFER && order.last_offer.from_type == Order::USER
+      OrderCancellationService.new(order).buyer_lapse!
+    else
+      OrderCancellationService.new(order).seller_lapse!
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -42,7 +42,8 @@ class Order < ApplicationRecord
       seller_rejected_artwork_unavailable: 'seller_rejected_artwork_unavailable'.freeze,
       seller_rejected_other: 'seller_rejected_other'.freeze,
       seller_rejected: 'seller_rejected'.freeze,
-      buyer_rejected: 'buyer_rejected'.freeze
+      buyer_rejected: 'buyer_rejected'.freeze,
+      buyer_lapsed: 'buyer_lapsed'.freeze
     }
   }.freeze
 
@@ -57,9 +58,10 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  ACTIONS = %i[abandon submit approve reject fulfill seller_lapse refund].freeze
+  ACTIONS = %i[abandon submit approve reject fulfill seller_lapse buyer_lapse refund].freeze
   ACTION_REASONS = {
     seller_lapse: REASONS[CANCELED][:seller_lapsed],
+    buyer_lapse: REASONS[CANCELED][:buyer_lapsed],
     reject: REASONS[CANCELED][:seller_rejected_other]
   }.freeze
 
@@ -219,6 +221,7 @@ class Order < ApplicationRecord
     machine.when(:approve, SUBMITTED => APPROVED)
     machine.when(:reject, SUBMITTED => CANCELED)
     machine.when(:seller_lapse, SUBMITTED => CANCELED)
+    machine.when(:buyer_lapse, SUBMITTED => CANCELED)
     machine.when(:cancel, SUBMITTED => CANCELED)
     machine.when(:fulfill, APPROVED => FULFILLED)
     machine.when(:refund, APPROVED => REFUNDED, FULFILLED => REFUNDED)

--- a/app/services/offers/submit_counter_offer_service.rb
+++ b/app/services/offers/submit_counter_offer_service.rb
@@ -12,6 +12,7 @@ module Offers
       @order.with_lock do
         SubmitOfferService.new(@offer).process!
       end
+      OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
       post_process!
     end
 

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -14,6 +14,13 @@ class OrderCancellationService
     @order.transactions << @transaction if @transaction.present?
   end
 
+  def buyer_lapse!
+    @order.buyer_lapse!
+    PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED)
+  ensure
+    @order.transactions << @transaction if @transaction.present?
+  end
+
   def reject!(rejection_reason = nil)
     @order.reject!(rejection_reason) do
       process_refund if @order.mode == Order::BUY


### PR DESCRIPTION
**#DontMerge** depends on https://github.com/artsy/exchange/pull/332

Addresses [SELL-1244](https://artsyproduct.atlassian.net/browse/SELL-1244)

First commit adds `buyer_lapse` action to `Order` and `OrderFollowUpService`

Second commit schedules the job after commit