### PR TITLE
Fix missing square image

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -82,7 +82,9 @@ ActiveAdmin.register Order do
         if artwork_info.present?
           if artwork_info[:images].kind_of?(Array)
             square_image = artwork_info[:images].find { |im| im[:image_urls].key?(:square) }
-            img :src => square_image[:image_urls][:square], :width => "100%"
+            if square_image
+              img :src => square_image[:image_urls][:square], :width => "100%"
+            end
           end
           br
           if artwork_info.key?(:title)


### PR DESCRIPTION
# Problem
When artwork is missing square image we are not able to render the admin page.

https://exchange.artsy.net/admin/orders/266559b8-88d5-4a4c-acbd-ba6dd18b3e84

# Solution
Add some defensive code.