### PR TITLE
Do not raise error if artwork versions mismatch on accepting offer

### DIFF
--- a/app/services/commit_order_service.rb
+++ b/app/services/commit_order_service.rb
@@ -61,7 +61,6 @@ class CommitOrderService
     raise Errors::ValidationError, :uncommittable_action unless COMMITTABLE_ACTIONS.include? @action
     raise Errors::ValidationError, :missing_required_info unless @order.can_commit?
 
-    OrderValidator.validate_artwork_versions!(order)
     OrderValidator.validate_credit_card!(@order_data.credit_card)
     OrderValidator.validate_commission_rate!(@order_data.partner)
 

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -9,6 +9,11 @@ class OrderSubmitService < CommitOrderService
 
   private
 
+  def pre_process!
+    OrderValidator.validate_artwork_versions!(order)
+    super
+  end
+
   def process_payment
     @transaction = PaymentService.create_and_authorize_charge(construct_charge_params)
     raise Errors::ProcessingError.new(:charge_authorization_failed, @transaction) if @transaction.failed?

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -148,7 +148,6 @@ describe Api::GraphqlController, type: :request do
         inventory_request = stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json)
         expect(Gravity).to receive(:get_merchant_account).and_return(merchant_account)
         expect(Gravity).to receive(:get_credit_card).and_return(credit_card)
-        expect(Gravity).to receive(:get_artwork).and_return(artwork)
         expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
         response = client.execute(mutation, buyer_accept_offer_input)
         expect(inventory_request).to have_been_requested

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -148,7 +148,6 @@ describe Api::GraphqlController, type: :request do
         inventory_request = stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json)
         expect(Gravity).to receive(:get_merchant_account).and_return(merchant_account)
         expect(Gravity).to receive(:get_credit_card).and_return(credit_card)
-        expect(Gravity).to receive(:get_artwork).and_return(artwork)
         expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
         response = client.execute(mutation, seller_accept_offer_input)
 


### PR DESCRIPTION
Addresses [PURCHASE-757](https://artsyproduct.atlassian.net/browse/PURCHASE-757).

Allows artwork mismatches when accepting an offer.