### PR TITLE
add datadog events on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - run:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1
+      - run:
+          name: Deploy Event
+          command: hokusai/deploy_event.sh exchange staging
 workflows:
   version: 2
   default:

--- a/hokusai/deploy_event.sh
+++ b/hokusai/deploy_event.sh
@@ -6,8 +6,8 @@
 
 curl -X POST -H "Content-type: application/json" \
 -d "{
-      \"title\": \"test API key\",
-      \"text\": \"does this work with curl?\",
+      \"title\": \"$1 was deployed to $2\",
+      \"text\": \"version: $CIRCLE_SHA1\",
       \"priority\": \"normal\",
       \"tags\": [\"service:$1\", \"env:$2\"],
       \"alert_type\": \"info\"

--- a/hokusai/deploy_event.sh
+++ b/hokusai/deploy_event.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# ./deploy_event app env
+# eg:
+# ./deploy_event exchange production
+# Must have DD_API_KEY set to datadog api key.
+
+curl -X POST -H "Content-type: application/json" \
+-d "{
+      \"title\": \"test API key\",
+      \"text\": \"does this work with curl?\",
+      \"priority\": \"normal\",
+      \"tags\": [\"service:$1\", \"env:$2\"],
+      \"alert_type\": \"info\"
+}" \
+"https://api.datadoghq.com/api/v1/events?api_key=$DD_API_KEY"

--- a/hokusai/deploy_event.sh
+++ b/hokusai/deploy_event.sh
@@ -4,6 +4,8 @@
 # ./deploy_event exchange production
 # Must have DD_API_KEY set to datadog api key.
 
+[ -z "$DD_API_KEY" ] && echo "Need to set DD_API_KEY" && exit 1;
+
 curl -X POST -H "Content-type: application/json" \
 -d "{
       \"title\": \"$1 was deployed to $2\",


### PR DESCRIPTION
Relies on DD_API_KEY being set in circle which I've already set up.

I know @izakp mentioned doing this in hokusai deploy hooks but to do that we'd need some mechanism where we could know in the hook if we're deploying to staging or prod. That would probably be nice so I'm still open to that path but this is simple and should be a good way to get started.

Events look like this and can be overlaid on metric graphs.
![](https://dl.dropbox.com/s/6m876k6yy6nb9zs/Screenshot%202018-12-18%2016.18.56.png)