### PR TITLE
Fix Missing Failed Transaction

### DIFF
--- a/app/controllers/errors/failed_transaction_error.rb
+++ b/app/controllers/errors/failed_transaction_error.rb
@@ -1,0 +1,9 @@
+module Errors
+  class FailedTransactionError < ProcessingError
+    attr_reader :transaction
+    def initialize(code, transaction)
+      @transaction = transaction
+      super(code, transaction.failure_data)
+    end
+  end
+end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -78,11 +78,18 @@ module OfferService
         seller_total_cents: totals.seller_total_cents
       )
       order_processor.charge
+      order.transactions << order_processor.transaction
     end
     OrderEvent.delay_post(order, Order::APPROVED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
     Exchange.dogstatsd.increment 'order.approved'
+  rescue Errors::FailedTransactionError => e
+    transaction = e.transaction
+    return if transaction.blank?
+
+    order.transactions << transaction
+    PostTransactionNotificationJob.perform_later(transaction.id, TransactionEvent::CREATED, user_id)
   end
 
   class << self

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -77,7 +77,7 @@ module OfferService
         commission_fee_cents: totals.commission_fee_cents,
         seller_total_cents: totals.seller_total_cents
       )
-      order_processor.charge
+      order_processor.charge!
       order.transactions << order_processor.transaction
     end
     OrderEvent.delay_post(order, Order::APPROVED, user_id)
@@ -90,6 +90,7 @@ module OfferService
 
     order.transactions << transaction
     PostTransactionNotificationJob.perform_later(transaction.id, TransactionEvent::CREATED, user_id)
+    raise e
   end
 
   class << self

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -58,7 +58,7 @@ module OrderService
     Exchange.dogstatsd.increment 'order.submitted'
     order
   rescue Errors::FailedTransactionError => e
-    handle_failed_transaction(e, order)
+    handle_failed_transaction(e, order, user_id)
     raise e
   end
 
@@ -88,7 +88,7 @@ module OrderService
   class << self
     private
 
-    def handle_failed_transaction(failed_transaction_exception, order)
+    def handle_failed_transaction(failed_transaction_exception, order, user_id)
       transaction = failed_transaction_exception.transaction
       return if transaction.blank?
 

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -163,10 +163,12 @@ describe Api::GraphqlController, type: :request do
           undeduct_inventory_request
           StripeMock.prepare_card_error(:card_declined)
         end
+
         it 'raises processing error' do
           response = client.execute(mutation, buyer_accept_offer_input)
           expect(response.data.buyer_accept_offer.order_or_error.error.code).to eq 'capture_failed'
         end
+
         it 'stores failed transaction' do
           expect do
             client.execute(mutation, buyer_accept_offer_input)
@@ -174,6 +176,7 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.external_charge_id).to be_nil
           expect(order.transactions.last.failed?).to be true
         end
+
         it 'undeducts inventory' do
           client.execute(mutation, buyer_accept_offer_input)
           expect(undeduct_inventory_request).to have_been_requested

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -145,20 +145,22 @@ describe Api::GraphqlController, type: :request do
 
     context 'with proper permission' do
       let(:deduct_inventory_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json) }
-      let(:merchant_account_request) { expect(Gravity).to receive(:get_merchant_account).and_return(merchant_account) }
-      let(:credit_card_request) { expect(Gravity).to receive(:get_credit_card).and_return(credit_card) }
-      let(:partner_request) { expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner) }
-      let(:undeduct_inventory) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: 200, body: {}.to_json) }
+      let(:undeduct_inventory_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: 200, body: {}.to_json) }
+      let(:credit_card_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/credit_card/#{credit_card_id}").to_return(status: 200, body: credit_card.to_json) }
+      let(:artwork_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1").to_return(status: 200, body: artwork.to_json) }
+      let(:merchant_account_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/merchant_accounts").with(query: { partner_id: order_seller_id }).to_return(status: 200, body: [merchant_account].to_json) }
+      let(:partner_account_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/partner/#{order_seller_id}/all").to_return(status: 200, body: gravity_v1_partner.to_json) }
       before do
         deduct_inventory_request
         merchant_account_request
         credit_card_request
-        partner_request
+        artwork_request
+        partner_account_request
       end
 
       context 'with failed stripe charge' do
         before do
-          undeduct_inventory
+          undeduct_inventory_request
           StripeMock.prepare_card_error(:card_declined)
         end
         it 'raises processing error' do
@@ -169,10 +171,12 @@ describe Api::GraphqlController, type: :request do
           expect do
             client.execute(mutation, buyer_accept_offer_input)
           end.to change(order.transactions.where(status: Transaction::FAILURE), :count).by(1)
+          expect(order.reload.external_charge_id).to be_nil
+          expect(order.transactions.last.failed?).to be true
         end
         it 'undeducts inventory' do
           client.execute(mutation, buyer_accept_offer_input)
-          expect(undeduct_inventory).to have_been_requested
+          expect(undeduct_inventory_request).to have_been_requested
         end
       end
 

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -144,13 +144,41 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
+      let(:deduct_inventory_request) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json) }
+      let(:merchant_account_request) { expect(Gravity).to receive(:get_merchant_account).and_return(merchant_account) }
+      let(:credit_card_request) { expect(Gravity).to receive(:get_credit_card).and_return(credit_card) }
+      let(:partner_request) { expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner) }
+      let(:undeduct_inventory) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }).to_return(status: 200, body: {}.to_json) }
+      before do
+        deduct_inventory_request
+        merchant_account_request
+        credit_card_request
+        partner_request
+      end
+
+      context 'with failed stripe charge' do
+        before do
+          undeduct_inventory
+          StripeMock.prepare_card_error(:card_declined)
+        end
+        it 'raises processing error' do
+          response = client.execute(mutation, buyer_accept_offer_input)
+          expect(response.data.buyer_accept_offer.order_or_error.error.code).to eq 'capture_failed'
+        end
+        it 'stores failed transaction' do
+          expect do
+            client.execute(mutation, buyer_accept_offer_input)
+          end.to change(order.transactions.where(status: Transaction::FAILURE), :count).by(1)
+        end
+        it 'undeducts inventory' do
+          client.execute(mutation, buyer_accept_offer_input)
+          expect(undeduct_inventory).to have_been_requested
+        end
+      end
+
       it 'approves the order' do
-        inventory_request = stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }).to_return(status: 200, body: {}.to_json)
-        expect(Gravity).to receive(:get_merchant_account).and_return(merchant_account)
-        expect(Gravity).to receive(:get_credit_card).and_return(credit_card)
-        expect(Adapters::GravityV1).to receive(:get).with("/partner/#{order_seller_id}/all").and_return(gravity_v1_partner)
         response = client.execute(mutation, buyer_accept_offer_input)
-        expect(inventory_request).to have_been_requested
+        expect(deduct_inventory_request).to have_been_requested
 
         expect(response.data.buyer_accept_offer.order_or_error).to respond_to(:order)
         expect(response.data.buyer_accept_offer.order_or_error.order).not_to be_nil

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -173,10 +173,12 @@ describe Api::GraphqlController, type: :request do
           undeduct_inventory_request
           StripeMock.prepare_card_error(:card_declined)
         end
+
         it 'raises processing error' do
           response = client.execute(mutation, seller_accept_offer_input)
           expect(response.data.seller_accept_offer.order_or_error.error.code).to eq 'capture_failed'
         end
+
         it 'stores failed transaction' do
           expect do
             client.execute(mutation, seller_accept_offer_input)
@@ -184,6 +186,7 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.external_charge_id).to be_nil
           expect(order.transactions.last.failed?).to be true
         end
+
         it 'undeducts inventory' do
           client.execute(mutation, seller_accept_offer_input)
           expect(undeduct_inventory_request).to have_been_requested


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-872
When we call Stripe to process a charge (hold/capture) regardless of the success or failure, we want to store the response as  a `Transaction`. For failed transactions we also post event so we can get notified about them on Slack.
We were notified about a failed charge yesterday and noticed we haven't received slack notifications for them. Looking deeper at the issue, we noticed this failed transaction was not stored on the order.

# Cause
This bug was introduced as part of #379 . What happens here is, we had test in newly added `OrderProccessor` to check if we create a failed transaction in the order in case of Stripe charge failures BUT `order_proccessor.charge` and `order_proceessor.hold` where called in one of `order.<action>` blocks which wraps the whole thing in a database transaction. So charge failures were raising error which would eventually lead to rollback of the whole thing in the block including adding failed transaction to the order.
```ruby
order.submit! do
  # everything in this block is wrapped in database transaction
  order_processor.charge! 
 # ☝️ would add transaction to the order in case of failure but since it's wrapped in transaction
 # it will rollback
end
```

# Solution
We now let `OrderProcessor` raise newly added `Errors::FailedTransactionError` in case of failed transaction which includes the failed transaction. 
Its now up to caller to rescue from this exception and properly add transaction to the order and post events if needed.

# Manual Migration
We've been monitoring failed transactions from Stripe dashboard and as of now (Feb, 12) we had only one failed transaction. Im going to manually add that stripe transaction to the order.