### PR TITLE
Fix missing Topic in post_event

### DIFF
--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -12,7 +12,7 @@ class OfferEvent < Events::BaseEvent
 
   def self.delay_post(offer, action)
     event = new(user: offer.creator_id, action: action, model: offer)
-    PostEventJob.perform_later(event.to_json, event.routing_key)
+    PostEventJob.perform_later(TOPIC, event.to_json, event.routing_key)
   end
 
   def subject

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -39,7 +39,7 @@ class OrderEvent < Events::BaseEvent
 
   def self.delay_post(order, action, user_id = nil)
     event = new(user: user_id, action: action, model: order)
-    PostEventJob.perform_later(event.to_json, event.routing_key)
+    PostEventJob.perform_later(TOPIC, event.to_json, event.routing_key)
   end
 
   def subject
@@ -77,7 +77,8 @@ class OrderEvent < Events::BaseEvent
       tax_total_cents: last_offer.tax_total_cents,
       from_participant: last_offer.from_participant,
       creator_id: last_offer.creator_id,
-      in_response_to: in_response_to
+      in_response_to: in_response_to,
+      note: last_offer.note
     }
   end
 

--- a/app/jobs/post_event_job.rb
+++ b/app/jobs/post_event_job.rb
@@ -1,7 +1,7 @@
 class PostEventJob < ApplicationJob
   queue_as :default
 
-  def perform(event_json, routing_key)
-    Artsy::EventService.post_data(topic: TOPIC, data: event_json, routing_key: routing_key)
+  def perform(topic, event_json, routing_key)
+    Artsy::EventService.post_data(topic: topic, data: event_json, routing_key: routing_key)
   end
 end

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -94,7 +94,7 @@ describe Api::GraphqlController, type: :request do
 
       it 'queues a job for posting events' do
         client.execute(mutation, approve_order_input)
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.approved')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
       end
 
       it 'queues a job for rejecting the order when the order should expire' do

--- a/spec/controllers/api/requests/confirm_pickup_request_spec.rb
+++ b/spec/controllers/api/requests/confirm_pickup_request_spec.rb
@@ -103,7 +103,7 @@ describe Api::GraphqlController, type: :request do
 
           it 'queues a job for posting events' do
             client.execute(mutation, confirm_pickup_input)
-            expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.fulfilled')
+            expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.fulfilled')
           end
         end
       end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -114,7 +114,7 @@ describe OrderEvent, type: :events do
       end
     end
     context 'with last_offer' do
-      let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin') }
+      let(:offer) { Fabricate(:offer, order: order, amount_cents: 200_00, shipping_total_cents: 100_00, tax_total_cents: 40_00, from_id: seller_id, from_type: 'gallery', creator_id: 'partner-admin', note: 'some random note') }
       before do
         order.update!(last_offer: offer)
       end
@@ -126,6 +126,7 @@ describe OrderEvent, type: :events do
         expect(event.properties[:last_offer][:from_participant]).to eq 'seller'
         expect(event.properties[:last_offer][:creator_id]).to eq 'partner-admin'
         expect(event.properties[:last_offer][:responds_to]).to be_nil
+        expect(event.properties[:last_offer][:note]).to eq 'some random note'
       end
     end
     context 'with last_offer that responds to another offer' do

--- a/spec/jobs/post_event_job_spec.rb
+++ b/spec/jobs/post_event_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe PostEventJob, type: :job do
+  let(:user_id) { 'user_id' }
+  let(:order) { Fabricate(:order, buyer_id: user_id, buyer_type: 'user') }
+  let!(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00) }
+  let(:event) { OrderEvent.new(user: user_id, action: Order::SUBMITTED, model: order) }
+
+  it 'post the event with correct topic, event and routing key' do
+    expect(Artsy::EventService).to receive(:post_data).with(topic: 'commerce', data: event.to_json, routing_key: 'order.submitted')
+    PostEventJob.new.perform('commerce', event.to_json, event.routing_key)
+  end
+end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -52,7 +52,7 @@ describe OrderApproveService, type: :services do
         expect(order.transactions.last.status).to eq Transaction::SUCCESS
       end
       it 'queues PostEvent' do
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.approved')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
       end
       it 'queues OrderFollowUpJob' do
         expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::APPROVED)

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -26,7 +26,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_rejected_other]
       end
       it 'queues notification job' do
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.canceled')
       end
     end
     context 'with an unsuccessful refund' do
@@ -72,7 +72,7 @@ describe OrderCancellationService, type: :services do
         end
 
         it 'sends a notification' do
-          expect(PostEventJob).to receive(:perform_later).with(kind_of(String), 'order.canceled')
+          expect(PostEventJob).to receive(:perform_later).with('commerce', kind_of(String), 'order.canceled')
           service.reject!(Order::REASONS[Order::CANCELED][:seller_rejected_offer_too_low])
         end
       end
@@ -112,7 +112,7 @@ describe OrderCancellationService, type: :services do
           expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
         end
         it 'queues notification job' do
-          expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
+          expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.canceled')
         end
       end
       context 'with an unsuccessful refund' do
@@ -143,7 +143,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:seller_lapsed]
       end
       it 'queues notification job' do
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.canceled')
       end
     end
   end
@@ -160,7 +160,7 @@ describe OrderCancellationService, type: :services do
         expect(order.state_reason).to eq Order::REASONS[Order::CANCELED][:buyer_lapsed]
       end
       it 'queues notification job' do
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.canceled')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.canceled')
       end
     end
   end
@@ -185,7 +185,7 @@ describe OrderCancellationService, type: :services do
             expect(order.state).to eq Order::REFUNDED
           end
           it 'queues notification job' do
-            expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.refunded')
+            expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.refunded')
           end
         end
         context 'with an unsuccessful refund' do

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -166,7 +166,7 @@ describe OrderService, type: :services do
       end
       it 'queues job to post fulfillment event' do
         OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
-        expect(PostEventJob).to have_been_enqueued.with(kind_of(String), 'order.fulfilled')
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.fulfilled')
       end
     end
     Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|


### PR DESCRIPTION
Follow up on #347 where we missed passing `topic` to the method and it was using not existing `TOPIC`.

Also added a missing spec and added `note` to `OrderEvent`'s `last_offer` in `properties`