### PR TITLE
Make GBP a Supported Currency for Orders (GALL-1966)

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,7 +2,7 @@ class Order < ApplicationRecord
   include OrderHelper
   has_paper_trail versions: { class_name: 'PaperTrail::OrderVersion' }
 
-  SUPPORTED_CURRENCIES = %w[USD].freeze
+  SUPPORTED_CURRENCIES = %w[USD GBP].freeze
 
   DEFAULT_EXPIRATION_REMINDER = 5.hours
 

--- a/spec/integration/gbp/buy_now_happy_path_spec.rb
+++ b/spec/integration/gbp/buy_now_happy_path_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock gbp'
+  include_context 'GraphQL Client Helpers'
+  describe 'buy now happy path gbp' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds the process of buyer create -> set shipping -> set payment -> submit -> seller accept' do
+      # Buyer creates the order
+      expect do
+        buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, items_total_cents: 1000_00, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP'
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits order
+      expect do
+        buyer_client.execute(QueryHelper::SUBMIT_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 100_00
+      )
+      expect(order.transactions.last).to have_attributes(
+        transaction_type: Transaction::HOLD,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS,
+        source_id: a_string_starting_with('test_')
+      )
+
+      # seller accepts order
+      expect do
+        seller_client.execute(QueryHelper::APPROVE_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1300_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 100_00,
+        transaction_fee_cents: 38_00,
+        seller_total_cents: 1162_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
+  include_context 'GraphQL Client Helpers'
+  describe 'make offer happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds the process of buyer create -> add initial offer -> set shipping -> set payment -> submit -> seller accepts' do
+      # Buyer creates the offer order
+      expect do
+        buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # adds initial offer to order
+      expect do
+        buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+      end.to change(Offer, :count).by(1)
+      offer = Offer.last
+      expect(order.reload).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+      expect(offer.amount_cents).to eq 500_00
+      expect(offer.order_id).to eq order.id
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: nil,
+        shipping_total_cents: nil,
+        tax_total_cents: nil,
+        buyer_total_cents: nil,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        shipping_city: 'New York',
+        shipping_address_line1: '401 Broadway',
+        shipping_address_line2: 'Suite 80',
+        shipping_postal_code: '10012',
+        currency_code: 'GBP'
+      )
+
+      expect(offer.reload).to have_attributes(
+        amount_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits offer order
+      expect do
+        buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(0)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00,
+        seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 50_00
+      )
+
+      # seller accepts offer
+      expect do
+        seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 800_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 50_00,
+        transaction_fee_cents: 23_50,
+        seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 800_00,
+        status: Transaction::SUCCESS
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -3,27 +3,31 @@ require 'support/gravity_helper'
 require 'support/taxjar_helper'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'use stripe mock gbp'
   include_context 'GraphQL Client Helpers'
-  describe 'make offer happy path' do
+  describe 'make offer happy path gbp' do
     let(:seller_id) { 'gravity-partner-id' }
     let(:buyer_id) { 'user-id1' }
     let(:buyer_shipping_address) do
       {
         name: 'Fname Lname',
-        country: 'US',
-        city: 'New York',
-        region: 'NY',
-        postalCode: '10012',
-        phoneNumber: '617-718-7818',
-        addressLine1: '401 Broadway',
-        addressLine2: 'Suite 80'
+        country: 'GB',
+        city: 'Manchester',
+        region: '',
+        postalCode: 'EF3 4GH',
+        phoneNumber: '+44 12 3456 7890',
+        addressLine1: '1 Test Rd.'
       }
     end
     let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
-    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_artwork) do
+      gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00, location: { country: 'GB',
+                                                                                                                                                                                                city: 'London',
+                                                                                                                                                                                                address: '1 Fake St.',
+                                                                                                                                                                                                postal_code: 'AB1 2CD' })
+    end
     let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
-    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY')] }
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
@@ -66,19 +70,19 @@ describe Api::GraphqlController, type: :request do
         tax_total_cents: nil,
         buyer_total_cents: nil,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
-        shipping_city: 'New York',
-        shipping_address_line1: '401 Broadway',
-        shipping_address_line2: 'Suite 80',
-        shipping_postal_code: '10012',
+        shipping_country: 'GB',
+        shipping_city: 'Manchester',
+        shipping_address_line1: '1 Test Rd.',
+        shipping_address_line2: nil,
+        shipping_postal_code: 'EF3 4GH',
         currency_code: 'GBP'
       )
 
       expect(offer.reload).to have_attributes(
         amount_cents: 500_00,
         shipping_total_cents: 200_00,
-        tax_total_cents: 100_00,
-        buyer_total_cents: 800_00
+        tax_total_cents: 0,
+        buyer_total_cents: 700_00
       )
 
       # Buyer sets credit card
@@ -86,7 +90,7 @@ describe Api::GraphqlController, type: :request do
       expect(order.reload).to have_attributes(
         state: Order::PENDING,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
+        shipping_country: 'GB',
         currency_code: 'GBP',
         credit_card_id: 'cc-1'
       )
@@ -99,11 +103,11 @@ describe Api::GraphqlController, type: :request do
         state: Order::SUBMITTED,
         items_total_cents: 500_00,
         shipping_total_cents: 200_00,
-        tax_total_cents: 100_00,
-        buyer_total_cents: 800_00,
-        seller_total_cents: 726_50,
+        tax_total_cents: 0,
+        buyer_total_cents: 700_00,
+        seller_total_cents: 629_40,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
+        shipping_country: 'GB',
         currency_code: 'GBP',
         credit_card_id: 'cc-1',
         commission_fee_cents: 50_00
@@ -117,19 +121,19 @@ describe Api::GraphqlController, type: :request do
         state: Order::APPROVED,
         items_total_cents: 500_00,
         shipping_total_cents: 200_00,
-        buyer_total_cents: 800_00,
-        tax_total_cents: 100_00,
+        buyer_total_cents: 700_00,
+        tax_total_cents: 0,
         commission_fee_cents: 50_00,
-        transaction_fee_cents: 23_50,
-        seller_total_cents: 726_50,
+        transaction_fee_cents: 20_60,
+        seller_total_cents: 629_40,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
+        shipping_country: 'GB',
         currency_code: 'GBP',
         credit_card_id: 'cc-1'
       )
       expect(order.transactions.order(created_at: :desc).first).to have_attributes(
         transaction_type: Transaction::CAPTURE,
-        amount_cents: 800_00,
+        amount_cents: 700_00,
         status: Transaction::SUCCESS
       )
 

--- a/spec/integration/gbp/reset_shipping_request_spec.rb
+++ b/spec/integration/gbp/reset_shipping_request_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  describe 'set_shipping mutation' do
+    include_context 'GraphQL Client'
+    let(:seller_id) { jwt_partner_ids.first }
+    let(:user_id) { jwt_user_id }
+    let(:order) { Fabricate(:order, seller_id: seller_id, buyer_id: user_id, currency_code: 'GBP') }
+    let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 1000_00, quantity: 1)] }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc' } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+
+    let(:us_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:international_shipping_address) do
+      {
+        name: 'NameF NameL',
+        country: 'IR',
+        city: 'Tehran',
+        region: 'TH',
+        postalCode: '09821',
+        phoneNumber: '0989121324',
+        addressLine1: 'Vanak',
+        addressLine2: 'Suite 81'
+      }
+    end
+    let(:set_shipping_input) do
+      {
+        input: {
+          id: order.id.to_s,
+          fulfillmentType: fulfillment_type,
+          shipping: shipping_address
+        }.compact
+      }
+    end
+
+    before do
+      stub_tax_for_order
+      allow(Gravity).to receive_messages(
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: partner,
+        get_artwork: artwork
+      )
+    end
+
+    describe 'switch from domestic to international shipping' do
+      before do
+        # set shipping to domestic
+        client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: us_shipping_address })
+        expect(order.reload).to have_attributes(
+          shipping_country: 'US',
+          shipping_city: 'New York',
+          shipping_region: 'NY',
+          shipping_postal_code: '10012',
+          buyer_phone_number: '617-718-7818',
+          shipping_name: 'Fname Lname',
+          shipping_address_line1: '401 Broadway',
+          shipping_address_line2: 'Suite 80',
+          shipping_total_cents: 200_00,
+          buyer_total_cents: 1201_16,
+          currency_code: 'GBP'
+        )
+        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: international_shipping_address })
+      end
+      it 'changes shipping info' do
+        expect(order.reload).to have_attributes(
+          shipping_country: 'IR',
+          shipping_city: 'Tehran',
+          shipping_region: 'TH',
+          shipping_postal_code: '09821',
+          buyer_phone_number: '0989121324',
+          shipping_name: 'NameF NameL',
+          shipping_address_line1: 'Vanak',
+          shipping_address_line2: 'Suite 81'
+        )
+      end
+      it 'updates order totals' do
+        expect(order.reload).to have_attributes(shipping_total_cents: 300_00, buyer_total_cents: 1301_16, currency_code: 'GBP')
+      end
+    end
+
+    describe 'switch from ship to pickup' do
+      before do
+        # set shipping to domestic
+        client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: us_shipping_address })
+        expect(order.reload).to have_attributes(
+          shipping_country: 'US',
+          shipping_city: 'New York',
+          shipping_region: 'NY',
+          shipping_postal_code: '10012',
+          buyer_phone_number: '617-718-7818',
+          shipping_name: 'Fname Lname',
+          shipping_address_line1: '401 Broadway',
+          shipping_address_line2: 'Suite 80',
+          shipping_total_cents: 200_00,
+          buyer_total_cents: 1201_16,
+          currency_code: 'GBP'
+        )
+        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP' })
+      end
+      it 'changes shipping info' do
+        expect(order.reload).to have_attributes(
+          fulfillment_type: Order::PICKUP,
+          shipping_country: nil,
+          shipping_city: nil,
+          shipping_region: nil,
+          shipping_postal_code: nil,
+          buyer_phone_number: nil,
+          shipping_name: nil,
+          shipping_address_line1: nil,
+          shipping_address_line2: nil
+        )
+      end
+      it 'updates order totals' do
+        expect(order.reload).to have_attributes(shipping_total_cents: 0, buyer_total_cents: 1001_16, currency_code: 'GBP')
+      end
+    end
+  end
+end

--- a/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'use stripe mock'
+  include_context 'GraphQL Client Helpers'
+  describe 'make offer happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds in the process of buyer offers -> seller counters -> buyer accepts' do
+      # The first few actions here (up through a buyer submitting an initial offer)
+      # are covered by the assertions in the make_offer_happy_path_spec and aren't repeated here.
+
+      # Buyer creates the offer order
+      buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+
+      order = Order.last
+
+      # adds initial offer to order
+      buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+
+      offer = Offer.last
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+
+      # Buyer submits offer order
+      buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+
+      # Here we start making new assertions, as this is new behavior not tested by any
+      # of our other integration tests.
+
+      # Seller submits counteroffer
+      expect do
+        seller_client.execute(OfferQueryHelper::SELLER_COUNTER_OFFER, input: { offerId: offer.id.to_s, amountCents: 700_00 })
+      end.to change(order.transactions, :count).by(0).and change(order.offers, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 700_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1000_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 70_00,
+        transaction_fee_cents: 29_30,
+        seller_total_cents: 900_70,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+
+      seller_counter = order.offers.order(created_at: :desc).first
+      expect(seller_counter).to have_attributes(
+        amount_cents: 700_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1000_00
+      )
+      expect(seller_counter.submitted_at).to_not be_nil
+
+      # Buyer accepts offer
+      expect do
+        buyer_client.execute(OfferQueryHelper::BUYER_ACCEPT_OFFER, input: { offerId: seller_counter.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 700_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1000_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 70_00,
+        transaction_fee_cents: 29_30,
+        seller_total_cents: 900_70,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        currency_code: 'GBP',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 1000_00,
+        status: Transaction::SUCCESS,
+        source_id: a_string_starting_with('test_')
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
@@ -11,19 +11,23 @@ describe Api::GraphqlController, type: :request do
     let(:buyer_shipping_address) do
       {
         name: 'Fname Lname',
-        country: 'US',
-        city: 'New York',
-        region: 'NY',
-        postalCode: '10012',
-        phoneNumber: '617-718-7818',
-        addressLine1: '401 Broadway',
-        addressLine2: 'Suite 80'
+        country: 'GB',
+        city: 'Manchester',
+        region: '',
+        postalCode: 'EF3 4GH',
+        phoneNumber: '+44 12 3456 7890',
+        addressLine1: '1 Test Rd.'
       }
     end
     let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
-    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_artwork) do
+      gravity_v1_artwork(_id: 'a-1', price_currency: 'GBP', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00, location: { country: 'GB',
+                                                                                                                                                                                                city: 'London',
+                                                                                                                                                                                                address: '1 Fake St.',
+                                                                                                                                                                                                postal_code: 'AB1 2CD' })
+    end
     let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
-    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY')] }
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
@@ -74,13 +78,13 @@ describe Api::GraphqlController, type: :request do
         state: Order::SUBMITTED,
         items_total_cents: 700_00,
         shipping_total_cents: 200_00,
-        buyer_total_cents: 1000_00,
-        tax_total_cents: 100_00,
+        buyer_total_cents: 900_00,
+        tax_total_cents: 0,
         commission_fee_cents: 70_00,
-        transaction_fee_cents: 29_30,
-        seller_total_cents: 900_70,
+        transaction_fee_cents: 26_40,
+        seller_total_cents: 803_60,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
+        shipping_country: 'GB',
         currency_code: 'GBP',
         credit_card_id: 'cc-1'
       )
@@ -89,8 +93,8 @@ describe Api::GraphqlController, type: :request do
       expect(seller_counter).to have_attributes(
         amount_cents: 700_00,
         shipping_total_cents: 200_00,
-        tax_total_cents: 100_00,
-        buyer_total_cents: 1000_00
+        tax_total_cents: 0,
+        buyer_total_cents: 900_00
       )
       expect(seller_counter.submitted_at).to_not be_nil
 
@@ -102,19 +106,19 @@ describe Api::GraphqlController, type: :request do
         state: Order::APPROVED,
         items_total_cents: 700_00,
         shipping_total_cents: 200_00,
-        buyer_total_cents: 1000_00,
-        tax_total_cents: 100_00,
+        buyer_total_cents: 900_00,
+        tax_total_cents: 0,
         commission_fee_cents: 70_00,
-        transaction_fee_cents: 29_30,
-        seller_total_cents: 900_70,
+        transaction_fee_cents: 26_40,
+        seller_total_cents: 803_60,
         fulfillment_type: Order::SHIP,
-        shipping_country: 'US',
+        shipping_country: 'GB',
         currency_code: 'GBP',
         credit_card_id: 'cc-1'
       )
       expect(order.transactions.order(created_at: :desc).first).to have_attributes(
         transaction_type: Transaction::CAPTURE,
-        amount_cents: 1000_00,
+        amount_cents: 900_00,
         status: Transaction::SUCCESS,
         source_id: a_string_starting_with('test_')
       )

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Order, type: :model do
 
   describe 'validate currency' do
     it 'raises invalid record for unsupported currencies' do
+      expect { order.update!(currency_code: 'USD') }.to_not raise_error(ActiveRecord::RecordInvalid)
+      expect { order.update!(currency_code: 'GBP') }.to_not raise_error(ActiveRecord::RecordInvalid)
       expect { order.update!(currency_code: 'CAD') }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Currency code is not included in the list')
     end
   end

--- a/spec/support/use_stripe_mock_gbp.rb
+++ b/spec/support/use_stripe_mock_gbp.rb
@@ -1,0 +1,40 @@
+require 'stripe_mock'
+
+RSpec.shared_context 'use stripe mock gbp' do
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  before { StripeMock.start }
+  after { StripeMock.stop }
+  let(:stripe_customer) do
+    Stripe::Customer.create(
+      email: 'someuser@email.co.uk',
+      source: stripe_helper.generate_card_token
+    )
+  end
+  let(:uncaptured_charge) do
+    Stripe::Charge.create(
+      amount: 22_222,
+      currency: 'gbp',
+      source: stripe_helper.generate_card_token,
+      destination: 'ma-1',
+      capture: false
+    )
+  end
+  let(:buyer_amount) { 22_222 }
+  let(:seller_amount) { 10_000 }
+  let(:captured_charge) do
+    Stripe::Charge.create(
+      amount: buyer_amount,
+      currency: 'gbp',
+      source: stripe_helper.generate_card_token,
+      destination: {
+        account: 'ma-1',
+        amount: seller_amount
+      },
+      capture: true
+    )
+  end
+end
+
+RSpec.configure do |rspec|
+  rspec.include_context 'use stripe mock gbp', include_shared: true
+end


### PR DESCRIPTION
This PR adds GBP to the list of supported currencies in Exchange. The list of supported currencies is used to validate the currency of a new order, and without GBP, collectors will not be able to click on the "Buy now" or "Make offer" buttons on Artsy.net to begin the order or offer flow.

#### Problem

![unable to create order](https://user-images.githubusercontent.com/44589599/61394787-f83d4500-a891-11e9-956c-14cf6bdef536.png)

#### Notes

- In order for artworks enrolled in NSO to be listed in GBP, partners need to have access to the `CMS UK Commerce` lab feature, so this change does not pose a risk to existing NSO artworks in production.
- This PR adds "happy path" integration tests for GBP artworks to ensure that orders can be created from GBP artworks and retain the same currency through the order and offer flows. These tests do not, however, use UK addresses for the seller and buyer since more work will be needed to [correctly calculate tax](https://artsyproduct.atlassian.net/browse/GALL-1979) and shipping for UK addresses.