### PR TITLE
Use SQL subqueries to reduce extra network roundtrips

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -118,8 +118,9 @@ class Order < ApplicationRecord
   end
 
   def competing_orders
-    artwork_ids = line_items.pluck(:artwork_id)
-    edition_set_ids = line_items.pluck(:edition_set_id)
+    artwork_ids = line_items.select(:artwork_id)
+    edition_set_ids = line_items.select(:edition_set_id)
+
     conditions = <<~SQL
       orders.id != ?
       AND orders.state = ?


### PR DESCRIPTION
In ActiveRecord, almost all `#pluck` calls could be replaced with `#select`. This will consolidate the three SQL queries sent individually and reduce extra network roundtrip and memory footprint.

## Before:

```sql
# First query
SELECT "line_items"."artwork_id" FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", "..."]]

 # Second query
SELECT "line_items"."edition_set_id" FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", "..."]]

SELECT *
FROM "orders"
INNER JOIN "line_items" ON "line_items"."order_id" = "orders"."id"
WHERE orders.id != '...'
  AND orders.state = 'submitted'
  AND (
    line_items.artwork_id IN ("...", "...") OR
    line_items.edition_set_id IN ("...", "...")
  )
```

## After:

```sql
SELECT *
FROM "orders" 
INNER JOIN "line_items" ON "line_items"."order_id" = "orders"."id" 
WHERE orders.id != '...'
  AND orders.state = 'submitted'
  AND (
    line_items.artwork_id IN (
      SELECT "line_items"."artwork_id" FROM "line_items" WHERE "line_items"."order_id" = '...'
    ) OR
    line_items.edition_set_id IN (
      SELECT "line_items"."edition_set_id" FROM "line_items" WHERE "line_items"."order_id" = '...'
    )
  )
) 
```