### PR TITLE
Ignores deleted artworks during inventory undeduction

### DIFF
--- a/app/jobs/undeduct_line_item_inventory_job.rb
+++ b/app/jobs/undeduct_line_item_inventory_job.rb
@@ -1,8 +1,13 @@
 class UndeductLineItemInventoryJob < ApplicationJob
   queue_as :default
+  discard_on(Errors::ValidationError) do |job, _error|
+    Rails.warn.info "Line item #{job.line_item.id} has deleted artwork, skipping inventory undeduction"
+  end
+
+  attr_accessor :line_item
 
   def perform(line_item_id)
-    line_item = LineItem.find(line_item_id)
-    Gravity.undeduct_inventory(line_item)
+    @line_item = LineItem.find(line_item_id)
+    Gravity.undeduct_inventory(@line_item)
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -63,7 +63,7 @@ module Gravity
       Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/inventory", params: { undeduct: line_item.quantity })
     end
   rescue Adapters::GravityNotFoundError
-    Rails.logger.info "Line item #{line_item.id} has deleted artwork, skipping inventory undeduction"
+    raise Errors::ValidationError.new(:unknown_artwork, line_item_id: line_item.id)
   rescue Adapters::GravityError
     raise Errors::ProcessingError.new(:undeduct_inventory_failure, line_item_id: line_item.id)
   end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -63,7 +63,7 @@ module Gravity
       Adapters::GravityV1.put("/artwork/#{line_item.artwork_id}/inventory", params: { undeduct: line_item.quantity })
     end
   rescue Adapters::GravityNotFoundError
-    raise Errors::ValidationError.new(:unknown_artwork, line_item_id: line_item.id)
+    Rails.logger.info "Line item #{line_item.id} has deleted artwork, skipping inventory undeduction"
   rescue Adapters::GravityError
     raise Errors::ProcessingError.new(:undeduct_inventory_failure, line_item_id: line_item.id)
   end


### PR DESCRIPTION
[Discussed in Slack](https://artsy.slack.com/archives/CB110C6LE/p1546616701076600?thread_ts=1546616137.073300&cid=CB110C6LE), this PR is a follow-up to #364 and [PURCHASE-718](https://artsyproduct.atlassian.net/browse/PURCHASE-718). This PR changes calls to gravity's `inventory` endpoint to undeduct inventory (typically from a refund). If the API call fails due to a 404 (a deleted artwork) then it won't be retried. I looked for other places we call this undeduction, and I don't see any issues with not retrying.