### PR TITLE
Remove deprecated “lastOffer” and “offers” fields from “Order” interface

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -60,7 +60,6 @@ type BuyOrder implements Order {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: DateTime
-  lastOffer: Offer @deprecated(reason: "Switch to OfferOrder lastOffer")
   lastSubmittedAt: DateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -76,21 +75,6 @@ type BuyOrder implements Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): OfferConnection @deprecated(reason: "Switch to OfferOrder offers")
   requestedFulfillment: RequestedFulfillmentUnion
   seller: OrderPartyUnion!
   sellerTotalCents: Int
@@ -507,7 +491,6 @@ interface Order {
   # Item total in cents, for Offer Orders this field reflects current offer
   itemsTotalCents: Int
   lastApprovedAt: DateTime
-  lastOffer: Offer @deprecated(reason: "Switch to OfferOrder lastOffer")
   lastSubmittedAt: DateTime
   lineItems(
     # Returns the elements in the list that come after the specified cursor.
@@ -523,21 +506,6 @@ interface Order {
     last: Int
   ): LineItemConnection
   mode: OrderModeEnum
-  offers(
-    # Returns the elements in the list that come after the specified cursor.
-    after: String
-
-    # Returns the elements in the list that come before the specified cursor.
-    before: String
-
-    # Returns the first _n_ elements from the list.
-    first: Int
-    fromId: String
-    fromType: String
-
-    # Returns the last _n_ elements from the list.
-    last: Int
-  ): OfferConnection @deprecated(reason: "Switch to OfferOrder offers")
   requestedFulfillment: RequestedFulfillmentUnion
   seller: OrderPartyUnion!
   sellerTotalCents: Int

--- a/app/graphql/types/order_interface.rb
+++ b/app/graphql/types/order_interface.rb
@@ -34,13 +34,6 @@ module Types::OrderInterface
   field :transaction_fee_cents, Integer, null: true, seller_only: true
   field :updated_at, Types::DateTimeType, null: false
 
-  # Deprecated
-  field :last_offer, Types::OfferType, null: true, deprecation_reason: 'Switch to OfferOrder lastOffer'
-  field :offers, Types::OfferType.connection_type, deprecation_reason: 'Switch to OfferOrder offers', null: true do
-    argument :from_id, String, required: false
-    argument :from_type, String, required: false
-  end
-
   orphan_types Types::BuyOrderType, Types::OfferOrderType
 
   def offers(**args)


### PR DESCRIPTION
~WIP because this PR depends on [a metaphysics PR](https://github.com/artsy/metaphysics/pull/1471) being merged **and deployed**.~ The metaphysics PR has been merged, so this one's ready to go!

*Partially* resolves https://artsyproduct.atlassian.net/browse/PURCHASE-796. We will still want to update all metaphysics clients that keep versions of the schema. 