### PR TITLE
Adds note to offer event

### DIFF
--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -27,6 +27,7 @@ class OfferEvent < Events::BaseEvent
       from_type: @object.from_type,
       creator_id: @object.creator_id,
       in_response_to: in_response_to,
+      note: @object.note,
       shipping_total_cents: @object.shipping_total_cents,
       tax_total_cents: @object.tax_total_cents,
       order: order

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -38,7 +38,18 @@ describe OfferEvent, type: :events do
   end
   let!(:line_item1) { Fabricate(:line_item, list_price_cents: 200, order: order, commission_fee_cents: 40) }
   let(:old_offer) { Fabricate(:offer, order: order, from_id: order.seller_id, from_type: 'gallery', amount_cents: 240) }
-  let(:offer) { Fabricate(:offer, order: order, from_id: order.buyer_id, from_type: Order::USER, submitted_at: Time.now.utc, amount_cents: 120, responds_to: old_offer) }
+  let(:offer) do
+    Fabricate(
+      :offer,
+      order: order,
+      from_id: order.buyer_id,
+      from_type: Order::USER,
+      submitted_at: Time.now.utc,
+      amount_cents: 120,
+      responds_to: old_offer,
+      note: 'Please consider my reasonable offer.'
+    )
+  end
 
   let(:expected_line_item_properties) do
     [
@@ -83,6 +94,7 @@ describe OfferEvent, type: :events do
       expect(event.properties[:creator_id]).to eq offer.creator_id
       expect(event.properties[:shipping_total_cents]).to eq offer.shipping_total_cents
       expect(event.properties[:tax_total_cents]).to eq offer.tax_total_cents
+      expect(event.properties[:note]).to eq 'Please consider my reasonable offer.'
     end
     it 'includes in_response_to' do
       in_response_to = event.properties[:in_response_to]


### PR DESCRIPTION
This includes the offer note in the event that we send to rabbit.

The length of the note is constrained client-side, so we're not likely to get ones > 200 characters. 