### PR TITLE
Exchange stores and returns the decline_code when a charge/hold/etc. fails

### DIFF
--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -39,6 +39,7 @@ class TransactionEvent < Events::BaseEvent
       },
       failure_code: @object.failure_code,
       failure_message: @object.failure_message,
+      decline_code: @object.decline_code,
       transaction_type: @object.transaction_type,
       status: @object.status
     }

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -16,32 +16,48 @@ class TransactionEvent < Events::BaseEvent
   end
 
   def properties
-    order = @object.order
     {
-      order: {
-        id: order.id,
-        mode: order.mode,
-        buyer_id: order.buyer_id,
-        buyer_total_cents: order.buyer_total_cents,
-        buyer_type: order.buyer_type,
-        code: order.code,
-        created_at: order.created_at,
-        currency_code: order.currency_code,
-        fulfillment_type: order.fulfillment_type,
-        items_total_cents: order.items_total_cents,
-        line_items: order.line_items.map { |li| line_item_detail(li) },
-        seller_id: order.seller_id,
-        seller_type: order.seller_type,
-        state: order.state,
-        state_reason: order.state_reason,
-        state_expires_at: order.state_expires_at,
-        updated_at: order.updated_at
-      },
+      order: order_details,
       failure_code: @object.failure_code,
       failure_message: @object.failure_message,
       decline_code: @object.decline_code,
       transaction_type: @object.transaction_type,
       status: @object.status
+    }
+  end
+
+  def order_details
+    order = @object.order
+    {
+      id: order.id,
+      mode: order.mode,
+      buyer_id: order.buyer_id,
+      buyer_total_cents: order.buyer_total_cents,
+      total_list_price_cents: order.total_list_price_cents,
+      buyer_type: order.buyer_type,
+      code: order.code,
+      created_at: order.created_at,
+      currency_code: order.currency_code,
+      fulfillment_type: order.fulfillment_type,
+      items_total_cents: order.items_total_cents,
+      line_items: order.line_items.map { |li| line_item_detail(li) },
+      seller_id: order.seller_id,
+      seller_type: order.seller_type,
+      state: order.state,
+      state_reason: order.state_reason,
+      state_expires_at: order.state_expires_at,
+      updated_at: order.updated_at,
+      last_offer: last_offer_details(order)
+    }
+  end
+
+  def last_offer_details(order)
+    return unless order.last_offer
+
+    {
+      id: last_offer.id,
+      amount_cents: last_offer.amount_cents,
+      from_participant: last_offer.from_participant,
     }
   end
 

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -57,7 +57,7 @@ class TransactionEvent < Events::BaseEvent
     {
       id: last_offer.id,
       amount_cents: last_offer.amount_cents,
-      from_participant: last_offer.from_participant,
+      from_participant: last_offer.from_participant
     }
   end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -26,7 +26,8 @@ class Transaction < ApplicationRecord
     {
       id: id,
       failure_code: failure_code,
-      failure_message: failure_message
+      failure_message: failure_message,
+      decline_code: decline_code
     }
   end
 end

--- a/db/migrate/20190319164840_add_decline_code_to_transactions.rb
+++ b/db/migrate/20190319164840_add_decline_code_to_transactions.rb
@@ -1,4 +1,5 @@
 class AddDeclineCodeToTransactions < ActiveRecord::Migration[5.2]
+  # decline_code is returned from stripe when a transaction is declined. It contains the reason for the card decline (i.e. insufficient_funds). 
   def change
     add_column :transactions, :decline_code, :string
   end

--- a/db/migrate/20190319164840_add_decline_code_to_transactions.rb
+++ b/db/migrate/20190319164840_add_decline_code_to_transactions.rb
@@ -1,0 +1,5 @@
+class AddDeclineCodeToTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transactions, :decline_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_11_132730) do
+ActiveRecord::Schema.define(version: 2019_03_19_164840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 2019_03_11_132730) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "transaction_type"
+    t.string "decline_code"
     t.index ["order_id"], name: "index_transactions_on_order_id"
   end
 

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -51,6 +51,7 @@ module PaymentService
       amount_cents: buyer_amount,
       failure_code: body[:code],
       failure_message: body[:message],
+      decline_code: body[:decline_code],
       transaction_type: type,
       status: Transaction::FAILURE
     )

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -236,6 +236,7 @@ describe OrderProcessor, type: :services do
         expect { order_processor.charge! }.to raise_error do |e|
           expect(e).to be_kind_of(Errors::FailedTransactionError)
           expect(e.transaction.failure_code).to eq 'card_declined'
+          expect(e.transaction.decline_code).to eq 'do_not_honor'
         end
       end
     end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -18,6 +18,7 @@ describe OrderApproveService, type: :services do
         expect(order.transactions.first.status).to eq Transaction::FAILURE
         expect(order.transactions.first.failure_code).to eq 'card_declined'
         expect(order.transactions.first.failure_message).to eq 'The card was declined'
+        expect(order.transactions.first.decline_code).to eq 'do_not_honor'
       end
 
       it 'keeps order in submitted state' do

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -31,6 +31,7 @@ describe PaymentService, type: :services do
       expect(transaction.transaction_type).to eq Transaction::HOLD
       expect(transaction.failure_code).to be_nil
       expect(transaction.failure_message).to be_nil
+      expect(transaction.decline_code).to be_nil
     end
     it 'catches Stripe errors and returns a failed transaction' do
       StripeMock.prepare_card_error(:card_declined, :new_charge)
@@ -40,6 +41,7 @@ describe PaymentService, type: :services do
       expect(transaction.destination_id).to eq 'ma-1'
       expect(transaction.failure_code).to eq 'card_declined'
       expect(transaction.failure_message).to eq 'The card was declined'
+      expect(transaction.decline_code).to eq 'do_not_honor'
       expect(transaction.transaction_type).to eq Transaction::HOLD
       expect(transaction.status).to eq Transaction::FAILURE
     end
@@ -58,6 +60,7 @@ describe PaymentService, type: :services do
       expect(transaction.external_id).to eq uncaptured_charge.id
       expect(transaction.failure_code).to eq 'card_declined'
       expect(transaction.failure_message).to eq 'The card was declined'
+      expect(transaction.decline_code).to eq 'do_not_honor'
       expect(transaction.transaction_type).to eq Transaction::CAPTURE
       expect(transaction.status).to eq Transaction::FAILURE
     end


### PR DESCRIPTION
When a charge fails, we’re not currently capturing the decline_code from Stripe. We need this data so we can distinguish between a charge failing due to insufficient_funds vs. other failures, like do_not_honor.

See https://stripe.com/docs/declines/codes for examples.

We’ll want to store this information on a Transaction in exchange, and expose it through the mutation payload and in TransactionEvent.