### PR TITLE
Raise error if missing artwork location in ShippingHelper.calculate

### DIFF
--- a/lib/shipping_helper.rb
+++ b/lib/shipping_helper.rb
@@ -1,6 +1,7 @@
 class ShippingHelper
   def self.calculate(artwork, fulfillment_type, shipping_address = nil)
     return 0 if fulfillment_type == Order::PICKUP
+    raise Errors::ValidationError.new(:missing_artwork_location, artwork_id: artwork[:_id]) if artwork[:location].blank?
 
     if domestic?(artwork, shipping_address)
       artwork[:domestic_shipping_fee_cents] || raise(Errors::ValidationError, :missing_domestic_shipping_fee)
@@ -9,9 +10,7 @@ class ShippingHelper
     end
   end
 
-  private
-
   def self.domestic?(artwork, shipping_address)
-    artwork[:location][:country].casecmp(@shipping_address.country).zero? && (shipping_address.country != Carmen::Country.coded('US').code || shipping_address.continental_us?)
+    artwork[:location][:country].casecmp(shipping_address.country).zero? && (shipping_address.country != Carmen::Country.coded('US').code || shipping_address.continental_us?)
   end
 end

--- a/lib/shipping_helper.rb
+++ b/lib/shipping_helper.rb
@@ -2,10 +2,16 @@ class ShippingHelper
   def self.calculate(artwork, fulfillment_type, shipping_address = nil)
     return 0 if fulfillment_type == Order::PICKUP
 
-    if artwork[:location][:country].casecmp(shipping_address.country).zero? && (shipping_address.country != Carmen::Country.coded('US').code || shipping_address.continental_us?)
+    if domestic?(artwork, shipping_address)
       artwork[:domestic_shipping_fee_cents] || raise(Errors::ValidationError, :missing_domestic_shipping_fee)
     else
       artwork[:international_shipping_fee_cents] || raise(Errors::ValidationError.new(:unsupported_shipping_location, failure_code: :domestic_shipping_only))
     end
+  end
+
+  private
+
+  def self.domestic?(artwork, shipping_address)
+    artwork[:location][:country].casecmp(@shipping_address.country).zero? && (shipping_address.country != Carmen::Country.coded('US').code || shipping_address.continental_us?)
   end
 end

--- a/spec/lib/shipping_helper_spec.rb
+++ b/spec/lib/shipping_helper_spec.rb
@@ -44,14 +44,32 @@ describe ShippingHelper, type: :services do
       }
     }
   end
+  let(:missing_artwork_location_config) do
+    {
+      _id: 'a-3',
+      domestic_shipping_fee_cents: 100_00,
+      international_shipping_fee_cents: 500_00,
+      location: nil
+    }
+  end
 
   let(:artwork) { gravity_v1_artwork }
   let(:continental_us_artwork) { gravity_v1_artwork(continental_us_artwork_config) }
   let(:artwork_in_italy) { gravity_v1_artwork(artwork_in_italy_config) }
+  let(:artwork_missing_location) { gravity_v1_artwork(missing_artwork_location_config) }
   describe '#calculate' do
     context 'with pickup fulfillment type' do
       it 'returns 0' do
         expect(ShippingHelper.calculate(artwork, Order::PICKUP)).to eq 0
+      end
+    end
+    context 'with missing artowrk location' do
+      it 'raises an error' do
+        expect { ShippingHelper.calculate(artwork_missing_location, Order::SHIP, us_shipping) }.to raise_error do |error|
+          expect(error).to be_a(Errors::ValidationError)
+          expect(error.code).to eq :missing_artwork_location
+          expect(error.data[:artwork_id]).to eq artwork_missing_location[:_id]
+        end
       end
     end
     context 'continental us artwork' do


### PR DESCRIPTION
### Problem
In rare instances it's possible to end up attempting to calculate shipping with a missing artwork location.

Addresses [PURCHASE-786](https://artsyproduct.atlassian.net/browse/PURCHASE-786).

### Solution
Raise a `missing_artwork_location` error if the artwork location is blank when we try to calculate shipping costs.

### What changed
- `ShippingHelper#calculate` raises an error if artwork location is blank when trying to calculate shipping costs
- Refactored domestic shipping logic in `calculate` into its own method `domestic?`