### PR TITLE
Fix merge issue with posting two events

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -60,7 +60,6 @@ module OfferService
 
     OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     Exchange.dogstatsd.increment 'order.submit'
-    PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, user_id)
   end
 
   def self.accept_offer(offer, user_id)
@@ -80,7 +79,7 @@ module OfferService
       )
       order_processor.charge
     end
-    PostOrderNotificationJob.perform_later(order.id, Order::APPROVED, user_id)
+    OrderEvent.delay_post(order, Order::APPROVED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
     Exchange.dogstatsd.increment 'order.approved'

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -51,7 +51,7 @@ module OrderService
       order_processor.hold
     end
 
-    PostOrderNotificationJob.perform_later(order.id, Order::SUBMITTED, user_id)
+    OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
     Exchange.dogstatsd.increment 'order.submitted'

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -23,7 +23,7 @@ describe OrderApproveService, type: :services do
         expect(order.reload.state).to eq Order::SUBMITTED
       end
       it 'does not queue any followup job' do
-        expect(PostOrderNotificationJob).not_to receive(:perform_later)
+        expect(OrderEvent).not_to receive(:delay_post)
         expect(OrderFollowUpJob).not_to receive(:set)
         expect(RecordSalesTaxJob).not_to receive(:perform_later)
       end


### PR DESCRIPTION
#347 got merged, we had some other changes already in Exchange for switching to new style for submit order events. The merge caused issue in posting two events in case of Order submission.

This removes the duplicate and also remove last usages of `PostOrderNotificaiton` and switches to `OrderEvent`. 