### PR TITLE
Post events when requested on ApplicationError

### DIFF
--- a/app/controllers/errors/application_error.rb
+++ b/app/controllers/errors/application_error.rb
@@ -1,13 +1,21 @@
 module Errors
   class ApplicationError < StandardError
     attr_reader :type, :code, :data
-    def initialize(type, code, data = nil)
+    def initialize(type, code, data = nil, post_event = false)
       raise "Invalid type: #{type} or #{code}. Make sure to add/reuse codes in error_types.rb" unless ERROR_TYPES[type].include?(code)
 
       @type = type
       @code = code
       @data = data
+      post_error_event if post_event
       super(type)
+    end
+
+    private
+
+    def post_error_event
+      event = ApplicationErrorEvent.new(self)
+      PostEventJob.perform_later(ApplicationErrorEvent::TOPIC, event.to_json, event.routing_key)
     end
   end
 end

--- a/app/controllers/errors/processing_error.rb
+++ b/app/controllers/errors/processing_error.rb
@@ -1,7 +1,7 @@
 module Errors
   class ProcessingError < ApplicationError
-    def initialize(code, data = nil)
-      super(:processing, code, data)
+    def initialize(code, data = nil, post_event = false)
+      super(:processing, code, data, post_event)
     end
   end
 end

--- a/app/controllers/errors/validation_error.rb
+++ b/app/controllers/errors/validation_error.rb
@@ -1,7 +1,7 @@
 module Errors
   class ValidationError < ApplicationError
-    def initialize(code, data = nil)
-      super(:validation, code, data)
+    def initialize(code, data = nil, post_event = false)
+      super(:validation, code, data, post_event)
     end
   end
 end

--- a/app/events/application_error_event.rb
+++ b/app/events/application_error_event.rb
@@ -1,20 +1,30 @@
 class ApplicationErrorEvent < Events::BaseEvent
   TOPIC = 'commerce'.freeze
+  ACTIONS = [
+    RAISED = 'raised'.freeze
+  ].freeze
 
   def initialize(application_error)
-    @application_error = application_error
+    super(user: nil, action: RAISED, model: application_error)
   end
 
-  def to_json
+  def object
     {
-      type: @application_error.type,
-      code: @application_error.code,
+      id: @object.class,
+      display: @object.to_s
+    }
+  end
+
+  def properties
+    {
+      type: @object.type,
+      code: @object.code,
       created_at: Time.now.utc,
-      data: @application_error.data
-    }.to_json
+      data: @object.data
+    }
   end
 
   def routing_key
-    "error.#{@application_error.type}.#{@application_error.code}"
+    "error.#{@object.type}.#{@object.code}"
   end
 end

--- a/app/events/application_error_event.rb
+++ b/app/events/application_error_event.rb
@@ -1,0 +1,20 @@
+class ApplicationErrorEvent < Events::BaseEvent
+  TOPIC = 'commerce'.freeze
+
+  def initialize(application_error)
+    @application_error = application_error
+  end
+
+  def to_json
+    {
+      type: @application_error.type,
+      code: @application_error.code,
+      created_at: Time.now.utc,
+      data: @application_error.data
+    }.to_json
+  end
+
+  def routing_key
+    "error.#{@application_error.type}.#{@application_error.code}"
+  end
+end

--- a/lib/line_item_totals.rb
+++ b/lib/line_item_totals.rb
@@ -41,7 +41,7 @@ class LineItemTotals
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
     end
   rescue Errors::ValidationError => e
-    raise Errors::ValidationError.new(e.code, { order_id: order.id, seller_id: order.seller_id }, true) unless e.code == :no_taxable_addresses
+    raise Errors::ValidationError.new(e.code, { order_id: @order.id, seller_id: @order.seller_id, line_item_id: @line_item_id, artwork_id: @line_item.artwork_id }, true) unless e.code == :no_taxable_addresses
 
     # If there are no taxable addresses then we set the sales tax to 0.
     OpenStruct.new(tax_total_cents: 0, should_remit_sales_tax: false)

--- a/lib/line_item_totals.rb
+++ b/lib/line_item_totals.rb
@@ -41,7 +41,7 @@ class LineItemTotals
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
     end
   rescue Errors::ValidationError => e
-    raise e unless e.code == :no_taxable_addresses
+    raise Errors::ValidationError.new(e.code, { order_id: order.id, seller_id: order.seller_id }, true) unless e.code == :no_taxable_addresses
 
     # If there are no taxable addresses then we set the sales tax to 0.
     OpenStruct.new(tax_total_cents: 0, should_remit_sales_tax: false)

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -213,6 +213,7 @@ describe Api::GraphqlController, type: :request do
               expect(response.data.set_shipping.order_or_error).to respond_to(:error)
               expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
               expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
+              expect(response.data.set_shipping.order_or_error.error.data).to include order.id
             end
           end
           context 'without a postal code' do

--- a/spec/controllers/errors/application_error_spec.rb
+++ b/spec/controllers/errors/application_error_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Errors::ApplicationError do
+  describe 'post_error_event' do
+    it 'posts application_error_event when asked for' do
+      Errors::ApplicationError.new(:validation, :missing_region, { what_was_invalid: 'everything!' }, true)
+      expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'error.validation.missing_region')
+    end
+    it 'wont post application_error_event by default' do
+      Errors::ApplicationError.new(:validation, :missing_region, what_was_invalid: 'everything!')
+      expect(PostEventJob).not_to have_been_enqueued
+    end
+    it 'wont post application_error_event when not requested' do
+      Errors::ApplicationError.new(:validation, :missing_region, { what_was_invalid: 'everything!' }, false)
+      expect(PostEventJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/events/applicaiton_error_event_spec.rb
+++ b/spec/events/applicaiton_error_event_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ApplicationErrorEvent, type: :events do
+  let(:application_error) { Errors::ApplicationError.new(:validation, :missing_region, { something: 'was wrong' }, true) }
+  let(:event) { ApplicationErrorEvent.new(application_error) }
+  describe 'TOPIC' do
+    it 'has correct topic' do
+      expect(ApplicationErrorEvent::TOPIC).to eq 'commerce'
+    end
+  end
+  describe 'to_json' do
+    let(:parsed_json) { JSON.parse(event.to_json) }
+    it 'has correct type' do
+      expect(parsed_json['type']).to eq 'validation'
+    end
+    it 'has correct code' do
+      expect(parsed_json['code']).to eq 'missing_region'
+    end
+    it 'has correct data' do
+      expect(parsed_json['data']).to eq('something' => 'was wrong')
+    end
+    it 'has created_at' do
+      expect(parsed_json['created_at']).not_to be_nil
+    end
+  end
+  describe 'routing_key' do
+    it 'has correct routing key' do
+      expect(event.routing_key).to eq 'error.validation.missing_region'
+    end
+  end
+end

--- a/spec/events/applicaiton_error_event_spec.rb
+++ b/spec/events/applicaiton_error_event_spec.rb
@@ -3,26 +3,33 @@ require 'rails_helper'
 describe ApplicationErrorEvent, type: :events do
   let(:application_error) { Errors::ApplicationError.new(:validation, :missing_region, { something: 'was wrong' }, true) }
   let(:event) { ApplicationErrorEvent.new(application_error) }
+
   describe 'TOPIC' do
     it 'has correct topic' do
       expect(ApplicationErrorEvent::TOPIC).to eq 'commerce'
     end
   end
+
   describe 'to_json' do
     let(:parsed_json) { JSON.parse(event.to_json) }
+
     it 'has correct type' do
       expect(parsed_json['properties']['type']).to eq 'validation'
     end
+
     it 'has correct code' do
       expect(parsed_json['properties']['code']).to eq 'missing_region'
     end
+
     it 'has correct data' do
       expect(parsed_json['properties']['data']).to eq('something' => 'was wrong')
     end
+
     it 'has created_at' do
       expect(parsed_json['properties']['created_at']).not_to be_nil
     end
   end
+
   describe 'routing_key' do
     it 'has correct routing key' do
       expect(event.routing_key).to eq 'error.validation.missing_region'

--- a/spec/events/applicaiton_error_event_spec.rb
+++ b/spec/events/applicaiton_error_event_spec.rb
@@ -11,16 +11,16 @@ describe ApplicationErrorEvent, type: :events do
   describe 'to_json' do
     let(:parsed_json) { JSON.parse(event.to_json) }
     it 'has correct type' do
-      expect(parsed_json['type']).to eq 'validation'
+      expect(parsed_json['properties']['type']).to eq 'validation'
     end
     it 'has correct code' do
-      expect(parsed_json['code']).to eq 'missing_region'
+      expect(parsed_json['properties']['code']).to eq 'missing_region'
     end
     it 'has correct data' do
-      expect(parsed_json['data']).to eq('something' => 'was wrong')
+      expect(parsed_json['properties']['data']).to eq('something' => 'was wrong')
     end
     it 'has created_at' do
-      expect(parsed_json['created_at']).not_to be_nil
+      expect(parsed_json['properties']['created_at']).not_to be_nil
     end
   end
   describe 'routing_key' do


### PR DESCRIPTION
# Problem
We want to get notified on slack when some special errors happened in Exchange. Mainly things that are actionable like when partner address is invalid.

# Solution
Add new `ApplicationErrorEvent` and add optional `post_event` param to exception initialize which by default is `false`. When it's set to true we post a newly added `ApplicaitonErrorEvent`.

This new event follows are existing pattern of `object`, `subject`, `verb` and `properties` but `subject` is always `nil`.

# When we are posting this event?
Currently we only request to post this event on address verification errors, but talked to @sweir27 about opening it up to all validation errors.