### PR TITLE
Refactor order_processor to not raise error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 9
 
 Metrics/AbcSize:
-  Max: 42
+  Max: 52
   Exclude:
     - "db/migrate/*"
 
@@ -25,6 +25,7 @@ Metrics/BlockLength:
     - "spec/**/*"
 
 Metrics/MethodLength:
+  Max: 30
   Exclude:
     - "db/migrate/*"
 

--- a/app/controllers/errors/insufficient_inventory_error.rb
+++ b/app/controllers/errors/insufficient_inventory_error.rb
@@ -1,0 +1,7 @@
+module Errors
+  class InsufficientInventoryError < ProcessingError
+    def initialize(line_item_id = nil)
+      super(:insufficient_inventory, line_item_id: line_item_id)
+    end
+  end
+end

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -1,11 +1,8 @@
 class TransactionEvent < Events::BaseEvent
   TOPIC = 'commerce'.freeze
-  ACTIONS = [
-    CREATED = 'created'.freeze
-  ].freeze
 
-  def self.post(transaction, action, user_id)
-    event = new(user: user_id, action: action, model: transaction)
+  def self.post(transaction, user_id)
+    event = new(user: user_id, action: transaction.status, model: transaction)
     Artsy::EventService.post_event(topic: TOPIC, event: event)
   end
 

--- a/app/jobs/post_transaction_notification_job.rb
+++ b/app/jobs/post_transaction_notification_job.rb
@@ -1,8 +1,8 @@
 class PostTransactionNotificationJob < ApplicationJob
   queue_as :default
 
-  def perform(transaction_id, action, user_id = nil)
+  def perform(transaction_id, user_id = nil)
     transaction = Transaction.find(transaction_id)
-    TransactionEvent.post(transaction, action, user_id)
+    TransactionEvent.post(transaction, user_id)
   end
 end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -27,7 +27,7 @@ module OfferService
   def self.submit_pending_offer(offer)
     order = offer.order
     raise Errors::ValidationError, :invalid_offer if offer.submitted?
-    raise Errors::ProcessingError, :insufficient_inventory unless order.inventory?
+    raise Errors::InsufficientInventoryError unless order.inventory?
 
     order = offer.order
     offer_order_totals = OfferOrderTotals.new(offer)
@@ -67,7 +67,7 @@ module OfferService
 
     order = offer.order
     order_processor = OrderProcessor.new(order, user_id)
-    raise Errors::ValidationError, order_processor.error unless order_processor.valid?
+    raise Errors::ValidationError, order_processor.validation_error unless order_processor.valid?
 
     order.approve! do
       totals = OfferOrderTotals.new(offer)
@@ -78,19 +78,18 @@ module OfferService
         seller_total_cents: totals.seller_total_cents
       )
       order_processor.charge!
-      order.transactions << order_processor.transaction
+      raise ActiveRecord::Rollback if order_processor.failed_payment?
+      raise Errors::InsufficientInventoryError if order_processor.failed_inventory?
+    end
+    order.transactions << order_processor.transaction
+    if order_processor.transaction.failed?
+      PostTransactionNotificationJob.perform_later(order_processor.transaction.id, TransactionEvent::CREATED, user_id)
+      raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction)
     end
     OrderEvent.delay_post(order, Order::APPROVED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
     Exchange.dogstatsd.increment 'order.approved'
-  rescue Errors::FailedTransactionError => e
-    transaction = e.transaction
-    return if transaction.blank?
-
-    order.transactions << transaction
-    PostTransactionNotificationJob.perform_later(transaction.id, TransactionEvent::CREATED, user_id)
-    raise e
   end
 
   class << self

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -85,7 +85,7 @@ module OfferService
     end
     order.transactions << order_processor.transaction
     PostTransactionNotificationJob.perform_later(order_processor.transaction.id, user_id)
-    raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction) if order_processor.transaction.failed?
+    raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction) if order_processor.failed_payment?
 
     OrderEvent.delay_post(order, Order::APPROVED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -67,7 +67,7 @@ module OrderService
 
     order.transactions << order_processor.transaction
     PostTransactionNotificationJob.perform_later(order_processor.transaction.id, user_id)
-    raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction) if order_processor.transaction.failed?
+    raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction) if order_processor.failed_payment?
 
     OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -45,7 +45,7 @@ module OrderService
     end
 
     order_processor = OrderProcessor.new(order, user_id)
-    raise Errors::ValidationError, order_processor.error unless order_processor.valid?
+    raise Errors::ValidationError, order_processor.validation_error unless order_processor.valid?
 
     order.submit! do
       order.line_items.each { |li| li.update!(commission_fee_cents: li.current_commission_fee_cents) }
@@ -57,17 +57,24 @@ module OrderService
         seller_total_cents: totals.seller_total_cents
       )
       order_processor.hold!
-      order.transactions << order_processor.transaction
+      raise Errors::InsufficientInventoryError if order_processor.failed_inventory?
+      # in case of failed transaction, we need to rollback this block,
+      # but still need to add transaction, so we raise an ActiveRecord::Rollback
+      raise ActiveRecord::Rollback if order_processor.failed_payment?
+
+      order.update!(external_charge_id: order_processor.transaction.external_id)
     end
 
+    order.transactions << order_processor.transaction
+    if order_processor.transaction.failed?
+      PostTransactionNotificationJob.perform_later(order_processor.transaction.id, TransactionEvent::CREATED, user_id)
+      raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction)
+    end
     OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
     ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
     Exchange.dogstatsd.increment 'order.submitted'
     order
-  rescue Errors::FailedTransactionError => e
-    handle_failed_transaction(e, order, user_id)
-    raise e
   end
 
   def self.fulfill_at_once!(order, fulfillment, user_id)
@@ -99,17 +106,5 @@ module OrderService
 
   def self.abandon!(order)
     order.abandon!
-  end
-
-  class << self
-    private
-
-    def handle_failed_transaction(failed_transaction_exception, order, user_id)
-      transaction = failed_transaction_exception.transaction
-      return if transaction.blank?
-
-      order.transactions << transaction
-      PostTransactionNotificationJob.perform_later(transaction.id, TransactionEvent::CREATED, user_id)
-    end
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -56,7 +56,7 @@ module Gravity
   rescue Adapters::GravityNotFoundError
     raise Errors::ValidationError.new(:unknown_artwork, line_item_id: line_item.id)
   rescue Adapters::GravityError
-    raise Errors::ProcessingError.new(:insufficient_inventory, line_item_id: line_item.id)
+    raise Errors::InsufficientInventoryError, line_item.id
   end
 
   def self.undeduct_inventory(line_item)

--- a/spec/controllers/api/requests/line_items_query_request_spec.rb
+++ b/spec/controllers/api/requests/line_items_query_request_spec.rb
@@ -54,8 +54,7 @@ describe Api::GraphqlController, type: :request do
       it 'returns line items' do
         result = client.execute(query, artworkId: artwork_id)
         expect(result.data.line_items.edges.count).to eq 3
-        expect(result.data.line_items.edges.first.node.artwork_id).to eq artwork_id
-        expect(result.data.line_items.edges.first.node.order.id).to eq order1.id
+        expect(result.data.line_items.edges.map { |e| e.node.id }).to match_array([line_item1.id, line_item2.id, line_item3.id])
       end
     end
 

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -60,12 +60,12 @@ describe TransactionEvent, type: :events do
     ]
   end
 
-  let(:event) { TransactionEvent.new(user: user_id, action: TransactionEvent::CREATED, model: transaction) }
+  let(:event) { TransactionEvent.new(user: user_id, action: transaction.status, model: transaction) }
 
   describe 'post' do
     it 'calls ArtsyEventService to post event' do
       expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(TransactionEvent))
-      TransactionEvent.post(order, TransactionEvent::CREATED, user_id)
+      TransactionEvent.post(transaction, user_id)
     end
   end
 

--- a/spec/jobs/post_transaction_notification_job_spec.rb
+++ b/spec/jobs/post_transaction_notification_job_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe PostTransactionNotificationJob, type: :job do
   let(:transaction) { Fabricate(:transaction, failure_code: 'stolen_card', failure_message: 'nvm! left the card at home', order: order) }
   it 'finds the transaction and posts the event' do
     expect(Artsy::EventService).to receive(:post_event).with(topic: 'commerce', event: instance_of(TransactionEvent))
-    PostTransactionNotificationJob.new.perform(transaction.id, TransactionEvent::CREATED, order.buyer_id)
+    PostTransactionNotificationJob.new.perform(transaction.id, order.buyer_id)
   end
 end


### PR DESCRIPTION
# Problem
When we started updating our logic around adding support for `PaymentIntents` which would add more conditions to a _failed payment_. Things got pretty complicated between `OrderProcessor` and how it's being used by `OrderService` and `OfferService`.

One thing that complicated things was who and where we raise exceptions and how and where we rescue from them. We were relying on exception raised from `OrderProcessor` to _rollback_ the status changes during order/offer `submit`.

# Change
instead of raising exceptions from `OrderProcessor`, have it set the status internally so the callers can decide what to do with the failed reason. 

This will help us later when we try to handle `requires_action` case of `PaymentIntent` but we should look at this PR regardless of the coming changes.