### PR TITLE
Set up Prettier Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'taxjar-ruby', require: 'taxjar'
 group :development, :test do
   gem 'byebug'
   gem 'graphlient'
+  gem 'prettier', git: 'https://github.com/prettier/plugin-ruby.git'
   gem 'rspec-rails'
   gem 'rubocop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ group :development, :test do
   gem 'graphlient'
   gem 'prettier', git: 'https://github.com/prettier/plugin-ruby.git'
   gem 'rspec-rails'
-  gem 'rubocop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,6 @@ GEM
       rails (>= 4.2.0)
     artsy-eventservice (1.0.9)
       bunny
-    ast (2.4.0)
     builder (3.2.3)
     bunny (2.13.0)
       amq-protocol (~> 2.3, >= 2.3.0)
@@ -182,7 +181,6 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
-    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -254,11 +252,7 @@ GEM
     paper_trail (10.0.1)
       activerecord (>= 4.2, < 5.3)
       request_store (~> 1.1)
-    parallel (1.12.1)
-    parser (2.5.1.2)
-      ast (~> 2.4.0)
     pg (1.1.3)
-    powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -290,7 +284,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rainbow (3.0.0)
     rake (12.3.1)
     ransack (2.0.1)
       actionpack (>= 5.0)
@@ -324,15 +317,6 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.59.2)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
@@ -430,7 +414,6 @@ DEPENDENCIES
   puma
   rails (= 5.2.1)
   rspec-rails
-  rubocop
   selenium-webdriver
   sentry-raven
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/prettier/plugin-ruby.git
+  revision: be6683d467791f4fd629da7086703a6c905ff737
+  specs:
+    prettier (0.12.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -420,6 +426,7 @@ DEPENDENCIES
   omniauth-artsy (~> 0.2.3)
   paper_trail
   pg
+  prettier!
   puma
   rails (= 5.2.1)
   rspec-rails
@@ -437,4 +444,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ services:
 foreman start -f Procfile.dev
 ```
 
+## Running Prettier Ruby
+
+Exchange uses [Prettier Ruby](https://github.com/prettier/plugin-ruby) to standarize coding styles. In order to run
+Prettier, a Node.js runtime needs to be available locally. You could so do by running the `prettier:isntall` task:
+
+```sh
+bundle exec rake prettier:install
+```
+
+Once this is done, you should be able to run the `prettier` task:
+
+```sh
+bundle exec rake prettier
+```
+
 ## Did You Change Models?
 
 ### Papertrail Audit Logging

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require_relative 'config/application'
 require 'graphql/rake_task'
 require 'coveralls/rake/task'
+require 'prettier/rake/task'
 
 Rails.application.load_tasks
 Coveralls::RakeTask.new
@@ -14,4 +15,17 @@ if %w[development test].include? Rails.env
 
   Rake::Task[:default].clear
   task default: %i[graphql:schema:diff_check rubocop spec coveralls:push]
+end
+
+Prettier::Rake::Task.new do |t|
+  t.source_files = '{app,config,lib,spec}/**/*.rb'
+end
+
+namespace :prettier do
+  desc 'Download JavaScript dependencies for Prettier'
+  task :install do
+    chdir Gem.loaded_specs['prettier'].full_gem_path do
+      sh 'yarn && yarn build'
+    end
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,12 +9,8 @@ Coveralls::RakeTask.new
 GraphQL::RakeTask.new(schema_name: 'ExchangeSchema', idl_outfile: '_schema.graphql')
 
 if %w[development test].include? Rails.env
-  require 'rubocop/rake_task'
-  desc 'Run RuboCop'
-  RuboCop::RakeTask.new(:rubocop)
-
   Rake::Task[:default].clear
-  task default: %i[graphql:schema:diff_check rubocop spec coveralls:push]
+  task default: %i[graphql:schema:diff_check spec coveralls:push]
 end
 
 Prettier::Rake::Task.new do |t|

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,9 +1,7 @@
 module PaperTrail
-  # rubocop:disable Rails/ApplicationRecord
   class Version < ActiveRecord::Base
     include PaperTrail::VersionConcern
 
     self.abstract_class = true
   end
-  # rubocop:enable Rails/ApplicationRecord
 end

--- a/config/initializers/datadog_statsd.rb
+++ b/config/initializers/datadog_statsd.rb
@@ -3,7 +3,7 @@ module Datadog
     attr_accessor :disabled
 
     def send_to_socket(message)
-      print message # rubocop:disable Rails/Output
+      print message
       super unless disabled
     end
   end


### PR DESCRIPTION
This PR sets up the Prettier Ruby plugin in Exchange. Since #390 the plugin has evolved and now we can simply use the rake tasks below to run Prettier:

```
bundle exec rake prettier:install prettier
```

(`rake prettier:install` needs to be run only once)

While this feels more natural in the Ruby world, it also comes with a catch - right now a whole Node.js runtime needs to be downloaded in order to run the `prettier` rake task. It might make sense to add an option to the upstream of the Ruby plugin so that it'll use a locally available runtime if the user doesn't mind having Node.js as a dependency.

## To-dos

 * [x] Remove Rubocop
 * [ ] Figure out a way to run Prettier without having to download the whole Node.js runtime

cc @kddeisz