### PR TITLE
#FF Add clc_assisted to Orders and to admin

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -77,7 +77,7 @@ ActiveAdmin.register Order do
 
   member_action :toggle_assisted, method: :post do
     resource.toggle!(:assisted)
-    redirect_to resource_path, notice: "toggled CLC assisted flag!"
+    redirect_to resource_path, notice: "toggled assisted flag!"
   end
 
   action_item :refund, only: :show do
@@ -119,7 +119,7 @@ ActiveAdmin.register Order do
 
   action_item :toggle_assisted_flag, only: :show do
     if order.state != Order::PENDING
-      link_to 'Toggle CLC', toggle_assisted_admin_order_path(order), method: :post
+      link_to 'Toggle Assisted', toggle_assisted_admin_order_path(order), method: :post
     end
   end
 

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -22,6 +22,7 @@ ActiveAdmin.register Order do
   filter :state, as: :check_boxes, collection: proc { Order::STATES }
   filter :state_reason, as: :check_boxes, collection: proc { Order::REASONS.values.map(&:values).flatten.uniq.map!(&:humanize) }
   filter :has_offer_note , as: :check_boxes, label: 'Has Offer Note'
+  filter :clc_assisted
 
   index do
     column :code do |order|
@@ -74,6 +75,11 @@ ActiveAdmin.register Order do
     redirect_to resource_path, notice: "Fulfillment confirmed!"
   end
 
+  member_action :toggle_clc_assisted, method: :post do
+    resource.toggle!(:clc_assited)
+    redirect_to resource_path, notice: "toggled CLC assisted flag!"
+  end
+
   action_item :refund, only: :show do
     if [Order::APPROVED, Order::FULFILLED].include? order.state
       link_to 'Refund', refund_admin_order_path(order), method: :post, data: {confirm: 'Are you sure you want to refund this order?'}
@@ -108,6 +114,12 @@ ActiveAdmin.register Order do
   action_item :confirm_fulfillment, only: :show do
     if order.state == Order::APPROVED && order.fulfillment_type == Order::SHIP
       link_to 'Confirm Fulfillment', confirm_fulfillment_admin_order_path(order), method: :post, data: {confirm: 'Confirm order fulfillment?'}
+    end
+  end
+
+  action_item :toggle_clc_flag, only: :show do
+    if order.state != Order::PENDING
+      link_to 'Toggle CLC', toggle_clc_assisted_admin_order_path(order), method: :post
     end
   end
 

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register Order do
   filter :state, as: :check_boxes, collection: proc { Order::STATES }
   filter :state_reason, as: :check_boxes, collection: proc { Order::REASONS.values.map(&:values).flatten.uniq.map!(&:humanize) }
   filter :has_offer_note , as: :check_boxes, label: 'Has Offer Note'
-  filter :clc_assisted
+  filter :assisted
 
   index do
     column :code do |order|
@@ -75,8 +75,8 @@ ActiveAdmin.register Order do
     redirect_to resource_path, notice: "Fulfillment confirmed!"
   end
 
-  member_action :toggle_clc_assisted, method: :post do
-    resource.toggle!(:clc_assited)
+  member_action :toggle_assisted, method: :post do
+    resource.toggle!(:assisted)
     redirect_to resource_path, notice: "toggled CLC assisted flag!"
   end
 
@@ -117,9 +117,9 @@ ActiveAdmin.register Order do
     end
   end
 
-  action_item :toggle_clc_flag, only: :show do
+  action_item :toggle_assisted_flag, only: :show do
     if order.state != Order::PENDING
-      link_to 'Toggle CLC', toggle_clc_assisted_admin_order_path(order), method: :post
+      link_to 'Toggle CLC', toggle_assisted_admin_order_path(order), method: :post
     end
   end
 
@@ -244,6 +244,7 @@ ActiveAdmin.register Order do
             last_admin_note.note_type.humanize
           end
         end
+        row :assisted
         row 'Last note' do |order|
           if last_admin_note.present?
             last_admin_note.description

--- a/db/migrate/20190530201701_add_clc_assisted_to_order.rb
+++ b/db/migrate/20190530201701_add_clc_assisted_to_order.rb
@@ -1,0 +1,5 @@
+class AddClcAssistedToOrder < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :clc_assisted, :boolean
+  end
+end

--- a/db/migrate/20190530201701_add_clc_assisted_to_order.rb
+++ b/db/migrate/20190530201701_add_clc_assisted_to_order.rb
@@ -1,4 +1,4 @@
-class AddClcAssistedToOrder < ActiveRecord::Migration[5.2]
+class AddAssistedToOrder < ActiveRecord::Migration[5.2]
   def change
     add_column :orders, :assisted, :boolean
   end

--- a/db/migrate/20190530201701_add_clc_assisted_to_order.rb
+++ b/db/migrate/20190530201701_add_clc_assisted_to_order.rb
@@ -1,5 +1,5 @@
 class AddClcAssistedToOrder < ActiveRecord::Migration[5.2]
   def change
-    add_column :orders, :clc_assisted, :boolean
+    add_column :orders, :assisted, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_19_164840) do
+ActiveRecord::Schema.define(version: 2019_05_30_201701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 2019_03_19_164840) do
     t.string "original_user_agent"
     t.string "original_user_ip"
     t.string "payment_method", null: false
+    t.boolean "assisted"
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["last_offer_id"], name: "index_orders_on_last_offer_id"


### PR DESCRIPTION
# Problem
When CRT assists a buyer during checkout, they often mention in slack that this order was created with CLC's help. 
This information seems to be important to them but currently lost in Slack.

https://artsyproduct.atlassian.net/browse/PURCHASE-1147

# Solution
Add a `clc_assisted` flag to `Order` and allow to toggle it from the admin UI.

# Selfie

![Screen Shot 2019-05-31 at 8 33 33 AM](https://user-images.githubusercontent.com/1230819/58706141-2ec10e00-837f-11e9-88a3-15ef9766ed43.png)


![Screen Shot 2019-05-31 at 8 33 42 AM](https://user-images.githubusercontent.com/1230819/58706154-341e5880-837f-11e9-8e35-20f4ef9f8149.png)

