### PR TITLE
Add payment method (include support for wire transfer)

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -1,7 +1,6 @@
 module Errors
   ERROR_TYPES = {
     validation: %i[
-      can_only_process_credit_cards
       cannot_offer
       cant_submit
       cannot_accept_offer
@@ -49,6 +48,7 @@ module Errors
       unknown_participant_type
       unknown_partner
       unpublished_artwork
+      unsupported_payment_method
       unsupported_shipping_location
       wrong_fulfillment_type
     ],

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -1,6 +1,7 @@
 module Errors
   ERROR_TYPES = {
     validation: %i[
+      can_only_process_credit_cards
       cannot_offer
       cant_submit
       cannot_accept_offer

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,6 +16,11 @@ class Order < ApplicationRecord
     SELLER = 'seller'.freeze
   ].freeze
 
+  PAYMENT_METHODS = [
+    CREDIT_CARD = 'credit card'.freeze,
+    WIRE_TRANSFER = 'wire transfer'.freeze
+  ].freeze
+
   # For more docs about states go to:
   # https://www.notion.so/artsy/37c311363ef046c3aa546047e60cc58a?v=de68d5bbc30748f88b0d92a059bc0ba8
   STATES = [
@@ -92,6 +97,7 @@ class Order < ApplicationRecord
   validates :state, presence: true, inclusion: STATES
   validate :state_reason_inclusion
   validates :currency_code, inclusion: SUPPORTED_CURRENCIES
+  validates :payment_method, presence: true, inclusion: PAYMENT_METHODS
 
   after_create :update_code
   after_create :create_state_history

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -8,6 +8,8 @@ class OrderApproveService
   end
 
   def process!
+    raise Errors::ValidationError.new(:can_only_process_credit_cards, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
+
     @order.approve! do
       @transaction = PaymentService.capture_authorized_charge(@order.external_charge_id)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -8,7 +8,7 @@ class OrderApproveService
   end
 
   def process!
-    raise Errors::ValidationError.new(:can_only_process_credit_cards, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
+    raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
 
     @order.approve! do
       @transaction = PaymentService.capture_authorized_charge(@order.external_charge_id)

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -49,6 +49,8 @@ class OrderCancellationService
   end
 
   def process_stripe_refund
+    raise Errors::ValidationError.new(:can_only_process_credit_cards, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
+
     @transaction = PaymentService.refund_charge(@order.external_charge_id)
     raise Errors::ProcessingError.new(:refund_failed, @transaction.failure_data) if @transaction.failed?
   end

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -49,7 +49,7 @@ class OrderCancellationService
   end
 
   def process_stripe_refund
-    raise Errors::ValidationError.new(:can_only_process_credit_cards, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
+    raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
 
     @transaction = PaymentService.refund_charge(@order.external_charge_id)
     raise Errors::ProcessingError.new(:refund_failed, @transaction.failure_data) if @transaction.failed?

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -1,6 +1,16 @@
 module OrderService
   def self.create_with_artwork!(buyer_id:, buyer_type:, mode:, quantity:, artwork_id:, edition_set_id: nil, user_agent:, user_ip:, find_active_or_create: false)
-    order_creator = OrderCreator.new(buyer_id: buyer_id, buyer_type: buyer_type, mode: mode, quantity: quantity, artwork_id: artwork_id, edition_set_id: edition_set_id, user_agent: user_agent, user_ip: user_ip)
+    order_creator = OrderCreator.new(
+      buyer_id: buyer_id,
+      buyer_type: buyer_type,
+      mode: mode,
+      quantity: quantity,
+      artwork_id: artwork_id,
+      edition_set_id: edition_set_id,
+      user_agent: user_agent,
+      user_ip: user_ip
+    )
+
     # in case of Offer orders, we want to reuse existing pending/submitted offers
     create_method = find_active_or_create ? :find_or_create! : :create!
     order_creator.send(create_method) do |created_order|

--- a/db/migrate/20190311132730_add_payment_method_to_orders.rb
+++ b/db/migrate/20190311132730_add_payment_method_to_orders.rb
@@ -1,0 +1,11 @@
+class AddPaymentMethodToOrders < ActiveRecord::Migration[5.2]
+  def up
+    add_column :orders, :payment_method, :string, null: true
+    Order.update_all(payment_method: Order::CREDIT_CARD)
+    change_column :orders, :payment_method, :string, null: false
+  end
+
+  def down
+    remove_column :orders, :payment_method
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_28_182354) do
+ActiveRecord::Schema.define(version: 2019_03_11_132730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2019_01_28_182354) do
     t.uuid "last_offer_id"
     t.string "original_user_agent"
     t.string "original_user_ip"
+    t.string "payment_method", null: false
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["last_offer_id"], name: "index_orders_on_last_offer_id"

--- a/lib/order_creator.rb
+++ b/lib/order_creator.rb
@@ -114,8 +114,10 @@ class OrderCreator
         state_updated_at: Time.now.utc,
         state_expires_at: Order::STATE_EXPIRATIONS[Order::PENDING].from_now,
         original_user_agent: @user_agent,
-        original_user_ip: @user_ip
+        original_user_ip: @user_ip,
+        payment_method: Order::CREDIT_CARD # Default to credit card payment method
       )
+
       line_item = order.line_items.create!(
         artwork_id: @artwork_id,
         artwork_version_id: artwork[:current_version_id],

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -38,7 +38,7 @@ class OrderProcessor
 
   def valid?
     @validated ||= begin
-      @error = :can_only_process_credit_cards unless @order.payment_method == Order::CREDIT_CARD
+      @error = :unsupported_payment_method unless @order.payment_method == Order::CREDIT_CARD
       @error ||= :missing_required_info unless @order.can_commit?
       @error ||= @order.assert_credit_card
     end

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -38,7 +38,8 @@ class OrderProcessor
 
   def valid?
     @validated ||= begin
-      @error = :missing_required_info unless @order.can_commit?
+      @error = :can_only_process_credit_cards unless @order.payment_method == Order::CREDIT_CARD
+      @error ||= :missing_required_info unless @order.can_commit?
       @error ||= @order.assert_credit_card
     end
     @error.nil?

--- a/spec/fabricators/order_fabricator.rb
+++ b/spec/fabricators/order_fabricator.rb
@@ -7,4 +7,5 @@ Fabricator(:order) do
   seller_type { 'gallery' }
   state { Order::PENDING }
   currency_code { 'USD' }
+  payment_method { Order::CREDIT_CARD }
 end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -42,7 +42,7 @@ describe OrderProcessor, type: :services do
       it 'raises validation error if you try to process an order that was paid for by wire transfer' do
         order.update!(payment_method: Order::WIRE_TRANSFER)
         expect { order_processor.hold! }.to raise_error do |e|
-          expect(e.code).to eq :can_only_process_credit_cards
+          expect(e.code).to eq :unsupported_payment_method
         end
       end
 
@@ -162,7 +162,7 @@ describe OrderProcessor, type: :services do
       it 'raises validation error if you try to process an order that was paid for by wire transfer' do
         order.update!(payment_method: Order::WIRE_TRANSFER)
         expect { order_processor.charge! }.to raise_error do |e|
-          expect(e.code).to eq :can_only_process_credit_cards
+          expect(e.code).to eq :unsupported_payment_method
         end
       end
 

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -67,7 +67,7 @@ describe OrderApproveService, type: :services do
       it 'raises an error' do
         order.update!(payment_method: Order::WIRE_TRANSFER)
         expect { service.process! }.to raise_error do |e|
-          expect(e.code).to eq :can_only_process_credit_cards
+          expect(e.code).to eq :unsupported_payment_method
         end
       end
     end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -32,16 +32,6 @@ describe OrderApproveService, type: :services do
       end
     end
 
-    context 'with failed transaction appending' do
-      xit 'goes to failed approve state' do
-      end
-    end
-
-    context 'with failed approve!' do
-      xit 'goes to pending approve state' do
-      end
-    end
-
     context 'with failed post_process' do
       it 'is in approved state' do
         allow(OrderEvent).to receive(:delay_post).and_raise('Perform what later?!')
@@ -74,7 +64,12 @@ describe OrderApproveService, type: :services do
     end
 
     context 'with an order that was paid for by wire transfer' do
-
+      it 'raises an error' do
+        order.update!(payment_method: Order::WIRE_TRANSFER)
+        expect { service.process! }.to raise_error do |e|
+          expect(e.code).to eq :can_only_process_credit_cards
+        end
+      end
     end
   end
 end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -12,30 +12,36 @@ describe OrderApproveService, type: :services do
       before do
         StripeMock.prepare_card_error(:card_declined, :capture_charge)
       end
+
       it 'adds failed transaction' do
         expect { service.process! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
         expect(order.transactions.first.status).to eq Transaction::FAILURE
         expect(order.transactions.first.failure_code).to eq 'card_declined'
         expect(order.transactions.first.failure_message).to eq 'The card was declined'
       end
+
       it 'keeps order in submitted state' do
         expect { service.process! }.to raise_error(Errors::ProcessingError)
         expect(order.reload.state).to eq Order::SUBMITTED
       end
+
       it 'does not queue any followup job' do
         expect(OrderEvent).not_to receive(:delay_post)
         expect(OrderFollowUpJob).not_to receive(:set)
         expect(RecordSalesTaxJob).not_to receive(:perform_later)
       end
     end
+
     context 'with failed transaction appending' do
       xit 'goes to failed approve state' do
       end
     end
+
     context 'with failed approve!' do
       xit 'goes to pending approve state' do
       end
     end
+
     context 'with failed post_process' do
       it 'is in approved state' do
         allow(OrderEvent).to receive(:delay_post).and_raise('Perform what later?!')
@@ -43,23 +49,32 @@ describe OrderApproveService, type: :services do
         expect(order.reload.state).to eq Order::APPROVED
       end
     end
+
     context 'with a successful order approval' do
       before do
         ActiveJob::Base.queue_adapter = :test
         expect { service.process! }.to change(order.transactions, :count).by(1)
       end
+
       it 'adds successful transaction' do
         expect(order.transactions.last.status).to eq Transaction::SUCCESS
       end
+
       it 'queues PostEvent' do
         expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
       end
+
       it 'queues OrderFollowUpJob' do
         expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::APPROVED)
       end
+
       it 'enqueues a RecordSalesTaxJob for each line item' do
         line_items.each { |li| expect(RecordSalesTaxJob).to have_been_enqueued.with(li.id) }
       end
+    end
+
+    context 'with an order that was paid for by wire transfer' do
+
     end
   end
 end

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -58,7 +58,7 @@ describe OrderCancellationService, type: :services do
       it 'raises a ValidationError' do
         order.update!(payment_method: Order::WIRE_TRANSFER)
         expect { service.reject! }.to raise_error do |e|
-          expect(e.code).to eq :can_only_process_credit_cards
+          expect(e.code).to eq :unsupported_payment_method
         end
       end
     end
@@ -248,7 +248,7 @@ describe OrderCancellationService, type: :services do
           it 'raises a ValidationError' do
             order.update!(payment_method: Order::WIRE_TRANSFER)
             expect { service.refund! }.to raise_error do |e|
-              expect(e.code).to eq :can_only_process_credit_cards
+              expect(e.code).to eq :unsupported_payment_method
             end
           end
         end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -15,8 +15,10 @@ describe OrderService, type: :services do
     let(:artwork_id) { 'artwork_id' }
     let(:edition_set_id) { 'edition-set-id' }
     let(:order_mode) { Order::OFFER }
+
     context 'find_active_or_create=true' do
       let(:call_service) { OrderService.create_with_artwork!(buyer_id: buyer_id, buyer_type: Order::USER, mode: order_mode, quantity: 2, artwork_id: artwork_id, edition_set_id: edition_set_id, user_agent: 'ua', user_ip: '0.1', find_active_or_create: true) }
+
       context 'with existing order with same artwork/editionset/mode/quantity' do
         before do
           @existing_order = Fabricate(:order, buyer_id: buyer_id, buyer_type: Order::USER, seller_id: seller_id, seller_type: 'Gallery', mode: order_mode)
@@ -221,6 +223,7 @@ describe OrderService, type: :services do
         expect { OrderService.abandon!(order) }.to change(order.state_histories, :count).by(1)
       end
     end
+
     Order::STATES.reject { |s| s == Order::PENDING }.each do |state|
       context "order in #{state}" do
         let(:state) { state }

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -22,15 +22,18 @@ describe OrderService, type: :services do
           @existing_order = Fabricate(:order, buyer_id: buyer_id, buyer_type: Order::USER, seller_id: seller_id, seller_type: 'Gallery', mode: order_mode)
           @line_item = Fabricate(:line_item, order: @existing_order, artwork_id: artwork_id, edition_set_id: edition_set_id, quantity: 2)
         end
+
         it 'returns existing order' do
           expect do
             expect(call_service).to eq @existing_order
           end.not_to change(Order, :count)
         end
+
         it 'does not call statsd' do
           expect(Exchange).not_to receive(:dogstatsd)
           call_service
         end
+
         it 'wont queue OrderFollowUpJob' do
           call_service
           expect(OrderFollowUpJob).not_to have_been_enqueued
@@ -40,6 +43,7 @@ describe OrderService, type: :services do
         before do
           expect(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").once.and_return(gravity_v1_artwork)
         end
+
         it 'creates new order' do
           expect do
             order = call_service
@@ -50,26 +54,31 @@ describe OrderService, type: :services do
             expect(order.line_items.pluck(:artwork_id, :edition_set_id, :quantity).first).to eq [artwork_id, edition_set_id, 2]
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
+
         it 'reports to statsd' do
           expect(Exchange).to receive_message_chain(:dogstatsd, :increment).with('order.create')
           call_service
         end
+
         it 'queues OrderFollowUpJob' do
           call_service
           expect(OrderFollowUpJob).to have_been_enqueued
         end
       end
     end
+
     context 'find_active_or_create=false' do
       let(:call_service) { OrderService.create_with_artwork!(buyer_id: buyer_id, buyer_type: Order::USER, mode: order_mode, quantity: 2, artwork_id: artwork_id, edition_set_id: edition_set_id, user_agent: 'ua', user_ip: '0.1', find_active_or_create: false) }
       before do
         expect(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").once.and_return(gravity_v1_artwork)
       end
+
       context 'with existing order with same artwork/editionset/mode/quantity' do
         before do
           @existing_order = Fabricate(:order, buyer_id: buyer_id, buyer_type: Order::USER, seller_id: seller_id, seller_type: 'Gallery', mode: order_mode)
           @line_item = Fabricate(:line_item, order: @existing_order, artwork_id: artwork_id, edition_set_id: edition_set_id, quantity: 2)
         end
+
         it 'creates new order' do
           expect do
             order = call_service
@@ -81,6 +90,7 @@ describe OrderService, type: :services do
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
       end
+
       context 'without existing order with same artwork/editionset/mode/quantity' do
         it 'creates new order' do
           expect do
@@ -92,10 +102,12 @@ describe OrderService, type: :services do
             expect(order.line_items.pluck(:artwork_id, :edition_set_id, :quantity).first).to eq [artwork_id, edition_set_id, 2]
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
+
         it 'reports to statsd' do
           expect(Exchange).to receive_message_chain(:dogstatsd, :increment).with('order.create')
           call_service
         end
+
         it 'queues OrderFollowUpJob' do
           call_service
           expect(OrderFollowUpJob).to have_been_enqueued
@@ -108,16 +120,20 @@ describe OrderService, type: :services do
     let(:credit_card_id) { 'gravity-cc-1' }
     context 'order in pending state' do
       let(:state) { Order::PENDING }
+
       context "with a credit card id for the buyer's credit card" do
         let(:credit_card) { { id: credit_card_id, user: { _id: 'b123' } } }
+
         it 'sets credit_card_id on the order' do
           expect(Gravity).to receive(:get_credit_card).with(credit_card_id).and_return(credit_card)
           OrderService.set_payment!(order, credit_card_id)
           expect(order.reload.credit_card_id).to eq 'gravity-cc-1'
         end
       end
+
       context 'with a credit card id for credit card not belonging to the buyer' do
         let(:invalid_credit_card) { { id: credit_card_id, user: { _id: 'b456' } } }
+
         it 'raises an error' do
           expect(Gravity).to receive(:get_credit_card).with(credit_card_id).and_return(invalid_credit_card)
           expect { OrderService.set_payment!(order, credit_card_id) }.to raise_error do |error|
@@ -131,12 +147,15 @@ describe OrderService, type: :services do
 
   describe 'fulfill_at_once!' do
     let(:fulfillment_params) { { courier: 'usps', tracking_id: 'track_this_id', estimated_delivery: 10.days.from_now } }
+
     context 'with order in approved state' do
       let(:state) { Order::APPROVED }
+
       it 'changes order state to fulfilled' do
         OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
         expect(order.reload.state).to eq Order::FULFILLED
       end
+
       it 'creates one fulfillment model' do
         Timecop.freeze do
           expect { OrderService.fulfill_at_once!(order, fulfillment_params, user_id) }.to change(Fulfillment, :count).by(1)
@@ -146,6 +165,7 @@ describe OrderService, type: :services do
           expect(fulfillment.estimated_delivery.to_date).to eq 10.days.from_now.to_date
         end
       end
+
       it 'sets all line items fulfillment to one fulfillment' do
         OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
         fulfillment = Fulfillment.last
@@ -153,11 +173,13 @@ describe OrderService, type: :services do
           expect(li.fulfillments.first.id).to eq fulfillment.id
         end
       end
+
       it 'queues job to post fulfillment event' do
         OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
         expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.fulfilled')
       end
     end
+
     Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|
       context "order in #{state}" do
         let(:state) { state }
@@ -169,6 +191,7 @@ describe OrderService, type: :services do
             expect(error.code).to eq :invalid_state
           end
         end
+
         it 'does not add fulfillments' do
           expect do
             OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
@@ -185,6 +208,7 @@ describe OrderService, type: :services do
         OrderService.abandon!(order)
         expect(order.reload.state).to eq Order::ABANDONED
       end
+
       it 'updates state_update_at' do
         Timecop.freeze do
           order.update!(state_updated_at: 10.days.ago)
@@ -192,6 +216,7 @@ describe OrderService, type: :services do
           expect(order.reload.state_updated_at.to_date).to eq Time.now.utc.to_date
         end
       end
+
       it 'creates state history' do
         expect { OrderService.abandon!(order) }.to change(order.state_histories, :count).by(1)
       end
@@ -203,6 +228,7 @@ describe OrderService, type: :services do
           expect { OrderService.abandon!(order) }.to raise_error(Errors::ValidationError)
           expect(order.reload.state).to eq state
         end
+
         it 'raises error' do
           expect { OrderService.abandon!(order) }.to raise_error do |error|
             expect(error).to be_a Errors::ValidationError


### PR DESCRIPTION
We need to be able to represent orders that are paid for by methods other than `credit_card`, even if we don't have _full_ support for those payment methods just yet.

This PR adds a `payment_method` field to the `Order` model and raises errors in places where we'd attempt to charge a cc for an order that had this set.

From an admin-perspective, if we have a UI for creating orders with `wire_transfer`, they'll have to be in the "approved" or "fulfilled" state, since we don't want to unknowingly mess with inventory or availability just yet. It gets complex 😅 