### PR TITLE
Stop posting order.submitted for offer submission

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -69,8 +69,6 @@ module OfferService
     def post_submit_offer(offer)
       OrderFollowUpJob.set(wait_until: offer.order.state_expires_at).perform_later(offer.order.id, offer.order.state)
       PostOfferNotificationJob.perform_later(offer.id, OfferEvent::SUBMITTED, offer.creator_id)
-      # We are posting order.submitted event 👇, for now since Pulse (email service) is expecting that in case of submitting pending offer
-      PostOrderNotificationJob.perform_later(offer.order.id, Order::SUBMITTED, offer.creator_id)
       Exchange.dogstatsd.increment 'offer.submit'
     end
 

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -178,7 +178,7 @@ describe OfferService, type: :services do
         allow(Gravity).to receive(:get_artwork).with(artwork[:_id]).and_return(artwork)
         allow(Gravity).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
         allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
-        expect(PostOrderNotificationJob).to receive(:perform_later).once.with(order.id, Order::SUBMITTED, buyer_id)
+        expect(PostOfferNotificationJob).to receive(:perform_later).once.with(offer.id, OfferEvent::SUBMITTED, buyer_id)
       end
       it 'submits the offer' do
         expect do
@@ -347,7 +347,7 @@ describe OfferService, type: :services do
 
       it 'queues job for posting notification' do
         call_service
-        expect(PostOrderNotificationJob).to have_been_enqueued
+        expect(PostOfferNotificationJob).to have_been_enqueued
       end
       it 'queues job for order follow up' do
         call_service


### PR DESCRIPTION
This PR removes posting `order.submitted` for offer submission. We now only send `offer.submitted` events.