### PR TITLE
PURCHASE-1138: Adds spec for the single counteroffer happy path scenario

### DIFF
--- a/spec/integration/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/single_counteroffer_happy_path_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
+  include_context 'GraphQL Client Helpers'
+  describe 'make offer happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds in the process of buyer offers -> seller counters -> buyer accepts' do
+      # The first few actions here (up through a buyer submitting an initial offer)
+      # are covered by the assertions in the make_offer_happy_path_spec and aren't repeated here.
+
+      # Buyer creates the offer order
+      buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+
+      order = Order.last
+
+      # adds initial offer to order
+      buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+
+      offer = Offer.last
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+
+      # Buyer submits offer order
+      buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+
+      # Here we start making new assertions, as this is new behavior not tested by any
+      # of our other integration tests.
+
+      # Seller submits counteroffer
+      expect do
+        seller_client.execute(OfferQueryHelper::SELLER_COUNTER_OFFER, input: { offerId: offer.id.to_s, amountCents: 700_00 })
+      end.to change(order.transactions, :count).by(0).and change(order.offers, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 700_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1000_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 70_00,
+        transaction_fee_cents: 29_30,
+        seller_total_cents: 900_70,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+
+      seller_counter = order.offers.order(created_at: :desc).first
+      expect(seller_counter).to have_attributes(
+        amount_cents: 700_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1000_00
+      )
+      expect(seller_counter.submitted_at).to_not be_nil
+
+      # Buyer accepts offer
+      expect do
+        buyer_client.execute(OfferQueryHelper::BUYER_ACCEPT_OFFER, input: { offerId: seller_counter.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 700_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1000_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 70_00,
+        transaction_fee_cents: 29_30,
+        seller_total_cents: 900_70,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 1000_00,
+        status: Transaction::SUCCESS,
+        source_id: a_string_starting_with('test_')
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -1,4 +1,4 @@
-module OfferQueryHelper
+module OfferQueryHelper # rubocop:disable Metrics/ModuleLength
   CREATE_OFFER_ORDER = %(
     mutation($input: CreateOfferOrderWithArtworkInput!) {
       createOfferOrderWithArtwork(input: $input) {
@@ -72,6 +72,50 @@ module OfferQueryHelper
   SELLER_ACCEPT_OFFER = %(
     mutation($input: SellerAcceptOfferInput!) {
       sellerAcceptOffer(input: $input) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              id
+              state
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              code
+              data
+              type
+            }
+          }
+        }
+      }
+    }
+  ).freeze
+
+  BUYER_ACCEPT_OFFER = %(
+    mutation($input: BuyerAcceptOfferInput!) {
+      buyerAcceptOffer(input: $input) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              id
+              state
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              code
+              data
+              type
+            }
+          }
+        }
+      }
+    }
+  ).freeze
+
+  SELLER_COUNTER_OFFER = %(
+    mutation($input: SellerCounterOfferInput!) {
+      sellerCounterOffer(input: $input) {
         orderOrError {
           ... on OrderWithMutationSuccess {
             order {


### PR DESCRIPTION
This PR adds a spec for the "happy path" scenario in which:
1. Buyer creates initial offer (and adds shipping, payment, etc.)
2. Seller counters that offer
3. Buyer accepts that offer

Since the first step here (buyer creating the offer) is validated in the "make offer happy path" spec, I had it go through the actions but I didn't repeat the assertions. Happy to revisit if you think I'm losing value here!