### PR TITLE
Reuse orders only if it's same mode

### DIFF
--- a/lib/order_creator.rb
+++ b/lib/order_creator.rb
@@ -18,7 +18,6 @@ class OrderCreator
   end
 
   def find_or_create!(&post_create_block)
-    existing_order = Order.joins(:line_items).find_by(buyer_id: @buyer_id, buyer_type: @buyer_type, state: [Order::PENDING, Order::SUBMITTED], line_items: { artwork_id: @artwork_id, edition_set_id: edition_set_id, quantity: @quantity })
     existing_order || create!(&post_create_block)
   end
 
@@ -70,6 +69,10 @@ class OrderCreator
     price_error ||= :missing_currency if item.present? && item[:price_currency].blank?
     @errors << price_error if price_error.present?
     price_error.nil?
+  end
+
+  def existing_order
+    @existing_order ||= Order.joins(:line_items).find_by(mode: @mode, buyer_id: @buyer_id, buyer_type: @buyer_type, state: [Order::PENDING, Order::SUBMITTED], line_items: { artwork_id: @artwork_id, edition_set_id: edition_set_id, quantity: @quantity })
   end
 
   def edition_set_id

--- a/spec/controllers/api/requests/offers/create_offer_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/create_offer_order_with_artwork_mutation_request_spec.rb
@@ -250,9 +250,25 @@ describe Api::GraphqlController, type: :request do
               end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
             end
           end
-          context 'with existing pending order for artwork' do
+          context 'with existing pending buy now order for artwork' do
             let!(:order) do
-              order = Fabricate(:order, buyer_id: jwt_user_id, state: Order::PENDING)
+              order = Fabricate(:order, buyer_id: jwt_user_id, state: Order::PENDING, mode: Order::BUY)
+              order.line_items = [Fabricate(:line_item, artwork_id: artwork_id)]
+              order
+            end
+            it 'creates a new offer order' do
+              expect do
+                response = client.execute(mutation, input: { artworkId: artwork_id, findActiveOrCreate: false })
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.id).not_to eq order.id
+                expect(response.data.create_offer_order_with_artwork.order_or_error).not_to respond_to(:error)
+                expect(order.reload.state).to eq Order::PENDING
+              end.to change(Order, :count).by(1)
+            end
+          end
+          context 'with existing pending offer order for artwork' do
+            let!(:order) do
+              order = Fabricate(:order, buyer_id: jwt_user_id, state: Order::PENDING, mode: Order::OFFER)
               order.line_items = [Fabricate(:line_item, artwork_id: artwork_id)]
               order
             end

--- a/spec/controllers/api/requests/offers/create_offer_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/create_offer_order_with_artwork_mutation_request_spec.rb
@@ -23,6 +23,7 @@ describe Api::GraphqlController, type: :request do
               ... on OrderWithMutationSuccess {
                 order {
                   id
+                  mode
                   itemsTotalCents
                   totalListPriceCents
                   buyer {
@@ -261,6 +262,7 @@ describe Api::GraphqlController, type: :request do
                 response = client.execute(mutation, input: { artworkId: artwork_id, findActiveOrCreate: false })
                 expect(response.data.create_offer_order_with_artwork.order_or_error.order.id).not_to be_nil
                 expect(response.data.create_offer_order_with_artwork.order_or_error.order.id).not_to eq order.id
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.mode).to eq 'OFFER'
                 expect(response.data.create_offer_order_with_artwork.order_or_error).not_to respond_to(:error)
                 expect(order.reload.state).to eq Order::PENDING
               end.to change(Order, :count).by(1)
@@ -281,10 +283,11 @@ describe Api::GraphqlController, type: :request do
               end.to change(Order, :count).by(0)
             end
 
-            it 'creates a new one when find_active_or_create is set to false' do
+            it 'creates a new order when find_active_or_create is set to false' do
               expect do
                 response = client.execute(mutation, input: { artworkId: artwork_id, findActiveOrCreate: false })
                 expect(response.data.create_offer_order_with_artwork.order_or_error.order.id).not_to be_nil
+                expect(response.data.create_offer_order_with_artwork.order_or_error.order.mode).to eq 'OFFER'
                 expect(response.data.create_offer_order_with_artwork.order_or_error).not_to respond_to(:error)
                 expect(order.reload.state).to eq Order::PENDING
               end.to change(Order, :count).by(1)

--- a/spec/lib/order_creator_spec.rb
+++ b/spec/lib/order_creator_spec.rb
@@ -8,7 +8,7 @@ describe OrderCreator, type: :services do
   let(:order_mode) { Order::BUY }
   let(:order_creator) { OrderCreator.new(buyer_id: 'user1', buyer_type: Order::USER, mode: order_mode, quantity: 1, artwork_id: artwork_id, edition_set_id: edition_set_id, user_agent: '007', user_ip: '0.0.7') }
   before do
-    expect(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").once.and_return(gravity_artwork)
+    allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").once.and_return(gravity_artwork)
   end
   describe '#valid?' do
     context 'unknown artwork' do
@@ -203,9 +203,10 @@ describe OrderCreator, type: :services do
 
   describe '#find_or_create!' do
     let(:order_state) { Order::PENDING }
-    let(:existing_order) { Fabricate(:order, buyer_id: 'user1', buyer_type: Order::USER, state: order_state) }
-    let!(:line_item) { Fabricate(:line_item, order: existing_order, artwork_id: 'artwork-id', edition_set_id: 'edition-set-id') }
-    context 'with existing order in pending state' do
+    let(:existing_order) { Fabricate(:order, buyer_id: 'user1', buyer_type: Order::USER, state: order_state, mode: order_mode) }
+    let(:edition_set_id) { 'edition-set-id' }
+    let!(:line_item) { Fabricate(:line_item, order: existing_order, artwork_id: 'artwork-id', edition_set_id: edition_set_id) }
+    context 'with existing order in pending state with same mode' do
       it 'returns existing order' do
         expect do
           order = order_creator.find_or_create!
@@ -220,7 +221,7 @@ describe OrderCreator, type: :services do
         end
       end
     end
-    context 'with existing order in submitted state' do
+    context 'with existing order in submitted state with same mode' do
       let(:order_state) { Order::SUBMITTED }
       it 'returns existing order' do
         expect do
@@ -234,6 +235,15 @@ describe OrderCreator, type: :services do
         order_creator.find_or_create! do |order|
           block_method.call(order)
         end
+      end
+    end
+    context 'with existing order in pending state in different mode' do
+      let(:existing_order) { Fabricate(:order, buyer_id: 'user1', buyer_type: Order::USER, state: order_state, mode: Order::OFFER) }
+      it 'creates new order' do
+        expect do
+          order = order_creator.find_or_create!
+          expect(order.id).not_to eq existing_order.id
+        end.to change(Order, :count).by(1)
       end
     end
     [Order::APPROVED, Order::FULFILLED, Order::REFUNDED, Order::ABANDONED].each do |state|

--- a/spec/lib/order_creator_spec.rb
+++ b/spec/lib/order_creator_spec.rb
@@ -239,20 +239,22 @@ describe OrderCreator, type: :services do
     end
     context 'with existing order in pending state in different mode' do
       let(:existing_order) { Fabricate(:order, buyer_id: 'user1', buyer_type: Order::USER, state: order_state, mode: Order::OFFER) }
-      it 'creates new order' do
+      it 'creates new Buy order' do
         expect do
           order = order_creator.find_or_create!
           expect(order.id).not_to eq existing_order.id
+          expect(order.mode).to eq Order::BUY
         end.to change(Order, :count).by(1)
       end
     end
     [Order::APPROVED, Order::FULFILLED, Order::REFUNDED, Order::ABANDONED].each do |state|
       context "with existing order in #{state}" do
         let(:order_state) { state }
-        it 'creates new order' do
+        it 'creates new Buy order' do
           expect do
             order = order_creator.find_or_create!
             expect(order.id).not_to eq existing_order.id
+            expect(order.mode).to eq Order::BUY
           end.to change(Order, :count).by(1)
         end
         it 'calls the block' do


### PR DESCRIPTION
# Problem
When a user has a `buy` order, when they try to make offer we return their `buy` order. 

https://artsyproduct.atlassian.net/browse/PURCHASE-778

# Cause
When checking for existing orders, we were not checking `mode`.

# Solution
Check for `mode` when looking for `existing_order `