### PR TITLE
[PURCHASE-1180] Extend approval expiration to 3 days

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -57,7 +57,7 @@ class Order < ApplicationRecord
 
   STATE_EXPIRATIONS = {
     'pending' => 2.days,
-    'submitted' => 2.days,
+    'submitted' => 3.days,
     'approved' => 7.days
   }.freeze
 

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -214,7 +214,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.reload.state).to eq Order::SUBMITTED
         expect(order.commission_fee_cents).to eq 800_00
         expect(order.state_updated_at).not_to be_nil
-        expect(order.state_expires_at).to eq(order.state_updated_at + 2.days)
+        expect(order.state_expires_at).to eq(order.state_updated_at + 3.days)
         expect(order.reload.transactions.last.external_id).not_to be_nil
         expect(order.reload.transactions.last.transaction_type).to eq Transaction::HOLD
       end

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -133,7 +133,7 @@ describe OfferEvent, type: :events do
           expect(order_prop[:shipping_postal_code]).to eq '60618'
           expect(order_prop[:buyer_phone_number]).to eq '00123459876'
           expect(order_prop[:shipping_region]).to eq 'IL'
-          expect(order_prop[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
+          expect(order_prop[:state_expires_at]).to eq Time.parse('2018-08-19 15:48:00 -0400')
           expect(order_prop[:total_list_price_cents]).to eq(200)
         end
       end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -108,7 +108,7 @@ describe OrderEvent, type: :events do
         expect(event.properties[:shipping_postal_code]).to eq '60618'
         expect(event.properties[:buyer_phone_number]).to eq '00123459876'
         expect(event.properties[:shipping_region]).to eq 'IL'
-        expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-18 15:48:00 -0400')
+        expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-19 15:48:00 -0400')
         expect(event.properties[:total_list_price_cents]).to eq(400)
         expect(event.properties[:last_offer]).to be_nil
       end


### PR DESCRIPTION
# Change
We need to extend approval expiration to 72 hours.
fixes https://artsyproduct.atlassian.net/browse/PURCHASE-1180

# Does this reflect existing pending orders?
No, once deployed to prod, it will impact *only* orders submitted after the deployment, for those order, approval expiration will be 3 days.

# Should this be an env variable?
I thought about it, but I think this is somehow significant enough change that might still be better to go  through PR and code review. For example extending this beyond 7 days will have charge expiration issue. 

# Related PRs
Pulse and Force have been already updated to show expiration based on `stateExpiresAt` and not hardcode in:
https://github.com/artsy/reaction/pull/2571
https://github.com/artsy/pulse/pull/372