### PR TITLE
Remove unused image push during prod deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,5 @@ workflows:
             - push-staging-image
 
       # release
-      - hokusai/push:
-          name: push-production-image
-          <<: *only_release
       - hokusai/deploy-production:
           <<: *only_release
-          requires:
-            - push-production-image


### PR DESCRIPTION
following up on https://github.com/artsy/vibrations/pull/452 and https://artsy.slack.com/archives/CA8SANW3W/p1563195752298200