### PR TITLE
Use order/offer snapshot before queuing the event job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,11 +64,11 @@ GEM
       omniauth-artsy (>= 0.2.2)
       omniauth-oauth2
       rails (>= 4.2.0)
-    artsy-eventservice (1.0.8)
+    artsy-eventservice (1.0.9)
       bunny
     ast (2.4.0)
     builder (3.2.3)
-    bunny (2.12.0)
+    bunny (2.13.0)
       amq-protocol (~> 2.3, >= 2.3.0)
     byebug (10.0.2)
     capybara (3.10.0)

--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -10,6 +10,11 @@ class OfferEvent < Events::BaseEvent
     Artsy::EventService.post_event(topic: TOPIC, event: event)
   end
 
+  def self.delay_post(offer, action)
+    event = new(user: offer.creator_id, action: action, model: offer)
+    PostEventJob.perform_later(event.to_json, event.routing_key)
+  end
+
   def subject
     {
       id: @subject

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -37,6 +37,11 @@ class OrderEvent < Events::BaseEvent
     Artsy::EventService.post_event(topic: TOPIC, event: event)
   end
 
+  def self.delay_post(order, action, user_id = nil)
+    event = new(user: user_id, action: action, model: order)
+    PostEventJob.perform_later(event.to_json, event.routing_key)
+  end
+
   def subject
     {
       id: @subject

--- a/app/jobs/post_event_job.rb
+++ b/app/jobs/post_event_job.rb
@@ -1,0 +1,7 @@
+class PostEventJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_json, routing_key)
+    Artsy::EventService.post_data(topic: TOPIC, data: event_json, routing_key: routing_key)
+  end
+end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -57,6 +57,7 @@ module OfferService
       submit_pending_offer(offer)
     end
 
+    OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     Exchange.dogstatsd.increment 'order.submit'
     PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, user_id)
   end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -89,7 +89,7 @@ module OfferService
 
     def post_submit_offer(offer)
       OrderFollowUpJob.set(wait_until: offer.order.state_expires_at).perform_later(offer.order.id, offer.order.state)
-      PostOfferNotificationJob.perform_later(offer.id, OfferEvent::SUBMITTED, offer.creator_id)
+      OfferEvent.delay_post(offer, OfferEvent::SUBMITTED)
       OfferRespondReminderJob.set(wait_until: offer.order.state_expires_at - Order::DEFAULT_EXPIRATION_REMINDER)
                              .perform_later(offer.order.id, offer.id)
       Exchange.dogstatsd.increment 'offer.submit'

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -22,7 +22,7 @@ class OrderApproveService
   def post_process
     record_stats
     @order.line_items.each { |li| RecordSalesTaxJob.perform_later(li.id) }
-    PostOrderNotificationJob.perform_later(@order.id, Order::APPROVED, @user_id)
+    OrderEvent.delay_post(@order, Order::APPROVED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
     ReminderFollowUpJob.set(wait_until: @order.state_expiration_reminder_time).perform_later(@order.id, @order.state)
   end

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -10,14 +10,14 @@ class OrderCancellationService
       process_stripe_refund if @order.mode == Order::BUY
     end
     process_inventory_undeduction
-    PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED)
+    OrderEvent.delay_post(@order, Order::CANCELED)
   ensure
     @order.transactions << @transaction if @transaction.present?
   end
 
   def buyer_lapse!
     @order.buyer_lapse!
-    PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED)
+    OrderEvent.delay_post(@order, Order::CANCELED)
   end
 
   def reject!(rejection_reason = nil)
@@ -26,7 +26,7 @@ class OrderCancellationService
     end
     Exchange.dogstatsd.increment 'order.reject'
     process_inventory_undeduction
-    PostOrderNotificationJob.perform_later(@order.id, Order::CANCELED, @user_id)
+    OrderEvent.delay_post(@order, Order::CANCELED, @user_id)
   ensure
     @order.transactions << @transaction if @transaction.present?
   end
@@ -37,7 +37,7 @@ class OrderCancellationService
     end
     record_stats
     process_inventory_undeduction
-    PostOrderNotificationJob.perform_later(@order.id, Order::REFUNDED, @user_id)
+    OrderEvent.delay_post(@order, Order::REFUNDED, @user_id)
   ensure
     @order.transactions << @transaction if @transaction.present?
   end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -65,7 +65,7 @@ module OrderService
         li.line_item_fulfillments.create!(fulfillment_id: fulfillment.id)
       end
     end
-    PostOrderNotificationJob.perform_later(order.id, Order::FULFILLED, user_id)
+    OrderEvent.delay_post(order, Order::FULFILLED, user_id)
     order
   end
 
@@ -73,7 +73,7 @@ module OrderService
     raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::PICKUP
 
     order.fulfill!
-    PostOrderNotificationJob.perform_later(order.id, Order::FULFILLED, user_id)
+    OrderEvent.delay_post(order, Order::FULFILLED, user_id)
     order
   end
 

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -94,7 +94,7 @@ describe Api::GraphqlController, type: :request do
 
       it 'queues a job for posting events' do
         client.execute(mutation, approve_order_input)
-        expect(PostOrderNotificationJob).to have_been_enqueued
+        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.approved')
       end
 
       it 'queues a job for rejecting the order when the order should expire' do

--- a/spec/controllers/api/requests/confirm_pickup_request_spec.rb
+++ b/spec/controllers/api/requests/confirm_pickup_request_spec.rb
@@ -103,7 +103,7 @@ describe Api::GraphqlController, type: :request do
 
           it 'queues a job for posting events' do
             client.execute(mutation, confirm_pickup_input)
-            expect(PostOrderNotificationJob).to have_been_enqueued
+            expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.fulfilled')
           end
         end
       end

--- a/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
@@ -49,7 +49,7 @@ RSpec.shared_examples 'rejecting an offer' do
 
   context 'with proper permission' do
     it 'rejects the order' do
-      expect(PostOrderNotificationJob).to receive(:perform_later).with(order.id, Order::CANCELED, 'user-id')
+      expect(OrderEvent).to receive(:delay_post).with(order, Order::CANCELED, 'user-id')
       expect do
         client.execute(mutation, input)
       end.to change { order.reload.state }.from(Order::SUBMITTED).to(Order::CANCELED)

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -279,12 +279,12 @@ describe OfferService, type: :services do
 
   describe '#submit_pending_offer' do
     let(:artwork) { gravity_v1_artwork }
-    let(:offer_from_id) { 'user-id' }
+    let(:buyer_id) { 'user-id' }
     let(:order_seller_id) { 'partner-1' }
-    let(:order) { Fabricate(:order, mode: Order::OFFER, state: Order::SUBMITTED, buyer_id: offer_from_id, seller_id: order_seller_id) }
+    let(:order) { Fabricate(:order, mode: Order::OFFER, state: Order::SUBMITTED, seller_id: order_seller_id, seller_type: 'gallery', buyer_id: buyer_id, buyer_type: Order::USER) }
     let(:line_item) { Fabricate(:line_item, order: order, artwork_id: artwork[:_id]) }
-    let(:current_offer) { Fabricate(:offer, order: order, amount_cents: 10000, submitted_at: 1.day.ago) }
-    let(:new_offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 50_00, responds_to: current_offer, from_id: offer_from_id) }
+    let(:current_offer) { Fabricate(:offer, order: order, from_id: order.seller_id, from_type: order.seller_type, amount_cents: 10000, submitted_at: 1.day.ago) }
+    let(:new_offer) { Fabricate(:offer, order: order, from_id: order.buyer_id, from_type: order.buyer_type, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 50_00, responds_to: current_offer) }
     let(:call_service) { OfferService.submit_pending_offer(new_offer) }
 
     before do
@@ -363,7 +363,7 @@ describe OfferService, type: :services do
     end
 
     context 'attempting to submit already submitted offer' do
-      let(:new_offer) { Fabricate(:offer, order: order, amount_cents: 20000, responds_to: current_offer, submitted_at: 1.minute.ago, from_id: offer_from_id) }
+      let(:new_offer) { Fabricate(:offer, order: order, amount_cents: 20000, responds_to: current_offer, submitted_at: 1.minute.ago, from_id: buyer_id, from_type: Order::USER) }
       it 'raises a validation error' do
         expect {  call_service }.to raise_error(Errors::ValidationError)
       end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -67,7 +67,7 @@ describe OfferService, type: :services do
     describe 'failed process' do
       before do
         order.update!(last_offer: offer)
-        expect(PostOrderNotificationJob).not_to receive(:perform_later)
+        expect(OfferEvent).not_to receive(:delay_post)
         expect(OrderFollowUpJob).not_to receive(:perform_later)
         expect(OfferRespondReminderJob).not_to receive(:perform_later)
       end
@@ -178,8 +178,8 @@ describe OfferService, type: :services do
         allow(Gravity).to receive(:get_artwork).with(artwork[:_id]).and_return(artwork)
         allow(Gravity).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
-        expect(PostOfferNotificationJob).to receive(:perform_later).once.with(offer.id, OfferEvent::SUBMITTED, buyer_id)
-        expect(PostOrderNotificationJob).to receive(:perform_later).once.with(order.id, Order::SUBMITTED, buyer_id)
+        expect(OrderEvent).to receive(:delay_post).once.with(order, Order::SUBMITTED, buyer_id)
+        expect(OfferEvent).to receive(:delay_post).once.with(offer, OfferEvent::SUBMITTED)
       end
       it 'submits the offer' do
         expect do

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -348,7 +348,7 @@ describe OfferService, type: :services do
 
       it 'queues job for posting notification' do
         call_service
-        expect(PostOfferNotificationJob).to have_been_enqueued
+        expect(PostEventJob).to have_been_enqueued
       end
       it 'queues job for order follow up' do
         call_service

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -4,7 +4,7 @@ describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
   let(:order_state) { Order::SUBMITTED }
   let(:order_mode) { Order::BUY }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state, mode: order_mode) }
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
@@ -47,7 +47,7 @@ describe OrderCancellationService, type: :services do
     end
 
     context 'with an offer-mode order' do
-      let!(:offer) { Fabricate(:offer, order: order, from_id: 'buyer') }
+      let!(:offer) { Fabricate(:offer, order: order, from_id: order.buyer_id, from_type: order.buyer_type) }
       let(:service) { OrderCancellationService.new(order, 'seller') }
 
       before do

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -26,7 +26,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_rejected_other]
       end
       it 'queues notification job' do
-        expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED, user_id)
+        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
       end
     end
     context 'with an unsuccessful refund' do
@@ -72,7 +72,7 @@ describe OrderCancellationService, type: :services do
         end
 
         it 'sends a notification' do
-          expect(PostOrderNotificationJob).to receive(:perform_later).with(order.id, Order::CANCELED, 'seller')
+          expect(PostEventJob).to receive(:perform_later).with(kind_of(String), 'order.canceled')
           service.reject!(Order::REASONS[Order::CANCELED][:seller_rejected_offer_too_low])
         end
       end
@@ -112,7 +112,7 @@ describe OrderCancellationService, type: :services do
           expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
         end
         it 'queues notification job' do
-          expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
+          expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
         end
       end
       context 'with an unsuccessful refund' do
@@ -143,7 +143,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
       end
       it 'queues notification job' do
-        expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
+        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
       end
     end
   end
@@ -160,7 +160,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:buyer_lapsed]
       end
       it 'queues notification job' do
-        expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::CANCELED)
+        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
       end
     end
   end
@@ -185,7 +185,7 @@ describe OrderCancellationService, type: :services do
             expect(order.state).to eq Order::REFUNDED
           end
           it 'queues notification job' do
-            expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::REFUNDED, user_id)
+            expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.refunded')
           end
         end
         context 'with an unsuccessful refund' do

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -166,7 +166,7 @@ describe OrderService, type: :services do
       end
       it 'queues job to post fulfillment event' do
         OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
-        expect(PostOrderNotificationJob).to have_been_enqueued.with(order.id, Order::FULFILLED, user_id)
+        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.fulfilled')
       end
     end
     Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-761
We queue jobs for posting order and offer events. Depending on whats the current state of the order/offer some fields may be wrong if by the time Sidekiq is processing the job, the order/offer is already updated.

# Solution
Add `delay_post` to both `OrderEvent` and `OfferEvent` which create the event and queue a newly added `PostEventJob` which gets an event json string and also the routing key.

# Follow up
We can remove `PostOrderNotifictionJob` and `PostOfferNotificationJob` since we've moved to `PostEventJob`.