### PR TITLE
Follow up on error events

### DIFF
--- a/lib/line_item_totals.rb
+++ b/lib/line_item_totals.rb
@@ -41,7 +41,7 @@ class LineItemTotals
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
     end
   rescue Errors::ValidationError => e
-    raise Errors::ValidationError.new(e.code, { order_id: @order.id, seller_id: @order.seller_id, line_item_id: @line_item_id, artwork_id: @line_item.artwork_id }, true) unless e.code == :no_taxable_addresses
+    raise Errors::ValidationError.new(e.code, { order_id: @order.id, seller_id: @order.seller_id, line_item_id: @line_item.id, artwork_id: @line_item.artwork_id }, true) unless e.code == :no_taxable_addresses
 
     # If there are no taxable addresses then we set the sales tax to 0.
     OpenStruct.new(tax_total_cents: 0, should_remit_sales_tax: false)

--- a/lib/offer_totals.rb
+++ b/lib/offer_totals.rb
@@ -45,7 +45,7 @@ class OfferTotals
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)
     end
   rescue Errors::ValidationError => e
-    raise e unless e.code == :no_taxable_addresses
+    raise raise Errors::ValidationError.new(e.code, { order_id: @order.id, seller_id: @order.seller_id, artwork_ids: @order.line_items.map(&:artwork_id).join(',') }, true) unless e.code == :no_taxable_addresses
 
     # If there are no taxable addresses then we set the sales tax to 0.
     OpenStruct.new(tax_total_cents: 0, should_remit_sales_tax: false)

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -214,6 +214,7 @@ describe Api::GraphqlController, type: :request do
               expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
               expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_region'
               expect(response.data.set_shipping.order_or_error.error.data).to include order.id
+              expect(response.data.set_shipping.order_or_error.error.data).to include 'a-1'
             end
           end
           context 'without a postal code' do


### PR DESCRIPTION
# Problem
When we did #400 , we missed posting similar events during offer submission.

# Change
This PR adds the missing part from ☝️ also fixed wrong `line_item` id posted in data.