### PR TITLE
PURCHASE-777: Include subject id in event properties

### DIFF
--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -17,6 +17,7 @@ class OfferEvent < Events::BaseEvent
 
   def properties
     {
+      id: @object.id,
       amount_cents: @object.amount_cents,
       submitted_at: @object.submitted_at,
       from_participant: @object.from_participant,

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -1,6 +1,7 @@
 class OrderEvent < Events::BaseEvent
   TOPIC = 'commerce'.freeze
   PROPERTIES_ATTRS = %i[
+    id
     mode
     buyer_id
     buyer_type

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -74,6 +74,7 @@ describe OfferEvent, type: :events do
 
   describe '#properties' do
     it 'includes expected offer properties' do
+      expect(event.properties[:id]).to eq offer.id
       expect(event.properties[:submitted_at]).not_to be_nil
       expect(event.properties[:from_participant]).to eq Order::BUYER
       expect(event.properties[:from_id]).to eq offer.from_id
@@ -93,6 +94,7 @@ describe OfferEvent, type: :events do
         it 'returns correct properties for a submitted order' do
           properties = event.properties
           order_prop = properties[:order]
+          expect(order_prop[:id]).to eq order.id
           expect(order_prop[:mode]).to eq Order::BUY
           expect(order_prop[:code]).to eq order.code
           expect(order_prop[:currency_code]).to eq 'USD'

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -82,6 +82,7 @@ describe OrderEvent, type: :events do
   describe '#properties' do
     context 'without last_offer' do
       it 'returns correct properties for a submitted order' do
+        expect(event.properties[:id]).to eq order.id
         expect(event.properties[:mode]).to eq Order::BUY
         expect(event.properties[:code]).to eq order.code
         expect(event.properties[:currency_code]).to eq 'USD'


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-777

Subject id is currently not included in event `properties` because we have that in `subject` separately. However, when nesting event properties in another event (e.g. [`order`](https://github.com/artsy/exchange/blob/4e33c444b27e750e6d30563112b8c32bada58bbe/app/events/offer_event.rb#L38) nested in an offer event), the consumer would [not get the id of the nested object](https://github.com/artsy/pulse/blob/0150d792a02cd74d52b404463c99e02067d8527a/app/event_handlers/seller_countered_offer_handler.rb#L27).

Let's always include id in the event properties. It's a bit of redundancy, but the id field seems essential to me.