### PR TITLE
Check inventory before offer submit

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -55,12 +55,12 @@ module Errors
       capture_failed
       charge_authorization_failed
       insufficient_inventory
+      received_partial_refund
       refund_failed
-      tax_recording_failure
       tax_calculator_failure
+      tax_recording_failure
       tax_refund_failure
       unknown_event_charge
-      received_partial_refund
     ],
     internal: %i[
       generic

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -19,9 +19,12 @@ module OfferService
   end
 
   def self.submit_pending_offer(offer)
-    raise Errors::ValidationError, :invalid_offer if offer.submitted?
-
     order = offer.order
+    order_data = OrderData.new(order)
+
+    raise Errors::ValidationError, :invalid_offer if offer.submitted?
+    raise Errors::ProcessingError, :insufficient_inventory unless order_data.inventory?
+
     offer_calculator = OfferCalculator.new(order, offer.amount_cents)
     order.with_lock do
       offer.update!(submitted_at: Time.now.utc)

--- a/lib/order_data.rb
+++ b/lib/order_data.rb
@@ -34,4 +34,12 @@ class OrderData
   def commission_rate
     @commission_rate ||= partner[:effective_commission_rate]
   end
+
+  def inventory?
+    @order.line_items.all? do |li|
+      artwork = artworks[li.artwork_id]
+      inventory = li.edition_set_id.present? ? artwork[:edition_sets][li.edition_set_id][:inventory] : artwork[:inventory]
+      inventory[:count].positive? || inventory[:unlimited] == true
+    end
+  end
 end

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -9,7 +9,7 @@ describe Api::GraphqlController, type: :request do
     let(:partner) { { id: order_seller_id, artsy_collects_sales_tax: true, effective_commission_rate: 0.4 } }
     let(:buyer_id) { jwt_user_id }
     let(:artwork_location) { { country: 'US' } }
-    let(:artwork) { { _id: 'a-1', current_version_id: '1', location: artwork_location, domestic_shipping_fee_cents: 1000 } }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1', location: artwork_location, domestic_shipping_fee_cents: 1000) }
     let(:order_state) { Order::SUBMITTED }
     let!(:order) { Fabricate(:order, state: order_state, seller_id: order_seller_id, buyer_id: buyer_id, **shipping_info) }
     let!(:offer) { Fabricate(:offer, order: order, amount_cents: 10000, from_id: buyer_id, from_type: Order::USER, submitted_at: Time.now.utc) }
@@ -153,6 +153,7 @@ describe Api::GraphqlController, type: :request do
     context 'with proper permission' do
       before do
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
+        allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{line_item.artwork_id}").and_return(artwork)
       end
       it 'counters the order' do
         expect do

--- a/spec/controllers/api/requests/offers/submit_pending_offer_request_spec.rb
+++ b/spec/controllers/api/requests/offers/submit_pending_offer_request_spec.rb
@@ -7,7 +7,7 @@ describe Api::GraphqlController, type: :request do
 
     let(:seller_id) { jwt_partner_ids.first }
     let(:buyer_id) { jwt_user_id }
-    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1') }
     let(:line_item_artwork_version) { artwork[:current_version_id] }
     let(:credit_card_id) { 'grav_c_id1' }
     let(:credit_card) { { external_id: 'cc-1', customer_account: { external_id: 'cus-1' }, deactivated_at: nil } }
@@ -106,6 +106,7 @@ describe Api::GraphqlController, type: :request do
         allow(Gravity).to receive(:get_artwork).with(artwork[:_id]).and_return(artwork)
         allow(Gravity).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
+        allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{line_item.artwork_id}").and_return(artwork)
       end
 
       it 'submits the order and updates submitted_at on the offer' do

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -77,6 +77,10 @@ def gravity_v1_artwork(options={})
         editions: 'Edition of 15',
         display_price_currency: 'USD (United States Dollar)',
         availability: 'for sale',
+        inventory: {
+          count: 1,
+          unlimited: false
+        },
       }],
     artists: [{
         _id: 'artist-id',
@@ -116,6 +120,10 @@ def gravity_v1_artwork(options={})
       },
     _id: 'artwork-id',
     id: 'artwork-slug',
+    inventory: {
+      count: 1,
+      unlimited: false
+    },
     current_version_id: 'current-version-id',
     title: 'Untitled Pl. 13 (from Men in the Cities)',
     display: 'BNMOsy, Untitled Pl. 13 (from Men in the Cities) (2005)',


### PR DESCRIPTION
# Problem
We want to raise error when buyer/seller submit counter offers.

Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-767

# Solution
In submission logic, check if we have enough inventory for this order's artwork.

# Raised Error
Processing error with `insufficient_inventory` as error code.