### PR TITLE
#coordinate-deploy Only pass valid addresses to taxjar #DONOTMERGE

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -156,7 +156,7 @@ ActiveAdmin.register Order do
       if partner_info.present?
         valid_partner_location = true
         begin
-          partner_locations = Gravity.fetch_partner_locations(order.seller_id, false)
+          partner_locations = Gravity.fetch_partner_locations(order.seller_id)
         rescue Errors::ValidationError
           valid_partner_location = false
         end

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -156,7 +156,7 @@ ActiveAdmin.register Order do
       if partner_info.present?
         valid_partner_location = true
         begin
-          partner_locations = Gravity.fetch_partner_locations(order.seller_id)
+          partner_locations = Gravity.fetch_partner_locations(order.seller_id, false)
         rescue Errors::ValidationError
           valid_partner_location = false
         end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -7,7 +7,7 @@ class RecordSalesTaxJob < ApplicationJob
 
     artwork = Gravity.get_artwork(line_item.artwork_id)
     artwork_address = Address.new(artwork[:location])
-    seller_addresses = Gravity.fetch_partner_locations(line_item.order.seller_id)
+    seller_addresses = Gravity.fetch_partner_locations(line_item.order.seller_id, tax_only: true)
     service = Tax::CollectionService.new(line_item, artwork_address, seller_addresses)
     service.record_tax_collected
     line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id) if service.transaction.present?

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -33,8 +33,10 @@ module Gravity
     nil
   end
 
-  def self.fetch_partner_locations(partner_id)
-    locations = Adapters::GravityV1.get("/partner/#{partner_id}/locations?private=true")
+  def self.fetch_partner_locations(partner_id, tax_valid = true)
+    query = "/partner/#{partner_id}/locations?private=true"
+    query += '&address_type[]=Business&address_type[]=Sales tax nexus' if tax_valid
+    locations = Adapters::GravityV1.get(query)
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?
 
     locations.map { |loc| Address.new(loc) }

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -33,10 +33,11 @@ module Gravity
     nil
   end
 
-  def self.fetch_partner_locations(partner_id, tax_valid = true)
-    query = "/partner/#{partner_id}/locations?private=true"
-    query += '&address_type[]=Business&address_type[]=Sales tax nexus' if tax_valid
-    locations = Adapters::GravityV1.get(query)
+  def self.fetch_partner_locations(partner_id, tax_only: false)
+    query = "/partner/#{partner_id}/locations"
+    params = { private: true }
+    params = params.merge(address_type: ['Business', 'Sales tax nexus']) if tax_only
+    locations = Adapters::GravityV1.get(query, params: params)
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?
 
     locations.map { |loc| Address.new(loc) }

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -34,10 +34,10 @@ module Gravity
   end
 
   def self.fetch_partner_locations(partner_id, tax_only: false)
-    query = "/partner/#{partner_id}/locations"
+    url = "/partner/#{partner_id}/locations"
     params = { private: true }
     params = params.merge(address_type: ['Business', 'Sales tax nexus']) if tax_only
-    locations = Adapters::GravityV1.get(query, params: params)
+    locations = Adapters::GravityV1.get(url, params: params)
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?
 
     locations.map { |loc| Address.new(loc) }

--- a/lib/order_helper.rb
+++ b/lib/order_helper.rb
@@ -28,7 +28,7 @@ module OrderHelper
   end
 
   def seller_locations
-    @seller_locations ||= Gravity.fetch_partner_locations(seller_id)
+    @seller_locations ||= Gravity.fetch_partner_locations(seller_id, tax_only: true)
   end
 
   def inventory?

--- a/spec/controllers/api/requests/offers/buyer_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_counter_offer_mutation_request_spec.rb
@@ -84,7 +84,7 @@ describe Api::GraphqlController, type: :request do
     before do
       order.update!(last_offer: seller_offer)
 
-      allow(Gravity).to receive(:fetch_partner_locations).with(order_seller_id).and_return([partner_address])
+      allow(Gravity).to receive(:fetch_partner_locations).with(order_seller_id, tax_only: true).and_return([partner_address])
       allow(Gravity).to receive(:get_artwork).and_return(artwork)
       allow(Taxjar::Client).to receive(:new).with(api_key: Rails.application.config_for(:taxjar)['taxjar_api_key'], api_url: nil).and_return(taxjar_client)
       allow(taxjar_client).to receive(:tax_for_order).with(any_args).and_return(tax_response)

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -163,7 +163,7 @@ describe Api::GraphqlController, type: :request do
         context 'with no partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -175,7 +175,7 @@ describe Api::GraphqlController, type: :request do
         context 'with untaxable partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -188,7 +188,7 @@ describe Api::GraphqlController, type: :request do
           let(:shipping_country) { 'ASDF' }
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -201,7 +201,7 @@ describe Api::GraphqlController, type: :request do
         context 'with a US-based shipping address' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -163,7 +163,7 @@ describe Api::GraphqlController, type: :request do
         context 'with no partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -175,7 +175,7 @@ describe Api::GraphqlController, type: :request do
         context 'with untaxable partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -188,7 +188,7 @@ describe Api::GraphqlController, type: :request do
           let(:shipping_country) { 'ASDF' }
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -201,7 +201,7 @@ describe Api::GraphqlController, type: :request do
         context 'with a US-based shipping address' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -76,7 +76,7 @@ describe Api::GraphqlController, type: :request do
     before do
       order.update!(last_offer: offer)
 
-      allow(Gravity).to receive(:fetch_partner_locations).with(order_seller_id).and_return([partner_address])
+      allow(Gravity).to receive(:fetch_partner_locations).with(order_seller_id, tax_only: true).and_return([partner_address])
       allow(Gravity).to receive_messages(
         get_artwork: artwork,
         fetch_partner: partner

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -159,7 +159,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -172,7 +172,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -189,7 +189,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -203,7 +203,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do
@@ -231,7 +231,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with artwork with missing location' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
@@ -241,7 +241,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with failed artwork fetch call' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -159,7 +159,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -172,7 +172,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -189,7 +189,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -203,7 +203,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do
@@ -231,7 +231,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with artwork with missing location' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
@@ -241,7 +241,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with failed artwork fetch call' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -22,7 +22,7 @@ describe RecordSalesTaxJob, type: :job do
     context 'with an order that has sales tax to remit' do
       it 'posts a transaction to TaxJar and saves the transaction id' do
         expect(Gravity).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
-        expect(Gravity).to receive(:fetch_partner_locations).with(line_item.order.seller_id).and_return(seller_addresses)
+        expect(Gravity).to receive(:fetch_partner_locations).with(line_item.order.seller_id, tax_only: true).and_return(seller_addresses)
         expect(Address).to receive(:new).with(artwork_location).and_return(Address.new(artwork_location))
         RecordSalesTaxJob.perform_now(line_item.id)
         expect(line_item.reload.sales_tax_transaction_id).to eq '123'

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -30,31 +30,31 @@ describe Gravity, type: :services do
     let(:valid_locations) { [{ country: 'US', state: 'NY', postal_code: '12345' }, { country: 'US', state: 'FL', postal_code: '67890' }] }
     let(:invalid_location) { [{ country: 'US', state: 'Floridada' }] }
     context 'calls the correct location Gravity endpoint' do
-      context 'without tax_valid flag' do
+      context 'without tax_only flag' do
         it 'does not filter by address type' do
-          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return(valid_locations)
-          Gravity.fetch_partner_locations(seller_id, false)
+          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true }).and_return(valid_locations)
+          Gravity.fetch_partner_locations(seller_id)
         end
       end
-      context 'with tax_valid flag' do
+      context 'with tax_only flag' do
         it 'filters by address type' do
-          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return(valid_locations)
-          Gravity.fetch_partner_locations(seller_id, true)
+          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { address_type: ['Business', 'Sales tax nexus'], private: true }).and_return(valid_locations)
+          Gravity.fetch_partner_locations(seller_id, tax_only: true)
         end
       end
     end
     context 'with at least one partner location' do
       context 'with valid partner locations' do
         it 'returns new addresses for each location' do
-          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return(valid_locations)
-          partner_addresses = Gravity.fetch_partner_locations(seller_id)
+          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { address_type: ['Business', 'Sales tax nexus'], private: true }).and_return(valid_locations)
+          partner_addresses = Gravity.fetch_partner_locations(seller_id, tax_only: true)
           partner_addresses.each { |ad| expect(ad).to be_a Address }
         end
       end
     end
     context 'with no partner locations' do
       it 'raises error' do
-        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([])
+        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true }).and_return([])
         expect { Gravity.fetch_partner_locations(seller_id) }.to raise_error do |error|
           expect(error).to be_a Errors::ValidationError
           expect(error.code).to eq :missing_partner_location

--- a/spec/lib/order_shipping_spec.rb
+++ b/spec/lib/order_shipping_spec.rb
@@ -11,7 +11,7 @@ describe OrderShipping, type: :services do
   before do
     line_item
     allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
-    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true").and_return([{ country: 'US', state: 'NY' }])
+    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
     allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").and_return(gravity_v1_artwork(_id: artwork_id))
   end
   describe '#pickup!' do

--- a/spec/lib/order_shipping_spec.rb
+++ b/spec/lib/order_shipping_spec.rb
@@ -11,7 +11,7 @@ describe OrderShipping, type: :services do
   before do
     line_item
     allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
-    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations?private=true&address_type[]=Business&address_type[]=Sales tax nexus").and_return([{ country: 'US', state: 'NY' }])
+    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
     allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").and_return(gravity_v1_artwork(_id: artwork_id))
   end
   describe '#pickup!' do


### PR DESCRIPTION
e.g. 'Business' and 'Sales tax nexus'

**#do_not_merge:** we need to validate partner addresses before merging this

Depends on https://github.com/artsy/gravity/pull/12274

Fixes [GALL-1453](https://artsyproduct.atlassian.net/browse/GALL-1453)