### PR TITLE
Transaction external type

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 26
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 26
+  Max: 30
 
 # Offense count: 1
 Metrics/PerceivedComplexity:

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :test do
   gem 'danger'
   gem 'fabrication'
   gem 'selenium-webdriver'
-  gem 'stripe-ruby-mock', git: 'https://github.com/ashkan18/stripe-ruby-mock', branch: 'add-support-for-payment-intents' , require: 'stripe_mock'
+  gem 'stripe-ruby-mock', git: 'https://github.com/ashkan18/stripe-ruby-mock', branch: 'more-payment-intents' , require: 'stripe_mock'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :test do
   gem 'danger'
   gem 'fabrication'
   gem 'selenium-webdriver'
-  gem 'stripe-ruby-mock', git: 'https://github.com/ashkan18/stripe-ruby-mock', branch: 'more-payment-intents' , require: 'stripe_mock'
+  gem 'stripe-ruby-mock', git: 'https://github.com/ashkan18/stripe-ruby-mock', branch: 'more-payment-intents', require: 'stripe_mock'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ashkan18/stripe-ruby-mock
-  revision: e2e7e6e2546774958a3dcbe15d8566f840ff2d84
+  revision: ad2b89b07f045df848e9b96771f1b735dcea4407
   branch: more-payment-intents
   specs:
     stripe-ruby-mock (2.5.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ashkan18/stripe-ruby-mock
-  revision: d288b4687b7034e2ce1c2ce5af9ef057545d3363
-  branch: add-support-for-payment-intents
+  revision: e2e7e6e2546774958a3dcbe15d8566f840ff2d84
+  branch: more-payment-intents
   specs:
     stripe-ruby-mock (2.5.8)
       dante (>= 0.2.0)

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -516,6 +516,11 @@ type FulfillmentEdge {
 }
 
 """
+Represents untyped JSON
+"""
+scalar JSON
+
+"""
 A Line Item
 """
 type LineItem {
@@ -915,7 +920,7 @@ enum OrderModeEnum {
 """
 Represents either a resolved Order or a potential failure
 """
-union OrderOrFailureUnion = OrderWithMutationFailure | OrderWithMutationSuccess
+union OrderOrFailureUnion = OrderRequiresAction | OrderWithMutationFailure | OrderWithMutationSuccess
 
 enum OrderParticipantEnum {
   """
@@ -933,6 +938,16 @@ enum OrderParticipantEnum {
 Represents either a partner or a user
 """
 union OrderPartyUnion = Partner | User
+
+"""
+A response indicating order needs action to be able to be submitted
+"""
+type OrderRequiresAction {
+  """
+  Data related to action needed
+  """
+  actionData: JSON!
+}
 
 enum OrderStateEnum {
   """

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -57,13 +57,14 @@ module Errors
       capture_failed
       charge_authorization_failed
       insufficient_inventory
+      payment_requires_action
       received_partial_refund
       refund_failed
       tax_calculator_failure
       tax_recording_failure
       tax_refund_failure
-      unknown_event_charge
       undeduct_inventory_failure
+      unknown_event_charge
     ],
     internal: %i[
       generic

--- a/app/controllers/errors/payment_requires_action_error.rb
+++ b/app/controllers/errors/payment_requires_action_error.rb
@@ -1,0 +1,9 @@
+module Errors
+  class PaymentRequiresActionError < ProcessingError
+    attr_reader :transaction
+    def initialize(transaction)
+      @transaction = transaction
+      super(:payment_requires_action, { client_secret: @transaction.payload[:client_secret] })
+    end
+  end
+end

--- a/app/graphql/mutations/order_or_failure_union_type.rb
+++ b/app/graphql/mutations/order_or_failure_union_type.rb
@@ -8,7 +8,7 @@ class Mutations::OrderWithMutationFailure < Types::BaseObject
   field :error, Types::ApplicationErrorType, null: false
 end
 
-class Mutations::OrderNeedsAction < Types::BaseObject
+class Mutations::OrderRequiresAction < Types::BaseObject
   description 'A response indicating order needs action to be able to be submitted'
   field :action_data, JSON, null: false, description: 'Data related to action needed'
 end

--- a/app/graphql/mutations/order_or_failure_union_type.rb
+++ b/app/graphql/mutations/order_or_failure_union_type.rb
@@ -10,16 +10,16 @@ end
 
 class Mutations::OrderRequiresAction < Types::BaseObject
   description 'A response indicating order needs action to be able to be submitted'
-  field :action_data, JSON, null: false, description: 'Data related to action needed'
+  field :action_data, GraphQL::Types::JSON, null: false, description: 'Data related to action needed'
 end
 
 class Mutations::OrderOrFailureUnionType < Types::BaseUnion
   description 'Represents either a resolved Order or a potential failure'
-  possible_types Mutations::OrderWithMutationSuccess, Mutations::OrderWithMutationFailure
+  possible_types Mutations::OrderWithMutationSuccess, Mutations::OrderWithMutationFailure, Mutations::OrderRequiresAction
 
   def self.resolve_type(object, _context)
     if object.key?(:action_data)
-      Mutations::OrderNeedsAction
+      Mutations::OrderRequiresAction
     elsif object.key?(:order)
       Mutations::OrderWithMutationSuccess
     elsif object.key?(:error)

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -10,7 +10,7 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     authorize_buyer_request!(order)
     { order_or_error: { order: OrderService.submit!(order, current_user_id) } }
   rescue Errors::PaymentRequiresActionError => e
-    { order_or_error: { client_secret: e.payment_intent.client_secret }}
+    { order_or_error: { action_data: { client_secret: e.transaction.payload['client_secret'] }}}
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
   end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -9,6 +9,8 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     order = Order.find(id)
     authorize_buyer_request!(order)
     { order_or_error: { order: OrderService.submit!(order, current_user_id) } }
+  rescue Errors::PaymentRequiresActionError => e
+    { order_or_error: { client_secret: e.payment_intent.client_secret }}
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
   end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -10,7 +10,7 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     authorize_buyer_request!(order)
     { order_or_error: { order: OrderService.submit!(order, current_user_id) } }
   rescue Errors::PaymentRequiresActionError => e
-    { order_or_error: { action_data: { client_secret: e.transaction.payload['client_secret'] }}}
+    { order_or_error: { action_data: { client_secret: e.transaction.payload['client_secret'] } } }
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
   end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -11,7 +11,7 @@ class Transaction < ApplicationRecord
   TYPES = [
     HOLD = 'hold'.freeze,
     CAPTURE = 'capture'.freeze,
-    REFUND = 'refund'.freeze,
+    REFUND = 'refund'.freeze
   ].freeze
 
   STATUSES = [

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,11 +3,15 @@ class Transaction < ApplicationRecord
 
   belongs_to :order
 
+  EXTERNAL_TYPES = [
+    PAYMENT_INTENT = 'payment_intent'.freeze,
+    CHARGE = 'charge'.freeze
+  ].freeze
+
   TYPES = [
     HOLD = 'hold'.freeze,
     CAPTURE = 'capture'.freeze,
     REFUND = 'refund'.freeze,
-    PAYMENT_INTENT = 'payment_intent'.freeze
   ].freeze
 
   STATUSES = [
@@ -22,7 +26,11 @@ class Transaction < ApplicationRecord
   end
 
   def failed?
-    [FAILURE, REQUIRES_ACTION].include?(status)
+    status == FAILURE
+  end
+
+  def requires_action?
+    status == REQUIRES_ACTION
   end
 
   def failure_data

--- a/db/migrate/20190717161109_add_external_type_and_payload_to_transactions.rb
+++ b/db/migrate/20190717161109_add_external_type_and_payload_to_transactions.rb
@@ -1,0 +1,6 @@
+class AddExternalTypeAndPayloadToTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transactions, :external_type, :string
+    add_column :transactions, :payload, :jsonb
+  end
+end

--- a/db/migrate/20190717171856_populate_transaction_external_type.rb
+++ b/db/migrate/20190717171856_populate_transaction_external_type.rb
@@ -1,6 +1,7 @@
 class PopulateTransactionExternalType < ActiveRecord::Migration[5.2]
   def up
-    Transaction.update_all(external_type: Transaction::CHARGE)
+    Transaction.where('external_id LIKE :prefix', prefix: 'ch_').update_all(external_type: Transaction::CHARGE)
+    Transaction.where('external_id LIKE :prefix', prefix: 're_').update_all(external_type: Transaction::REFUND)
   end
 
   def down

--- a/db/migrate/20190717171856_populate_transaction_external_type.rb
+++ b/db/migrate/20190717171856_populate_transaction_external_type.rb
@@ -1,0 +1,9 @@
+class PopulateTransactionExternalType < ActiveRecord::Migration[5.2]
+  def up
+    Transaction.update_all(external_type: Transaction::CHARGE)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This was a data migration, can't be easily rollback"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_30_201701) do
+ActiveRecord::Schema.define(version: 2019_07_17_171856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -215,6 +215,8 @@ ActiveRecord::Schema.define(version: 2019_05_30_201701) do
     t.datetime "updated_at", null: false
     t.string "transaction_type"
     t.string "decline_code"
+    t.string "external_type"
+    t.jsonb "payload"
     t.index ["order_id"], name: "index_transactions_on_order_id"
   end
 

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -16,7 +16,7 @@ class OrderProcessor
     deduct_inventory
     @transaction = PaymentService.hold_charge(construct_charge_params)
     raise Errors::FailedTransactionError.new(:charge_authorization_failed, @transaction) if @transaction.failed?
-    raise Errors::PaymentRequiresActionError.new(@transaction) if @transaction.requires_action?
+    raise Errors::PaymentRequiresActionError, @transaction if @transaction.requires_action?
 
     @order.update!(external_charge_id: @transaction.external_id)
   rescue Errors::ValidationError, Errors::ProcessingError => e
@@ -30,8 +30,7 @@ class OrderProcessor
     deduct_inventory
     @transaction = PaymentService.immediate_capture(construct_charge_params)
     raise Errors::FailedTransactionError.new(:capture_failed, @transaction) if @transaction.failed?
-    raise Errors::PaymentRequiresActionError.new(@transaction) if @transaction.requires_action?
-
+    raise Errors::PaymentRequiresActionError, @transaction if @transaction.requires_action?
 
     @order.update!(external_charge_id: @transaction.external_id)
   rescue Errors::ValidationError, Errors::ProcessingError => e

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -1,43 +1,57 @@
 module PaymentService
-  def self.create_and_authorize_charge(charge_params)
+  def self.hold_charge(charge_params)
     create_payment_intent(charge_params.merge(capture: false))
   end
 
-  def self.create_and_capture_charge(charge_params)
+  def self.immediate_capture(charge_params)
     create_payment_intent(charge_params.merge(capture: true))
   end
 
   def self.capture_authorized_charge(external_id)
-    if external_id.include?('ch_')
-      # its a charge
+    transaction = Transaction.find_by(external_id: external_id)
+    capture_transaction = case transaction.external_type
+    when Transaction::CHARGE
       # @TODO: we can remove this code after 7 days of moving to payment intents
       charge = Stripe::Charge.retrieve(external_id)
       charge.capture
       Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
-    else
+    when Transaction::PAYMENT_INTENT
       payment_intent = Stripe::PaymentIntent.retrieve(external_id)
       payment_intent.capture
-      Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: payment_intent.transfer_data&.destination, amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
+      new_transaction = Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: payment_intent.transfer_data&.destination, amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE)
+      if payment_intent.status == 'succeeded'
+        new_transaction.status = Transaction::SUCCESS
+      else
+        new_transaction.status = Transaction::FAILURE
+        new_transaction.failure_code = payment_intent.last_payment_error.code
+        new_transaction.failure_message = payment_intent.last_payment_error.message
+        new_transaction.decline_code = payment_intent.last_payment_error.decline_code
+      end
+      new_transaction
+    else
+      raise "Unknown Transaction"
     end
+    capture_transaction
   rescue Stripe::StripeError => e
     generate_transaction_from_exception(e, Transaction::CAPTURE, external_id: external_id)
   end
 
   def self.refund_charge(external_id)
-    if external_id.include?('ch_')
+    transaction = Transaction.find_by(external_id: external_id)
+    case transaction.external_type
+    when Transaction::CHARGE
       # its a charge
       refund = Stripe::Refund.create(charge: external_id, reverse_transfer: true)
       Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
-    else
+    when Transaction::PAYMENT_INTENT
       # we need to refund using payment_intent
       payment_intent = Stripe::PaymentIntent.retrieve(external_id)
-      refund = Stripe::Refund.create(charge: payment_intent.charge.id, reverse_transfer: true)
+      refund = Stripe::Refund.create(charge: payment_intent.charges.first.id, reverse_transfer: true)
       Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
     end
   rescue Stripe::StripeError => e
     generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id)
   end
-
 
   def self.create_payment_intent(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {}, capture:)
     payment_intent = Stripe::PaymentIntent.create(
@@ -58,22 +72,34 @@ module PaymentService
       setup_future_usage: 'off-session',
       confirmation_method: 'manual'
     )
+    transaction = Transaction.new(
+      external_id: payment_intent.id,
+      source_id: payment_intent.payment_method,
+      destination_id: merchant_account[:external_id],
+      amount_cents: payment_intent.amount,
+      external_type: Transaction::PAYMENT_INTENT,
+      transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD,
+      payload: payment_intent.to_h
+    )
     case payment_intent.status # https://stripe.com/docs/payments/intents#intent-statuses
     when 'requires_action'
-      Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: merchant_account[:external_id], amount_cents: payment_intent.amount, transaction_type: Transaction::PAYMENT_INTENT, status: Transaction::REQUIRES_ACTION)
+      transaction.status = Transaction::REQUIRES_ACTION
     when 'requires_capture'
-      Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: merchant_account[:external_id], amount_cents: payment_intent.amount, transaction_type: Transaction::PAYMENT_INTENT, status: Transaction::REQUIRES_CAPTURE)
+      transaction.status = Transaction::REQUIRES_CAPTURE
     when 'succeeded'
-      Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: merchant_account[:external_id], amount_cents: payment_intent.amount, transaction_type: Transaction::PAYMENT_INTENT, status: Transaction::SUCCESS)
+      transaction.status = Transaction::SUCCESS
     when 'requires_payment_method'
       # attempting confirm failed
-      Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: merchant_account[:external_id], amount_cents: payment_intent.amount, transaction_type: Transaction::PAYMENT_INTENT, status: Transaction::FAILURE, 
-        failure_code: payment_intent.last_payment_error.code,
-        failure_message: payment_intent.last_payment_error.message,
-        decline_code: payment_intent.last_payment_error.decline_code)
+      transaction.status = Transaction::FAILURE
+      transaction.failure_code = payment_intent.last_payment_error.code
+      transaction.failure_message = payment_intent.last_payment_error.message
+      transaction.decline_code = payment_intent.last_payment_error.decline_code
+    else
+      # unknown status raise error
+      raise "Unknown status"
     end
+    transaction
   end
-
 
   def self.generate_transaction_from_exception(exc, type, credit_card: nil, merchant_account: nil, buyer_amount: nil, external_id: nil)
     body = exc.json_body[:error]

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -47,7 +47,7 @@ module PaymentService
       # we need to refund using payment_intent
       payment_intent = Stripe::PaymentIntent.retrieve(external_id)
       refund = Stripe::Refund.create(charge: payment_intent.charges.first.id, reverse_transfer: true)
-      Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
+      Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, external_type: Transaction::REFUND)
     end
   rescue Stripe::StripeError => e
     generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id)

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -72,7 +72,7 @@ module PaymentService
       setup_future_usage: 'off-session',
       confirmation_method: 'manual'
     )
-    transaction = Transaction.new(
+    new_transaction = Transaction.new(
       external_id: payment_intent.id,
       source_id: payment_intent.payment_method,
       destination_id: merchant_account[:external_id],
@@ -83,22 +83,22 @@ module PaymentService
     )
     case payment_intent.status # https://stripe.com/docs/payments/intents#intent-statuses
     when 'requires_action'
-      transaction.status = Transaction::REQUIRES_ACTION
+      new_transaction.status = Transaction::REQUIRES_ACTION
     when 'requires_capture'
-      transaction.status = Transaction::REQUIRES_CAPTURE
+      new_transaction.status = Transaction::REQUIRES_CAPTURE
     when 'succeeded'
-      transaction.status = Transaction::SUCCESS
+      new_transaction.status = Transaction::SUCCESS
     when 'requires_payment_method'
       # attempting confirm failed
-      transaction.status = Transaction::FAILURE
-      transaction.failure_code = payment_intent.last_payment_error.code
-      transaction.failure_message = payment_intent.last_payment_error.message
-      transaction.decline_code = payment_intent.last_payment_error.decline_code
+      new_transaction.status = Transaction::FAILURE
+      new_transaction.failure_code = payment_intent.last_payment_error.code
+      new_transaction.failure_message = payment_intent.last_payment_error.message
+      new_transaction.decline_code = payment_intent.last_payment_error.decline_code
     else
       # unknown status raise error
       raise "Unknown status"
     end
-    transaction
+    new_transaction
   end
 
   def self.generate_transaction_from_exception(exc, type, credit_card: nil, merchant_account: nil, buyer_amount: nil, external_id: nil)

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -9,30 +9,21 @@ module PaymentService
 
   def self.capture_authorized_charge(external_id)
     transaction = Transaction.find_by(external_id: external_id)
-    capture_transaction =
-      case transaction.external_type
-      when Transaction::CHARGE
-        # @TODO: we can remove this code after 7 days of moving to payment intents
-        charge = Stripe::Charge.retrieve(external_id)
-        charge.capture
-        Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
-      when Transaction::PAYMENT_INTENT
-        payment_intent = Stripe::PaymentIntent.retrieve(external_id)
-        payment_intent.capture
-        new_transaction = Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: payment_intent.transfer_data&.destination, amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE)
-        if payment_intent.status == 'succeeded'
-          new_transaction.status = Transaction::SUCCESS
-        else
-          new_transaction.status = Transaction::FAILURE
-          new_transaction.failure_code = payment_intent.last_payment_error.code
-          new_transaction.failure_message = payment_intent.last_payment_error.message
-          new_transaction.decline_code = payment_intent.last_payment_error.decline_code
-        end
-        new_transaction
-      else
-        raise 'Unknown Transaction type'
-      end
-    capture_transaction
+    case transaction.external_type
+    when Transaction::CHARGE
+      # @TODO: we can remove this code after 7 days of moving to payment intents
+      charge = Stripe::Charge.retrieve(external_id)
+      charge.capture
+      Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
+    when Transaction::PAYMENT_INTENT
+      payment_intent = Stripe::PaymentIntent.retrieve(external_id)
+      payment_intent.capture
+      new_transaction = Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: payment_intent.transfer_data&.destination, amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE)
+      update_transaction_with_payment_intent(new_transaction, payment_intent)
+      new_transaction
+    else
+      raise 'Unknown Transaction type'
+    end
   rescue Stripe::StripeError => e
     generate_transaction_from_exception(e, Transaction::CAPTURE, external_id: external_id)
   end

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -88,8 +88,8 @@ describe Api::GraphqlController, type: :request do
           expect(response.data.approve_order.order_or_error.order.state).to eq 'APPROVED'
           expect(response.data.approve_order.order_or_error).not_to respond_to(:error)
           expect(order.reload.state).to eq Order::APPROVED
-          expect(order.reload.transactions.last.external_id).to eq payment_intent.id
-          expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
+          transaction = order.transactions.order(created_at: :desc).first
+          expect(transaction).to have_attributes(external_id: payment_intent.id, transaction_type: Transaction::CAPTURE)
         end.to change(order, :state_expires_at)
       end
 

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -9,7 +9,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+    let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd') }
     let(:order) { Fabricate(:order, seller_id: seller_id, buyer_id: user_id, external_charge_id: payment_intent.id) }
 
     let(:mutation) do

--- a/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/approve_order_mutation_request_spec.rb
@@ -9,7 +9,8 @@ describe Api::GraphqlController, type: :request do
     let(:seller_id) { jwt_partner_ids.first }
     let(:user_id) { jwt_user_id }
     let(:credit_card_id) { 'cc-1' }
-    let(:order) { Fabricate(:order, seller_id: seller_id, buyer_id: user_id) }
+    let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+    let(:order) { Fabricate(:order, seller_id: seller_id, buyer_id: user_id, external_charge_id: payment_intent.id) }
 
     let(:mutation) do
       <<-GRAPHQL
@@ -77,8 +78,8 @@ describe Api::GraphqlController, type: :request do
 
     context 'with proper permission' do
       before do
+        Fabricate(:transaction, order: order, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT)
         order.update_attributes! state: Order::SUBMITTED
-        order.update_attributes! external_charge_id: uncaptured_charge.id
       end
       it 'approves the order' do
         expect do
@@ -87,7 +88,7 @@ describe Api::GraphqlController, type: :request do
           expect(response.data.approve_order.order_or_error.order.state).to eq 'APPROVED'
           expect(response.data.approve_order.order_or_error).not_to respond_to(:error)
           expect(order.reload.state).to eq Order::APPROVED
-          expect(order.reload.transactions.last.external_id).to eq uncaptured_charge.id
+          expect(order.reload.transactions.last.external_id).to eq payment_intent.id
           expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
         end.to change(order, :state_expires_at)
       end

--- a/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
@@ -213,8 +213,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
               expect(order.reload.transactions.last.external_id).not_to be_nil
               transaction = order.reload.transactions.order(updated_at: 'asc').last
-              expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-              expect(transaction.status).to eq Transaction::SUCCESS
+              expect(transaction).to have_attributes(transaction_type: Transaction::CAPTURE, external_type: Transaction::PAYMENT_INTENT, status: Transaction::SUCCESS)
             end
 
             context 'with offer from buyer' do
@@ -248,8 +247,7 @@ describe Api::GraphqlController, type: :request do
                 expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
                 expect(order.reload.transactions.last.external_id).not_to be_nil
                 transaction = order.reload.transactions.order(updated_at: 'asc').last
-                expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-                expect(transaction.status).to eq Transaction::SUCCESS
+                expect(transaction).to have_attributes(transaction_type: Transaction::CAPTURE, external_type: Transaction::PAYMENT_INTENT, status: Transaction::SUCCESS)
               end
             end
 

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -201,8 +201,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
         transaction = order.reload.transactions.last
         expect(transaction.external_id).not_to be_nil
-        expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-        expect(transaction.status).to eq Transaction::SUCCESS
+        expect(transaction).to have_attributes(transaction_type: Transaction::CAPTURE, external_type: Transaction::PAYMENT_INTENT, status: Transaction::SUCCESS)
       end
     end
   end

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -211,9 +211,7 @@ describe Api::GraphqlController, type: :request do
         expect(order.state_updated_at).not_to be_nil
         expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
         transaction = order.reload.transactions.last
-        expect(transaction.external_id).not_to be_nil
-        expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-        expect(transaction.status).to eq Transaction::SUCCESS
+        expect(transaction).to have_attributes(transaction_type: Transaction::CAPTURE, external_type: Transaction::PAYMENT_INTENT, status: Transaction::SUCCESS)
       end
     end
   end

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -74,7 +74,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+      let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd') }
       let!(:payment_intent_transaction) { Fabricate(:transaction, order: order, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT) }
       before do
         order.update_attributes! state: Order::SUBMITTED, external_charge_id: payment_intent.id

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -74,8 +74,10 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
+      let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+      let!(:payment_intent_transaction) { Fabricate(:transaction, order: order, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT) }
       before do
-        order.update_attributes! state: Order::SUBMITTED
+        order.update_attributes! state: Order::SUBMITTED, external_charge_id: payment_intent.id
       end
       it 'rejects the order' do
         response = client.execute(mutation, reject_order_input)
@@ -83,8 +85,8 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.reject_order.order_or_error.order.state).to eq 'CANCELED'
         expect(response.data.reject_order.order_or_error).not_to respond_to(:error)
         expect(order.reload.state).to eq Order::CANCELED
-        expect(order.transactions.last.external_id).to_not eq nil
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction.transaction_type).to eq Transaction::REFUND
       end
     end
   end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -215,8 +215,8 @@ describe Api::GraphqlController, type: :request do
         expect(order.commission_fee_cents).to eq 800_00
         expect(order.state_updated_at).not_to be_nil
         expect(order.state_expires_at).to eq(order.state_updated_at + 3.days)
-        expect(order.reload.transactions.last.external_id).not_to be_nil
-        expect(order.reload.transactions.last.transaction_type).to eq Transaction::PAYMENT_INTENT
+        transaction = order.reload.transactions.last
+        expect(transaction).to have_attributes(external_type: Transaction::PAYMENT_INTENT, transaction_type: Transaction::HOLD, status: Transaction::SUCCESS)
       end
     end
   end

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -208,7 +208,7 @@ describe Api::GraphqlController, type: :request do
         end
         it 'returns OrderRequiresAction including client_secret' do
           response = client.execute(mutation, submit_order_input)
-          expect(response.data.submit_order.order_or_error.action_data["client_secret"]).to eq 'pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v'
+          expect(response.data.submit_order.order_or_error.action_data['client_secret']).to eq 'pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v'
         end
 
         it 'stores transaction' do

--- a/spec/integration/buy_now_happy_path_spec.rb
+++ b/spec/integration/buy_now_happy_path_spec.rb
@@ -89,7 +89,8 @@ describe Api::GraphqlController, type: :request do
         commission_fee_cents: 100_00
       )
       expect(order.transactions.last).to have_attributes(
-        transaction_type: Transaction::PAYMENT_INTENT,
+        external_type: Transaction::PAYMENT_INTENT,
+        transaction_type: Transaction::HOLD,
         amount_cents: 1300_00,
         status: Transaction::SUCCESS,
         source_id: a_string_starting_with('test_')

--- a/spec/integration/make_offer_happy_path_spec.rb
+++ b/spec/integration/make_offer_happy_path_spec.rb
@@ -124,7 +124,8 @@ describe Api::GraphqlController, type: :request do
         credit_card_id: 'cc-1'
       )
       expect(order.transactions.order(created_at: :desc).first).to have_attributes(
-        transaction_type: Transaction::PAYMENT_INTENT,
+        external_type: Transaction::PAYMENT_INTENT,
+        transaction_type: Transaction::CAPTURE,
         amount_cents: 800_00,
         status: Transaction::SUCCESS
       )

--- a/spec/integration/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/single_counteroffer_happy_path_spec.rb
@@ -111,7 +111,8 @@ describe Api::GraphqlController, type: :request do
         credit_card_id: 'cc-1'
       )
       expect(order.transactions.order(created_at: :desc).first).to have_attributes(
-        transaction_type: Transaction::PAYMENT_INTENT,
+        external_type: Transaction::PAYMENT_INTENT,
+        transaction_type: Transaction::CAPTURE,
         amount_cents: 1000_00,
         status: Transaction::SUCCESS,
         source_id: a_string_starting_with('test_')

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -23,7 +23,7 @@ describe OrderApproveService, type: :services do
       it 'adds failed transaction' do
         expect { service.process! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
         transaction = order.transactions.order(created_at: :desc).first
-        expect(transaction).to have_attributes(status: Transaction::FAILURE, failure_code: 'card_declined', failure_message: 'Not enough funds.' , decline_code: 'insufficient_funds')
+        expect(transaction).to have_attributes(status: Transaction::FAILURE, failure_code: 'card_declined', failure_message: 'Not enough funds.', decline_code: 'insufficient_funds')
       end
 
       it 'keeps order in submitted state' do

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -4,10 +4,12 @@ describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
   let(:order_state) { Order::SUBMITTED }
   let(:order_mode) { Order::BUY }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
+  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+  let(:order) { Fabricate(:order, external_charge_id: payment_intent.id, state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
+  let!(:payment_intent_transaction) { Fabricate(:transaction, order: order, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT) }
 
   describe '#reject!' do
     context 'with a successful refund' do
@@ -20,9 +22,8 @@ describe OrderCancellationService, type: :services do
       end
 
       it 'records the transaction' do
-        expect(order.transactions.last.external_id).to_not eq nil
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::SUCCESS
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction).to have_attributes(external_id: payment_intent.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
       end
 
       it 'updates the order state' do
@@ -37,16 +38,13 @@ describe OrderCancellationService, type: :services do
 
     context 'with an unsuccessful refund' do
       before do
-        allow(Stripe::Refund).to receive(:create)
-          .with(hash_including(charge: captured_charge.id))
-          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+        StripeMock.prepare_card_error(:processing_error, :new_refund)
         expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
       end
 
       it 'raises a ProcessingError and records the transaction' do
-        expect(order.transactions.last.external_id).to eq captured_charge.id
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::FAILURE
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction).to have_attributes(external_id: payment_intent.id, transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
       end
 
       it 'does not queue undeduct inventory job' do
@@ -139,16 +137,13 @@ describe OrderCancellationService, type: :services do
 
       context 'with an unsuccessful refund' do
         before do
-          allow(Stripe::Refund).to receive(:create)
-            .with(hash_including(charge: captured_charge.id))
-            .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+          StripeMock.prepare_card_error(:processing_error, :new_refund)
           expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
         end
 
         it 'raises a ProcessingError and records the transaction' do
-          expect(order.transactions.last.external_id).to eq captured_charge.id
-          expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-          expect(order.transactions.last.status).to eq Transaction::FAILURE
+          transaction = order.transactions.order(created_at: :desc).first
+          expect(transaction).to have_attributes(external_id: payment_intent.id, transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
         end
 
         it 'does not queue undeduct inventory job' do
@@ -227,16 +222,13 @@ describe OrderCancellationService, type: :services do
 
         context 'with an unsuccessful refund' do
           before do
-            allow(Stripe::Refund).to receive(:create)
-              .with(hash_including(charge: captured_charge.id))
-              .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+            StripeMock.prepare_card_error(:processing_error, :new_refund)
             expect { service.refund! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
           end
 
           it 'raises a ProcessingError and records the transaction' do
-            expect(order.transactions.last.external_id).to eq captured_charge.id
-            expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-            expect(order.transactions.last.status).to eq Transaction::FAILURE
+            transaction = order.transactions.order(created_at: :desc).first
+            expect(transaction).to have_attributes(external_id: payment_intent.id, transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
           end
 
           it 'does not queue undeduct inventory job' do

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -4,7 +4,7 @@ describe OrderCancellationService, type: :services do
   include_context 'use stripe mock'
   let(:order_state) { Order::SUBMITTED }
   let(:order_mode) { Order::BUY }
-  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd') }
   let(:order) { Fabricate(:order, external_charge_id: payment_intent.id, state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
   let!(:payment_intent_transaction) { Fabricate(:transaction, order: order, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -10,7 +10,7 @@ describe PaymentService, type: :services do
   let(:seller_amount) { 10_00 }
   let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
   let(:merchant_account) { { external_id: 'ma-1' } }
-  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd') }
   let(:failed_payment_intent) { Stripe::PaymentIntent.create(amount: 3178, currency: 'usd') }
   let(:params) do
     {

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -23,7 +23,6 @@ describe PaymentService, type: :services do
       seller_amount: seller_amount
     }
   end
-  let(:payment_intent_success) { Stripe::PaymentIntent.create(amount: 20_00, currency: 'usd', payment_method: stripe_customer.default_source) }
 
   describe '#hold_charge' do
     it "creates a payment_intent using user's credit card and amount and stores it" do

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -10,6 +10,8 @@ describe PaymentService, type: :services do
   let(:seller_amount) { 10_00 }
   let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
   let(:merchant_account) { { external_id: 'ma-1' } }
+  let(:payment_intent) { Stripe::PaymentIntent.create(amount: 200, currency: 'usd')}
+  let(:failed_payment_intent) { Stripe::PaymentIntent.create(amount: 3178, currency: 'usd') }
   let(:params) do
     {
       buyer_amount: buyer_amount,
@@ -23,64 +25,71 @@ describe PaymentService, type: :services do
   end
   let(:payment_intent_success) { Stripe::PaymentIntent.create(amount: 20_00, currency: 'usd', payment_method: stripe_customer.default_source) }
 
-  describe '#create_and_authorize_charge' do
+  describe '#hold_charge' do
     it "creates a payment_intent using user's credit card and amount and stores it" do
-      expect(Stripe::PaymentIntent).to receive(:create).and_return(payment_intent_success)
-      transaction = PaymentService.create_and_authorize_charge(params)
-      expect(transaction.amount_cents).to eq(20_00)
-      expect(transaction.source_id).to eq(stripe_customer.default_source)
-      expect(transaction.status).to eq(Transaction::SUCCESS)
-      expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-      expect(transaction.external_id).to eq(payment_intent_success.id)
-      expect(transaction.destination_id).to eq 'ma-1'
-      expect(transaction.failure_code).to be_nil
-      expect(transaction.failure_message).to be_nil
-      expect(transaction.decline_code).to be_nil
+      transaction = PaymentService.hold_charge(params)
+      expect(transaction).to have_attributes(
+        amount_cents: 20_00,
+        source_id: stripe_customer.default_source,
+        destination_id: 'ma-1',
+        failure_code: nil,
+        failure_message: nil,
+        decline_code: nil,
+        transaction_type: Transaction::HOLD,
+        status: Transaction::SUCCESS,
+        external_type: Transaction::PAYMENT_INTENT
+      )
     end
     it 'creates transaction in REQUIRES_ACTION state when payment intent couldnt be confirmed' do
-      transaction = PaymentService.create_and_authorize_charge(params.merge(buyer_amount: 3184))
-      expect(transaction.amount_cents).to eq 3184
-      expect(transaction.source_id).to eq stripe_customer.default_source
-      expect(transaction.destination_id).to eq 'ma-1'
-      expect(transaction.failure_code).to be_nil
-      expect(transaction.failure_message).to be_nil
-      expect(transaction.decline_code).to be_nil
-      expect(transaction.transaction_type).to eq Transaction::PAYMENT_INTENT
-      expect(transaction.status).to eq Transaction::REQUIRES_ACTION
+      transaction = PaymentService.hold_charge(params.merge(buyer_amount: 3184))
+      expect(transaction).to have_attributes(
+        amount_cents: 3184,
+        source_id: stripe_customer.default_source,
+        destination_id: 'ma-1',
+        failure_code: nil,
+        failure_message: nil,
+        decline_code: nil,
+        transaction_type: Transaction::HOLD,
+        status: Transaction::REQUIRES_ACTION,
+        external_type: Transaction::PAYMENT_INTENT
+      )
     end
   end
 
   describe '#capture_authorized_charge' do
     it 'captures a charge' do
-      transaction = PaymentService.capture_authorized_charge(uncaptured_charge.id)
-      expect(transaction.amount_cents).to eq(uncaptured_charge.amount)
-      expect(transaction.transaction_type).to eq Transaction::CAPTURE
-      expect(transaction.source_id).to eq 'test_cc_2'
-      expect(transaction.status).to eq Transaction::SUCCESS
+      @hold_transaction = Fabricate(:transaction, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT)
+      transaction = PaymentService.capture_authorized_charge(payment_intent.id)
+      expect(transaction).to have_attributes(amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE, source_id: payment_intent.payment_method, status: Transaction::SUCCESS)
     end
     it 'catches Stripe errors and returns a failed transaction' do
-      StripeMock.prepare_card_error(:card_declined, :capture_charge)
-      transaction = PaymentService.capture_authorized_charge(uncaptured_charge.id)
-      expect(transaction.external_id).to eq uncaptured_charge.id
-      expect(transaction.failure_code).to eq 'card_declined'
-      expect(transaction.failure_message).to eq 'The card was declined'
-      expect(transaction.decline_code).to eq 'do_not_honor'
-      expect(transaction.transaction_type).to eq Transaction::CAPTURE
-      expect(transaction.status).to eq Transaction::FAILURE
+      Fabricate(:transaction, external_id: failed_payment_intent.id, external_type: Transaction::PAYMENT_INTENT)
+      allow_any_instance_of(Stripe::PaymentIntent).to receive(:capture)
+      transaction = PaymentService.capture_authorized_charge(failed_payment_intent.id)
+      expect(transaction).to have_attributes(
+        external_id: failed_payment_intent.id,
+        failure_code: 'card_declined',
+        failure_message: 'Not enough funds.',
+        decline_code: 'insufficient_funds',
+        transaction_type: Transaction::CAPTURE,
+        status: Transaction::FAILURE
+      )
     end
   end
 
   describe '#refund_charge' do
     it 'refunds a charge for the full amount' do
-      transaction = PaymentService.refund_charge(captured_charge.id)
+      Fabricate(:transaction, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT)
+      transaction = PaymentService.refund_charge(payment_intent.id)
       expect(transaction.external_id).to match(/test_re/i)
       expect(transaction.transaction_type).to eq Transaction::REFUND
       expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and returns a failed transaction' do
+      Fabricate(:transaction, external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT)
       StripeMock.prepare_card_error(:processing_error, :new_refund)
-      transaction = PaymentService.refund_charge(captured_charge.id)
-      expect(transaction.external_id).to eq captured_charge.id
+      transaction = PaymentService.refund_charge(payment_intent.id)
+      expect(transaction.external_id).to eq payment_intent.id
       expect(transaction.failure_code).to eq 'processing_error'
       expect(transaction.failure_message).to eq 'An error occurred while processing the card'
       expect(transaction.transaction_type).to eq Transaction::REFUND


### PR DESCRIPTION
# Change
This adds `external_type` to `transactions` table, this way we can distinguish between `charge`, `refund` and newly added `payment_intent` transactions.
This way when trying to `capture` or `refund` we first find the `transaction` for this `external_id` and based on it's type decide if we need to do a `charge` or `payment_intent` refund/capture.