### PR TITLE
PURCHASE-1137: Fix storing source instead of source.id in transaction.source_id

### DIFF
--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -30,7 +30,7 @@ module PaymentService
   def self.capture_authorized_charge(charge_id)
     charge = Stripe::Charge.retrieve(charge_id)
     charge.capture
-    Transaction.new(external_id: charge.id, source_id: charge.source, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
+    Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
     generate_transaction_from_exception(e, Transaction::CAPTURE, charge_id: charge_id)
   end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -52,6 +52,7 @@ describe PaymentService, type: :services do
       transaction = PaymentService.capture_authorized_charge(uncaptured_charge.id)
       expect(transaction.amount_cents).to eq(uncaptured_charge.amount)
       expect(transaction.transaction_type).to eq Transaction::CAPTURE
+      expect(transaction.source_id).to eq 'test_cc_2'
       expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and returns a failed transaction' do


### PR DESCRIPTION
# Problem (not the biggest problem on earth, but still a problem)
During adding #412 noticed that for successful capture transactions, we store the whole `source` coming back from Stripe in `source_id` field of `Transaction`. 
```ruby
 Transaction.where(transaction_type: Transaction::CAPTURE).first.source_id
=> "{\n  \"id\": \"card_1DjZ47GK3Gnpfa3O5rULDzXE\",\n  \"object\": \"card\",\n  \"address_city\": \"Minneapolis\",\n  \"address_country\": \"US\",\n  \"address_line1\": \"3017 Harriet Ave\",\n  \"address_line1_check\": \"pass\",\n  \"address_line2\": \"\",\n  \"address_state\": \"MN\",\n  \"address_zip\": \"55408\",\n  \"address_zip_check\": \"pass\",\n  \"brand\": \"Visa\",\n  \"country\": \"US\",\n  \"customer\": \"cus_E5V2tn9XLAna9Z\",\n  \"cvc_check\": \"pass\",\n  \"dynamic_last4\": null,\n  \"exp_month\": 4,\n  \"exp_year\": 2024,\n  \"fingerprint\": \"AFgZNBWrGj8U4RSj\",\n  \"funding\": \"credit\",\n  \"last4\": \"4242\",\n  \"metadata\": {\n  },\n  \"name\": \"Jonathan Allured\",\n  \"tokenization_method\": null\n}"
```
https://artsyproduct.atlassian.net/browse/PURCHASE-1137

## Impact
```ruby
irb(main):002:0> weird_transactions.count
=> 1795
```

# Cause
https://github.com/artsy/exchange/blob/bef6444cd70ff6d92fcc37cdc85946aeec4ca35f/lib/payment_service.rb#L33

# Solution
Use `source.id` same as https://github.com/artsy/exchange/blob/bef6444cd70ff6d92fcc37cdc85946aeec4ca35f/lib/payment_service.rb#L17

# Migration
Once this gets merged, we can make sure for all new capture transactions we store the correct field we need to fix existing records:
```ruby
weird_transactions = Transaction.where('source_id ilike ?', '%\n%')
weird.transactions.each do |t|
  parsed_source_id_json = JSON.parse(t.source_id)
  t.update!(source_id: parsed_source_id_json["id"])
end
```

# Selfie 

![image](https://user-images.githubusercontent.com/1230819/59035956-5ced9480-883c-11e9-85a7-9ab607dd5b6d.png)

![image](https://user-images.githubusercontent.com/1230819/59036006-7989cc80-883c-11e9-84e1-d7f2b8c874d9.png)

