### PR TITLE
Update offer expiration to match submitted order expiration

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,7 +1,7 @@
 class Offer < ApplicationRecord
   has_paper_trail versions: { class_name: 'PaperTrail::OfferVersion' }
 
-  EXPIRATION = 2.days.freeze
+  EXPIRATION = 3.days.freeze
 
   belongs_to :order
   belongs_to :responds_to, class_name: 'Offer', optional: true

--- a/spec/controllers/api/requests/offers/submit_order_with_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/submit_order_with_offer_mutation_request_spec.rb
@@ -163,6 +163,7 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.submit_order_with_offer.order_or_error.order.last_offer.id).to eq offer.id
         expect(response.data.submit_order_with_offer.order_or_error.order.last_offer.submitted_at).to_not be_nil
         expect(order.reload.state).to eq Order::SUBMITTED
+        expect(order.state_expires_at > 2.days.from_now).to be true
       end
     end
   end


### PR DESCRIPTION
# Problem
When we tested #430 on staging, looks like buy now orders get proper expiration but for MO we still get 2 days.

# Cause
We had a separate const for offer expiration, this probably originally was designed this way so we can decouple offer and order expirations since offers are less timely. For example, its ok to set expiration on an offer to be 8 days but we can't do that on order since stripe hold will expire.

# Solution
Update offer expiration to 3 days.