### PR TITLE
Update reminder emails to 5hrs before expiration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/MethodLength:
     - "db/migrate/*"
 
 Metrics/ClassLength:
-  Max: 183
+  Max: 190
 
 Metrics/ModuleLength:
   Max: 151

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@ class Order < ApplicationRecord
 
   SUPPORTED_CURRENCIES = %w[USD].freeze
 
-  INITIAL_EXPIRATION_REMINDER = 5.hours
+  DEFAULT_EXPIRATION_REMINDER = 5.hours
 
   MODES = [
     BUY = 'buy'.freeze,
@@ -176,8 +176,8 @@ class Order < ApplicationRecord
     last_offer&.awaiting_response_from
   end
 
-  def initial_reminder_time
-    state_expires_at - INITIAL_EXPIRATION_REMINDER
+  def state_expiration_reminder_time(time_to_expiration = DEFAULT_EXPIRATION_REMINDER)
+    state_expires_at - time_to_expiration
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,8 @@ class Order < ApplicationRecord
 
   SUPPORTED_CURRENCIES = %w[USD].freeze
 
+  INITIAL_EXPIRATION_REMINDER = 5.hours
+
   MODES = [
     BUY = 'buy'.freeze,
     OFFER = 'offer'.freeze
@@ -172,6 +174,10 @@ class Order < ApplicationRecord
     return unless mode == Order::OFFER && state == Order::SUBMITTED
 
     last_offer&.awaiting_response_from
+  end
+
+  def initial_reminder_time
+    state_expires_at - INITIAL_EXPIRATION_REMINDER
   end
 
   private

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -61,7 +61,7 @@ module OfferService
 
     Exchange.dogstatsd.increment 'order.submit'
     PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, user_id)
-    ReminderFollowUpJob.set(wait_until: order.state_expires_at - 2.hours).perform_later(order.id, order.state)
+    ReminderFollowUpJob.set(wait_until: order.initial_reminder_time).perform_later(order.id, order.state)
   end
 
   class << self

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -61,7 +61,7 @@ module OfferService
 
     Exchange.dogstatsd.increment 'order.submit'
     PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, user_id)
-    ReminderFollowUpJob.set(wait_until: order.initial_reminder_time).perform_later(order.id, order.state)
+    ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
   end
 
   class << self

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -24,7 +24,7 @@ class OrderApproveService
     @order.line_items.each { |li| RecordSalesTaxJob.perform_later(li.id) }
     PostOrderNotificationJob.perform_later(@order.id, Order::APPROVED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
-    ReminderFollowUpJob.set(wait_until: @order.state_expires_at - 2.hours).perform_later(@order.id, @order.state)
+    ReminderFollowUpJob.set(wait_until: @order.initial_reminder_time).perform_later(@order.id, @order.state)
   end
 
   def record_stats

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -24,7 +24,7 @@ class OrderApproveService
     @order.line_items.each { |li| RecordSalesTaxJob.perform_later(li.id) }
     PostOrderNotificationJob.perform_later(@order.id, Order::APPROVED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
-    ReminderFollowUpJob.set(wait_until: @order.initial_reminder_time).perform_later(@order.id, @order.state)
+    ReminderFollowUpJob.set(wait_until: @order.state_expiration_reminder_time).perform_later(@order.id, @order.state)
   end
 
   def record_stats

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -23,6 +23,6 @@ class OrderSubmitService < CommitOrderService
     super
     PostOrderNotificationJob.perform_later(@order.id, Order::SUBMITTED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
-    ReminderFollowUpJob.set(wait_until: @order.initial_reminder_time).perform_later(@order.id, @order.state)
+    ReminderFollowUpJob.set(wait_until: @order.state_expiration_reminder_time).perform_later(@order.id, @order.state)
   end
 end

--- a/app/services/order_submit_service.rb
+++ b/app/services/order_submit_service.rb
@@ -23,6 +23,6 @@ class OrderSubmitService < CommitOrderService
     super
     PostOrderNotificationJob.perform_later(@order.id, Order::SUBMITTED, @user_id)
     OrderFollowUpJob.set(wait_until: @order.state_expires_at).perform_later(@order.id, @order.state)
-    ReminderFollowUpJob.set(wait_until: @order.state_expires_at - 2.hours).perform_later(@order.id, @order.state)
+    ReminderFollowUpJob.set(wait_until: @order.initial_reminder_time).perform_later(@order.id, @order.state)
   end
 end


### PR DESCRIPTION
# Problem
We want to switch Pulse emails to use Exchange notification instead of queuing their own job in the future for reminder emails. https://github.com/artsy/pulse/pull/325

# Solution
Currently reminder notifications are posted only 2hrs before expiration and only consumer is APRb for these for slack notification. Emails need to be sent 5hrs before expiration. After talking to CRT we are good with getting internal notifications at 5hr too.
We updated reminder notification to 5hrs and this way pulse could switch to these events.

# What happens to existing queued jobs?
For existing ones we still use 2hrs since they were already queued, if we want to not send emails 2hrs before for existing jobs we can follow this:
- Deploy Exchange with this change
- Wait 2 days (so all jobs queued in 2 days from the deploy time are finished)
- Merge https://github.com/artsy/pulse/pull/325 
- Delete current jobs queued in Pulse for reminder emails
- Deploy Pulse