### PR TITLE
Add OfferEvent and post when offer is submitted

### DIFF
--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -1,0 +1,72 @@
+class OfferEvent < Events::BaseEvent
+  TOPIC = 'commerce'.freeze
+  ACTIONS = [
+    CREATED = 'created'.freeze,
+    SUBMITTED = 'submitted'.freeze
+  ].freeze
+
+  def self.post(offer, action, user_id)
+    event = new(user: user_id, action: action, model: offer)
+    Artsy::EventService.post_event(topic: TOPIC, event: event)
+  end
+
+  def subject
+    {
+      id: @subject
+    }
+  end
+
+  def properties
+    {
+      amount_cents: @object.amount_cents,
+      submitted_at: @object.submitted_at,
+      from_participant: @object.from_participant,
+      order: order
+    }
+  end
+
+  private
+
+  def order
+    order = @object.order
+    OrderEvent::PROPERTIES_ATTRS.map { |att| [att, order.send(att)] }.to_h.merge(line_items: line_items_details, last_offer: last_offer)
+  end
+
+  def line_items_details
+    @object.order.line_items.map { |li| line_item_detail(li) }
+  end
+
+  def last_offer
+    return unless @object.order.last_offer
+
+    last_offer = @object.order.last_offer
+    in_response_to = if last_offer.responds_to
+                       {
+                         id: last_offer.responds_to.id,
+                         amount_cents: last_offer.responds_to.amount_cents,
+                         created_at: last_offer.responds_to.created_at,
+                         from_participant: last_offer.responds_to.from_participant
+                       }
+                     end
+    {
+      id: last_offer.id,
+      amount_cents: last_offer.amount_cents,
+      shipping_total_cents: last_offer.shipping_total_cents,
+      tax_total_cents: last_offer.tax_total_cents,
+      from_participant: last_offer.from_participant,
+      creator_id: last_offer.creator_id,
+      in_response_to: in_response_to
+    }
+  end
+
+  def line_item_detail(line_item)
+    {
+      price_cents: line_item.list_price_cents,
+      list_price_cents: line_item.list_price_cents,
+      artwork_id: line_item.artwork_id,
+      edition_set_id: line_item.edition_set_id,
+      quantity: line_item.quantity,
+      commission_fee_cents: line_item.commission_fee_cents
+    }
+  end
+end

--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -21,6 +21,13 @@ class OfferEvent < Events::BaseEvent
       amount_cents: @object.amount_cents,
       submitted_at: @object.submitted_at,
       from_participant: @object.from_participant,
+      last_offer: @object.last_offer?,
+      from_id: @object.from_id,
+      from_type: @object.from_type,
+      creator_id: @object.creator_id,
+      responds_to: @object.responds_to_id,
+      shipping_total_cents: @object.shipping_total_cents,
+      tax_total_cents: @object.tax_total_cents,
       order: order
     }
   end
@@ -29,7 +36,7 @@ class OfferEvent < Events::BaseEvent
 
   def order
     order = @object.order
-    OrderEvent::PROPERTIES_ATTRS.map { |att| [att, order.send(att)] }.to_h.merge(line_items: line_items_details, last_offer: last_offer)
+    OrderEvent::PROPERTIES_ATTRS.map { |att| [att, order.send(att)] }.to_h.merge(line_items: line_items_details)
   end
 
   def line_items_details

--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -43,29 +43,6 @@ class OfferEvent < Events::BaseEvent
     @object.order.line_items.map { |li| line_item_detail(li) }
   end
 
-  def last_offer
-    return unless @object.order.last_offer
-
-    last_offer = @object.order.last_offer
-    in_response_to = if last_offer.responds_to
-                       {
-                         id: last_offer.responds_to.id,
-                         amount_cents: last_offer.responds_to.amount_cents,
-                         created_at: last_offer.responds_to.created_at,
-                         from_participant: last_offer.responds_to.from_participant
-                       }
-                     end
-    {
-      id: last_offer.id,
-      amount_cents: last_offer.amount_cents,
-      shipping_total_cents: last_offer.shipping_total_cents,
-      tax_total_cents: last_offer.tax_total_cents,
-      from_participant: last_offer.from_participant,
-      creator_id: last_offer.creator_id,
-      in_response_to: in_response_to
-    }
-  end
-
   def line_item_detail(line_item)
     {
       price_cents: line_item.list_price_cents,

--- a/app/jobs/post_offer_notification_job.rb
+++ b/app/jobs/post_offer_notification_job.rb
@@ -1,0 +1,8 @@
+class PostOfferNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(offer_id, action, user_id = nil)
+    offer = Offer.find(offer_id)
+    OfferEvent.post(offer, action, user_id)
+  end
+end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -40,11 +40,20 @@ module OfferService
         state_expires_at: Offer::EXPIRATION.from_now # expand order expiration
       )
     end
-    OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
-    # We are posting order.submitted event 👇, for now since Pulse (email service) is expecting that in case of submitting pending offer
-    # We need to send OfferEvent eventually in this case to be more accurate
-    PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, offer.creator_id)
-    Exchange.dogstatsd.increment 'offer.submit'
+    post_submit_offer(offer)
     offer
+  end
+
+  class << self
+    private
+
+    def post_submit_offer(offer)
+      OrderFollowUpJob.set(wait_until: offer.order.state_expires_at).perform_later(offer.order.id, offer.order.state)
+      PostOfferNotificationJob.perform_later(offer.id, OfferEvent::SUBMITTED, offer.creator_id)
+      # We are posting order.submitted event 👇, for now since Pulse (email service) is expecting that in case of submitting pending offer
+      # We need to send OfferEvent eventually in this case to be more accurate
+      PostOrderNotificationJob.perform_later(offer.order.id, Order::SUBMITTED, offer.creator_id)
+      Exchange.dogstatsd.increment 'offer.submit'
+    end
   end
 end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -51,7 +51,6 @@ module OfferService
       OrderFollowUpJob.set(wait_until: offer.order.state_expires_at).perform_later(offer.order.id, offer.order.state)
       PostOfferNotificationJob.perform_later(offer.id, OfferEvent::SUBMITTED, offer.creator_id)
       # We are posting order.submitted event 👇, for now since Pulse (email service) is expecting that in case of submitting pending offer
-      # We need to send OfferEvent eventually in this case to be more accurate
       PostOrderNotificationJob.perform_later(offer.order.id, Order::SUBMITTED, offer.creator_id)
       Exchange.dogstatsd.increment 'offer.submit'
     end

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -75,6 +75,12 @@ describe OfferEvent, type: :events do
     it 'includes expected offer properties' do
       expect(event.properties[:submitted_at]).not_to be_nil
       expect(event.properties[:from_participant]).to eq Order::BUYER
+      expect(event.properties[:from_id]).to eq offer.from_id
+      expect(event.properties[:from_type]).to eq offer.from_type
+      expect(event.properties[:creator_id]).to eq offer.creator_id
+      expect(event.properties[:responds_to]).to eq offer.responds_to_id
+      expect(event.properties[:shipping_total_cents]).to eq offer.shipping_total_cents
+      expect(event.properties[:tax_total_cents]).to eq offer.tax_total_cents
     end
     describe '#order' do
       context 'without last_offer' do
@@ -108,24 +114,6 @@ describe OfferEvent, type: :events do
           expect(order_prop[:shipping_region]).to eq 'IL'
           expect(order_prop[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
           expect(order_prop[:total_list_price_cents]).to eq(200)
-          expect(order_prop[:last_offer]).to be_nil
-        end
-      end
-      context 'with last_offer' do
-        let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin') }
-        before do
-          order.update!(last_offer: offer)
-        end
-        it 'includes last_offer' do
-          properties = event.properties
-          order_prop = properties[:order]
-          expect(order_prop[:last_offer][:id]).to eq offer.id
-          expect(order_prop[:last_offer][:amount_cents]).to eq 200_00
-          expect(order_prop[:last_offer][:shipping_total_cents]).to eq 100_00
-          expect(order_prop[:last_offer][:tax_total_cents]).to eq 40_00
-          expect(order_prop[:last_offer][:from_participant]).to eq 'seller'
-          expect(order_prop[:last_offer][:creator_id]).to eq 'partner-admin'
-          expect(order_prop[:last_offer][:responds_to]).to be_nil
         end
       end
     end

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+describe OfferEvent, type: :events do
+  before { Timecop.freeze(Time.parse('2018-08-16 15:48:00 -0400')) }
+  after { Timecop.return }
+
+  let(:seller_id) { 'partner-1' }
+  let(:user_id) { 'user-1' }
+  let(:shipping_info) do
+    {
+      fulfillment_type: Order::SHIP,
+      shipping_name: 'Fname Lname',
+      shipping_address_line1: '123 Main St',
+      shipping_address_line2: 'Apt 2',
+      shipping_city: 'Chicago',
+      shipping_country: 'USA',
+      shipping_postal_code: '60618',
+      shipping_region: 'IL'
+    }
+  end
+  let(:order) do
+    Fabricate(
+      :order,
+      buyer_id: user_id,
+      buyer_type: Order::USER,
+      buyer_phone_number: '00123459876',
+      seller_id: 'partner-1',
+      seller_type: 'gallery',
+      currency_code: 'usd',
+      shipping_total_cents: 50,
+      tax_total_cents: 30,
+      items_total_cents: 300,
+      buyer_total_cents: 380,
+      state: 'submitted',
+      **shipping_info
+    )
+  end
+  let!(:line_item1) { Fabricate(:line_item, list_price_cents: 200, order: order, commission_fee_cents: 40) }
+  let(:offer) { Fabricate(:offer, order: order, from_id: order.buyer_id, from_type: Order::USER, submitted_at: Time.now.utc, amount_cents: 120) }
+
+  let(:expected_line_item_properties) do
+    [
+      {
+        price_cents: 200,
+        list_price_cents: 200,
+        artwork_id: line_item1.artwork_id,
+        edition_set_id: line_item1.edition_set_id,
+        quantity: 1,
+        commission_fee_cents: 40
+      }
+    ]
+  end
+  let(:event) { OfferEvent.new(user: user_id, action: OfferEvent::SUBMITTED, model: offer) }
+
+  describe 'post' do
+    it 'calls ArtsyEventService to post event' do
+      expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(OfferEvent))
+      OfferEvent.post(offer, OfferEvent::SUBMITTED, user_id)
+    end
+  end
+
+  describe '#subject' do
+    it 'returns user id' do
+      expect(event.subject[:id]).to eq user_id
+    end
+  end
+
+  describe '#object' do
+    it 'returns order id' do
+      expect(event.object[:id]).to eq offer.id.to_s
+    end
+  end
+
+  describe '#properties' do
+    it 'includes expected offer properties' do
+      expect(event.properties[:submitted_at]).not_to be_nil
+      expect(event.properties[:from_participant]).to eq Order::BUYER
+    end
+    describe '#order' do
+      context 'without last_offer' do
+        it 'returns correct properties for a submitted order' do
+          properties = event.properties
+          order_prop = properties[:order]
+          expect(order_prop[:mode]).to eq Order::BUY
+          expect(order_prop[:code]).to eq order.code
+          expect(order_prop[:currency_code]).to eq 'USD'
+          expect(order_prop[:state]).to eq 'submitted'
+          expect(order_prop[:buyer_id]).to eq user_id
+          expect(order_prop[:buyer_type]).to eq Order::USER
+          expect(order_prop[:fulfillment_type]).to eq Order::SHIP
+          expect(order_prop[:seller_id]).to eq seller_id
+          expect(order_prop[:seller_type]).to eq 'gallery'
+          expect(order_prop[:items_total_cents]).to eq 300
+          expect(order_prop[:shipping_total_cents]).to eq 50
+          expect(order_prop[:tax_total_cents]).to eq 30
+          expect(order_prop[:buyer_total_cents]).to eq 380
+          expect(order_prop[:updated_at]).not_to be_nil
+          expect(order_prop[:created_at]).not_to be_nil
+          expect(order_prop[:line_items].count).to eq 1
+          expect(order_prop[:line_items]).to match_array(expected_line_item_properties)
+          expect(order_prop[:shipping_name]).to eq 'Fname Lname'
+          expect(order_prop[:shipping_address_line1]).to eq '123 Main St'
+          expect(order_prop[:shipping_address_line2]).to eq 'Apt 2'
+          expect(order_prop[:shipping_city]).to eq 'Chicago'
+          expect(order_prop[:shipping_country]).to eq 'USA'
+          expect(order_prop[:shipping_postal_code]).to eq '60618'
+          expect(order_prop[:buyer_phone_number]).to eq '00123459876'
+          expect(order_prop[:shipping_region]).to eq 'IL'
+          expect(order_prop[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
+          expect(order_prop[:total_list_price_cents]).to eq(200)
+          expect(order_prop[:last_offer]).to be_nil
+        end
+      end
+      context 'with last_offer' do
+        let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin') }
+        before do
+          order.update!(last_offer: offer)
+        end
+        it 'includes last_offer' do
+          properties = event.properties
+          order_prop = properties[:order]
+          expect(order_prop[:last_offer][:id]).to eq offer.id
+          expect(order_prop[:last_offer][:amount_cents]).to eq 200_00
+          expect(order_prop[:last_offer][:shipping_total_cents]).to eq 100_00
+          expect(order_prop[:last_offer][:tax_total_cents]).to eq 40_00
+          expect(order_prop[:last_offer][:from_participant]).to eq 'seller'
+          expect(order_prop[:last_offer][:creator_id]).to eq 'partner-admin'
+          expect(order_prop[:last_offer][:responds_to]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Problem
When an offer is submitted currently we are posting an `Order::SUBMITTED` event. There are 2 issues with it:
1) Order was not actually submitted :) Order was _submitted_ before and at this stage we are only adding a new offer but submitting a _pending_ Offer. 
2) Currently ☝️ event is used for sending emails when offer is submitted and they rely on order event's `last_offer` to send email for last email. The issue is, we queue jobs for posting these events, and technically speaking its possible that the `last_offer` may not be the offer we wanted to send event for at the time we are processing the job. In this case consumers will receive an event but there is no way for them to find the offer triggered this event originally.

Because of ☝️ reasons, we want to send an offer-based event when an offer is submitted.

# Solution
Add an `OfferEvent` which gets an `Offer` as its main object.
Post ☝️ when an offer is submitted. An `OfferEvent` includes the offer details also order details are accessible in the `properties` section of the event under `properties[:order]`.

# Follow up
For now we are still posting `Order::Submitted` event but eventually once consumers have switched to new event for counter offer, we can stop sending that one.