### PR TITLE
Switch to payment intent stuff

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -54,6 +54,7 @@ module Errors
     ],
     processing: %i[
       artwork_version_mismatch
+      cannot_capture
       capture_failed
       charge_authorization_failed
       insufficient_inventory
@@ -62,8 +63,8 @@ module Errors
       tax_calculator_failure
       tax_recording_failure
       tax_refund_failure
-      unknown_event_charge
       undeduct_inventory_failure
+      unknown_event_charge
     ],
     internal: %i[
       generic

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,6 +3,11 @@ class Transaction < ApplicationRecord
 
   belongs_to :order
 
+  EXTERNAL_TYPES = [
+    PAYMENT_INTENT = 'payment_intent'.freeze,
+    CHARGE = 'charge'.freeze
+  ].freeze
+
   TYPES = [
     HOLD = 'hold'.freeze,
     CAPTURE = 'capture'.freeze,
@@ -11,7 +16,9 @@ class Transaction < ApplicationRecord
 
   STATUSES = [
     SUCCESS = 'success'.freeze,
-    FAILURE = 'failure'.freeze
+    FAILURE = 'failure'.freeze,
+    REQUIRES_ACTION = 'requires_action'.freeze,
+    REQUIRES_CAPTURE = 'requires_capture'.freeze
   ].freeze
 
   def to_s

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -11,7 +11,7 @@ class OrderApproveService
     raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
 
     @order.approve! do
-      @transaction = PaymentService.capture_authorized_charge(@order.external_charge_id)
+      @transaction = PaymentService.capture_authorized_payment(@order.external_charge_id)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?
     end
     post_process

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -9,9 +9,10 @@ class OrderApproveService
 
   def process!
     raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
-
+    @charge_transaction = order.transactions.where(external_id: @order.external_charge_id).first
     @order.approve! do
-      @transaction = PaymentService.capture_authorized_payment(@order.external_charge_id)
+      @transaction = @charge_transaction.external_type == Transaction::PAYMENT_INTENT ?
+        PaymentService.capture_authorized_payment(@order.external_charge_id) : PaymentService.capture_authorized_charge(@order.external_charge_id)
       raise Errors::ProcessingError.new(:capture_failed, @transaction.failure_data) if @transaction.failed?
     end
     post_process

--- a/app/services/order_approve_service.rb
+++ b/app/services/order_approve_service.rb
@@ -13,7 +13,7 @@ class OrderApproveService
     @charge_transaction = order.transactions.where(external_id: @order.external_charge_id).first
     @order.approve! do
       @transaction = if @charge_transaction.external_type == Transaction::PAYMENT_INTENT
-        PaymentService.capture_authorized_payment(@order.external_charge_id)
+        PaymentService.capture_authorized_hold(@order.external_charge_id)
       else
         PaymentService.capture_authorized_charge(@order.external_charge_id)
       end

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -51,7 +51,7 @@ class OrderCancellationService
   def process_stripe_refund
     raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
 
-    @transaction = PaymentService.refund_charge(@order.external_charge_id)
+    @transaction = PaymentService.refund_payment(@order.external_charge_id)
     raise Errors::ProcessingError.new(:refund_failed, @transaction.failure_data) if @transaction.failed?
   end
 

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -51,7 +51,8 @@ class OrderCancellationService
   def process_stripe_refund
     raise Errors::ValidationError.new(:unsupported_payment_method, @order.payment_method) unless @order.payment_method == Order::CREDIT_CARD
 
-    @transaction = PaymentService.refund_payment(@order.external_charge_id)
+    payment_transaction = @order.transactions.where(external_id: @order.external_charge_id).first
+    @transaction = PaymentService.refund(@order.external_charge_id, payment_transaction.external_type)
     raise Errors::ProcessingError.new(:refund_failed, @transaction.failure_data) if @transaction.failed?
   end
 

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,2 +1,4 @@
 require 'stripe'
 Stripe.api_key = Rails.application.config_for(:stripe)['stripe_api_key']
+Stripe.api_version = '2019-05-16'
+

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,4 +1,3 @@
 require 'stripe'
 Stripe.api_key = Rails.application.config_for(:stripe)['stripe_api_key']
 Stripe.api_version = '2019-05-16'
-

--- a/db/migrate/20190723204933_add_external_type_and_payload_to_transactions.rb
+++ b/db/migrate/20190723204933_add_external_type_and_payload_to_transactions.rb
@@ -1,0 +1,6 @@
+class AddExternalTypeAndPayloadToTransactions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transactions, :external_type, :string
+    add_column :transactions, :payload, :jsonb
+  end
+end

--- a/db/migrate/20190723204947_populate_transaction_external_type.rb
+++ b/db/migrate/20190723204947_populate_transaction_external_type.rb
@@ -1,0 +1,10 @@
+class PopulateTransactionExternalType < ActiveRecord::Migration[5.2]
+  def up
+    Transaction.where('external_id LIKE :prefix', prefix: 'ch_').update_all(external_type: Transaction::CHARGE)
+    Transaction.where('external_id LIKE :prefix', prefix: 're_').update_all(external_type: Transaction::REFUND)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This was a data migration, can't be easily rollback"
+  end
+end

--- a/db/migrate/20190723204947_populate_transaction_external_type.rb
+++ b/db/migrate/20190723204947_populate_transaction_external_type.rb
@@ -5,6 +5,6 @@ class PopulateTransactionExternalType < ActiveRecord::Migration[5.2]
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration, "This was a data migration, can't be easily rollback"
+    raise ActiveRecord::IrreversibleMigration, "This was a data migration, can't be easily rolled back"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_30_201701) do
+ActiveRecord::Schema.define(version: 2019_07_23_204947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -215,6 +215,8 @@ ActiveRecord::Schema.define(version: 2019_05_30_201701) do
     t.datetime "updated_at", null: false
     t.string "transaction_type"
     t.string "decline_code"
+    t.string "external_type"
+    t.jsonb "payload"
     t.index ["order_id"], name: "index_transactions_on_order_id"
   end
 

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -35,7 +35,7 @@ class OrderProcessor
     raise Errors::ValidationError, @validation_error unless valid?
 
     deduct_inventory
-    @transaction = PaymentService.immediate_capture_payment(construct_charge_params)
+    @transaction = PaymentService.capture_without_hold(construct_charge_params)
     undeduct_inventory if @transaction.failed?
   rescue Errors::InsufficientInventoryError
     undeduct_inventory

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -24,7 +24,7 @@ class OrderProcessor
     raise Errors::ValidationError, @validation_error unless valid?
 
     deduct_inventory
-    @transaction = PaymentService.create_and_authorize_charge(construct_charge_params)
+    @transaction = PaymentService.hold_payment(construct_charge_params)
     undeduct_inventory if @transaction.failed?
   rescue Errors::InsufficientInventoryError
     undeduct_inventory
@@ -35,7 +35,7 @@ class OrderProcessor
     raise Errors::ValidationError, @validation_error unless valid?
 
     deduct_inventory
-    @transaction = PaymentService.create_and_capture_charge(construct_charge_params)
+    @transaction = PaymentService.immediate_capture_payment(construct_charge_params)
     undeduct_inventory if @transaction.failed?
   rescue Errors::InsufficientInventoryError
     undeduct_inventory

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -34,7 +34,11 @@ module PaymentService
     new_transaction
   end
 
-  def refund_charge(charge_id)
+  def self.refund(external_id, external_type)
+    external_type == Transaction::PAYMENT_INTENT ? refund_payment(external_id) : refund_charge(external_id)
+  end
+
+  def self.refund_charge(charge_id)
     refund = Stripe::Refund.create(charge: charge_id, reverse_transfer: true)
     Transaction.new(external_id: refund.id, external_type: Transaction::REFUND, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: refund.charge)
   rescue Stripe::StripeError => e

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -1,51 +1,106 @@
 module PaymentService
-  def self.create_charge(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {}, capture:)
-    transaction_type = capture ? Transaction::CAPTURE : Transaction::HOLD
-    charge = Stripe::Charge.create(
+  def self.hold_payment(payment_params)
+    create_payment_intent(payment_params.merge(capture: false))
+  end
+
+  def self.immediate_capture_payment(payment_params)
+    create_payment_intent(payment_params.merge(capture: true))
+  end
+
+  def self.capture_authorized_payment(external_id)
+    transaction = Transaction.find_by(external_id: external_id)
+    case transaction.external_type
+    when Transaction::CHARGE
+      # @TODO: we can remove this code after 7 days of moving to payment intents
+      charge = Stripe::Charge.retrieve(external_id)
+      charge.capture
+      Transaction.new(external_id: charge.id, source_id: charge.payment_method, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
+    when Transaction::PAYMENT_INTENT
+      payment_intent = Stripe::PaymentIntent.retrieve(external_id)
+      raise Errors::ProcessingError, :cannot_capture unless payment_intent.status == 'requires_capture'
+
+      payment_intent.capture
+      new_transaction = Transaction.new(external_id: payment_intent.id, source_id: payment_intent.payment_method, destination_id: payment_intent.transfer_data&.destination, amount_cents: payment_intent.amount, transaction_type: Transaction::CAPTURE)
+      update_transaction_with_payment_intent(new_transaction, payment_intent)
+      new_transaction
+    else
+      raise 'Unknown Transaction type'
+    end
+  rescue Stripe::StripeError => e
+    generate_transaction_from_exception(e, Transaction::CAPTURE, external_id: external_id)
+  end
+
+  def self.refund_payment(external_id)
+    transaction = Transaction.find_by(external_id: external_id)
+    case transaction.external_type
+    when Transaction::CHARGE
+      # its a charge
+      refund = Stripe::Refund.create(charge: external_id, reverse_transfer: true)
+      Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
+    when Transaction::PAYMENT_INTENT
+      # we need to refund using payment_intent
+      payment_intent = Stripe::PaymentIntent.retrieve(external_id)
+      refund = Stripe::Refund.create(charge: payment_intent.charges.first.id, reverse_transfer: true)
+      Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, external_type: Transaction::REFUND)
+    end
+  rescue Stripe::StripeError => e
+    generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id)
+  end
+
+  def self.create_payment_intent(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {}, capture:)
+    payment_intent = Stripe::PaymentIntent.create(
       amount: buyer_amount,
       currency: currency_code,
       description: description,
-      source: credit_card[:external_id],
+      payment_method_types: ['card'],
+      payment_method: credit_card[:external_id],
       customer: credit_card[:customer_account][:external_id],
-      destination: {
-        account: merchant_account[:external_id],
+      on_behalf_of: merchant_account[:external_id],
+      transfer_data: {
+        destination: merchant_account[:external_id],
         amount: seller_amount
       },
       metadata: metadata,
-      capture: capture
+      capture_method: capture ? 'automatic' : 'manual',
+      confirm: true, # it creates payment intent and tries to confirm at the same time
+      setup_future_usage: 'off_session',
+      confirmation_method: 'manual' # if requires action, we will confirm manually after
     )
-    Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: transaction_type, status: Transaction::SUCCESS)
-  rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, transaction_type, credit_card: credit_card, merchant_account: merchant_account, buyer_amount: buyer_amount)
+    new_transaction = Transaction.new(
+      external_id: payment_intent.id,
+      source_id: payment_intent.payment_method,
+      destination_id: merchant_account[:external_id],
+      amount_cents: payment_intent.amount,
+      external_type: Transaction::PAYMENT_INTENT,
+      transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD,
+      payload: payment_intent.to_h
+    )
+    update_transaction_with_payment_intent(new_transaction, payment_intent)
+    new_transaction
   end
 
-  def self.create_and_authorize_charge(charge_params)
-    create_charge(charge_params.merge(capture: false))
+  def self.update_transaction_with_payment_intent(transaction, payment_intent)
+    case payment_intent.status # https://stripe.com/docs/payments/intents#intent-statuses
+    when 'requires_capture'
+      transaction.status = Transaction::REQUIRES_CAPTURE
+    when 'succeeded'
+      transaction.status = Transaction::SUCCESS
+    when 'requires_payment_method', 'requires_action'
+      # attempting confirm failed
+      transaction.status = Transaction::FAILURE
+      transaction.failure_code = payment_intent.last_payment_error.code
+      transaction.failure_message = payment_intent.last_payment_error.message
+      transaction.decline_code = payment_intent.last_payment_error.decline_code
+    else
+      # unknown status raise error
+      raise "Unknown transaction status: #{payment_intent.status}"
+    end
   end
 
-  def self.create_and_capture_charge(charge_params)
-    create_charge(charge_params.merge(capture: true))
-  end
-
-  def self.capture_authorized_charge(charge_id)
-    charge = Stripe::Charge.retrieve(charge_id)
-    charge.capture
-    Transaction.new(external_id: charge.id, source_id: charge.source.id, destination_id: charge.destination, amount_cents: charge.amount, transaction_type: Transaction::CAPTURE, status: Transaction::SUCCESS)
-  rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::CAPTURE, charge_id: charge_id)
-  end
-
-  def self.refund_charge(charge_id)
-    refund = Stripe::Refund.create(charge: charge_id, reverse_transfer: true)
-    Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
-  rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::REFUND, charge_id: charge_id)
-  end
-
-  def self.generate_transaction_from_exception(exc, type, credit_card: nil, merchant_account: nil, buyer_amount: nil, charge_id: nil)
+  def self.generate_transaction_from_exception(exc, type, credit_card: nil, merchant_account: nil, buyer_amount: nil, external_id: nil)
     body = exc.json_body[:error]
     Transaction.new(
-      external_id: charge_id || body[:charge],
+      external_id: external_id || body[:charge],
       source_id: (credit_card.present? ? credit_card[:external_id] : nil),
       destination_id: (merchant_account.present? ? merchant_account[:external_id] : nil),
       amount_cents: buyer_amount,

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -27,10 +27,10 @@ module PaymentService
   end
 
   def refund_charge(charge_id)
-    refund = Stripe::Refund.create(charge: external_id, reverse_transfer: true)
+    refund = Stripe::Refund.create(charge: charge_id, reverse_transfer: true)
     Transaction.new(external_id: refund.id, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
   rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id)
+    generate_transaction_from_exception(e, Transaction::REFUND, external_id: charge_id)
   end
 
   def self.refund_payment(external_id)

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -3,7 +3,7 @@ module PaymentService
     create_payment_intent(payment_params.merge(capture: false))
   end
 
-  def self.immediate_capture_payment(payment_params)
+  def self.capture_without_hold(payment_params)
     create_payment_intent(payment_params.merge(capture: true))
   end
 
@@ -16,7 +16,7 @@ module PaymentService
     generate_transaction_from_exception(e, Transaction::CAPTURE, external_id: charge_id, external_type: Transaction::CHARGE)
   end
 
-  def self.capture_authorized_payment(payment_intent_id)
+  def self.capture_authorized_hold(payment_intent_id)
     payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
     raise Errors::ProcessingError, :cannot_capture unless payment_intent.status == 'requires_capture'
 

--- a/spec/controllers/api/requests/line_items_query_request_spec.rb
+++ b/spec/controllers/api/requests/line_items_query_request_spec.rb
@@ -71,8 +71,7 @@ describe Api::GraphqlController, type: :request do
       it 'returns line items' do
         result = client.execute(query, artworkId: artwork_id, orderStates: %w[SUBMITTED FULFILLED])
         expect(result.data.line_items.edges.count).to eq 2
-        expect(result.data.line_items.edges.first.node.artwork_id).to eq artwork_id
-        expect(result.data.line_items.edges.first.node.order.id).to eq order2.id
+        expect(result.data.line_items.edges.map { |e| e.node.id }).to match_array([line_item2.id, line_item3.id])
       end
     end
 

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
-require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   describe 'buyer_accept_offer mutation' do
     include_context 'GraphQL Client'
     let(:partner) { { effective_commission_rate: 0.1 } }
@@ -11,7 +10,7 @@ describe Api::GraphqlController, type: :request do
     let(:order_state) { Order::SUBMITTED }
     let(:credit_card_id) { 'cc-1' }
     let(:merchant_account) { { external_id: 'ma-1' } }
-    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
     let(:order) do
       Fabricate(
         :order,
@@ -161,7 +160,7 @@ describe Api::GraphqlController, type: :request do
       context 'with failed stripe charge' do
         before do
           undeduct_inventory_request
-          StripeMock.prepare_card_error(:card_declined)
+          prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
         end
 
         it 'raises processing error' do
@@ -185,6 +184,7 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'approves the order' do
+        prepare_payment_intent_create_success(amount: 20_00)
         response = client.execute(mutation, buyer_accept_offer_input)
         expect(deduct_inventory_request).to have_been_requested
 

--- a/spec/controllers/api/requests/offers/buyer_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_counter_offer_mutation_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/use_stripe_mock'
 require 'support/gravity_helper'
 
 describe Api::GraphqlController, type: :request do

--- a/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/use_stripe_mock'
 
 RSpec.shared_examples 'rejecting an offer' do
   before do

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
-require 'support/use_stripe_mock'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   describe 'seller_accept_offer mutation' do
     include_context 'GraphQL Client'
     let(:partner) { { effective_commission_rate: 0.1 } }
@@ -11,7 +10,7 @@ describe Api::GraphqlController, type: :request do
     let(:order_state) { Order::SUBMITTED }
     let(:credit_card_id) { 'cc-1' }
     let(:merchant_account) { { external_id: 'ma-1' } }
-    let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
     let(:order) do
       Fabricate(
         :order,
@@ -171,7 +170,7 @@ describe Api::GraphqlController, type: :request do
       context 'with failed stripe charge' do
         before do
           undeduct_inventory_request
-          StripeMock.prepare_card_error(:card_declined)
+          prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
         end
 
         it 'raises processing error' do
@@ -195,6 +194,7 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'approves the order' do
+        prepare_payment_intent_create_success(amount: 20_00)
         response = client.execute(mutation, seller_accept_offer_input)
 
         expect(deduct_inventory_request).to have_been_requested

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -170,7 +170,7 @@ describe Api::GraphqlController, type: :request do
       context 'with failed stripe charge' do
         before do
           undeduct_inventory_request
-          prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
+          prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
         end
 
         it 'raises processing error' do

--- a/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_counter_offer_mutation_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/use_stripe_mock'
 require 'support/gravity_helper'
 
 describe Api::GraphqlController, type: :request do

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -75,7 +75,7 @@ describe Api::GraphqlController, type: :request do
 
     context 'with proper permission' do
       before do
-        Fabricate(:transaction, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
+        Fabricate(:transaction, order: order, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
         order.update_attributes! state: Order::SUBMITTED
       end
       it 'rejects the order' do
@@ -85,8 +85,8 @@ describe Api::GraphqlController, type: :request do
         expect(response.data.reject_order.order_or_error.order.state).to eq 'CANCELED'
         expect(response.data.reject_order.order_or_error).not_to respond_to(:error)
         expect(order.reload.state).to eq Order::CANCELED
-        expect(order.transactions.last.external_id).to_not eq nil
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction).to have_attributes(external_id: 're_1', external_type: Transaction::REFUND, transaction_type: Transaction::REFUND)
       end
     end
   end

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -79,7 +79,7 @@ describe Api::GraphqlController, type: :request do
         order.update_attributes! state: Order::SUBMITTED
       end
       it 'rejects the order' do
-        prepare_payment_intent_refund_success()
+        prepare_payment_intent_refund_success
         response = client.execute(mutation, reject_order_input)
         expect(response.data.reject_order.order_or_error.order.id).to eq order.id.to_s
         expect(response.data.reject_order.order_or_error.order.state).to eq 'CANCELED'

--- a/spec/integration/buy_now_happy_path_spec.rb
+++ b/spec/integration/buy_now_happy_path_spec.rb
@@ -3,7 +3,7 @@ require 'support/gravity_helper'
 require 'support/taxjar_helper'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   include_context 'GraphQL Client Helpers'
   describe 'buy now happy path' do
     let(:seller_id) { 'gravity-partner-id' }
@@ -20,7 +20,7 @@ describe Api::GraphqlController, type: :request do
         addressLine2: 'Suite 80'
       }
     end
-    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
     let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
     let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
     let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
@@ -38,6 +38,8 @@ describe Api::GraphqlController, type: :request do
         deduct_inventory: nil,
         get_merchant_account: seller_merchant_account
       )
+      prepare_payment_intent_create_success(amount: 1300_00)
+      prepare_payment_intent_capture_success(amount: 1300_00)
     end
 
     it 'succeeds the process of buyer create -> set shipping -> set payment -> submit -> seller accept' do
@@ -92,7 +94,7 @@ describe Api::GraphqlController, type: :request do
         transaction_type: Transaction::HOLD,
         amount_cents: 1300_00,
         status: Transaction::SUCCESS,
-        source_id: a_string_starting_with('test_')
+        source_id: 'cc_1'
       )
 
       # seller accepts order

--- a/spec/integration/make_offer_happy_path_spec.rb
+++ b/spec/integration/make_offer_happy_path_spec.rb
@@ -3,7 +3,7 @@ require 'support/gravity_helper'
 require 'support/taxjar_helper'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   include_context 'GraphQL Client Helpers'
   describe 'make offer happy path' do
     let(:seller_id) { 'gravity-partner-id' }
@@ -20,7 +20,7 @@ describe Api::GraphqlController, type: :request do
         addressLine2: 'Suite 80'
       }
     end
-    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
     let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
     let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
     let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
@@ -38,6 +38,7 @@ describe Api::GraphqlController, type: :request do
         deduct_inventory: nil,
         get_merchant_account: seller_merchant_account
       )
+      prepare_payment_intent_create_success(amount: 800_00)
     end
 
     it 'succeeds the process of buyer create -> add initial offer -> set shipping -> set payment -> submit -> seller accepts' do

--- a/spec/integration/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/single_counteroffer_happy_path_spec.rb
@@ -3,7 +3,7 @@ require 'support/gravity_helper'
 require 'support/taxjar_helper'
 
 describe Api::GraphqlController, type: :request do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   include_context 'GraphQL Client Helpers'
   describe 'make offer happy path' do
     let(:seller_id) { 'gravity-partner-id' }
@@ -20,7 +20,7 @@ describe Api::GraphqlController, type: :request do
         addressLine2: 'Suite 80'
       }
     end
-    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
     let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
     let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
     let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
@@ -38,6 +38,7 @@ describe Api::GraphqlController, type: :request do
         deduct_inventory: nil,
         get_merchant_account: seller_merchant_account
       )
+      prepare_payment_intent_create_success(amount: 1000_00)
     end
 
     it 'succeeds in the process of buyer offers -> seller counters -> buyer accepts' do
@@ -114,7 +115,7 @@ describe Api::GraphqlController, type: :request do
         transaction_type: Transaction::CAPTURE,
         amount_cents: 1000_00,
         status: Transaction::SUCCESS,
-        source_id: a_string_starting_with('test_')
+        source_id: 'cc_1'
       )
 
       # seller fulfills order

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -98,7 +98,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
+        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
         order_processor.hold!
       end
 
@@ -211,7 +211,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
+        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
         order_processor.charge!
       end
 

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -71,7 +71,7 @@ describe OrderProcessor, type: :services do
       it 'does not call stripe' do
         stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:create_and_capture_charge)
+        expect(PaymentService).not_to receive(:immediate_capture_payment)
         order_processor.hold!
         expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -82,7 +82,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:create_and_capture_charge)
+        expect(PaymentService).not_to receive(:immediate_capture_payment)
         order_processor.hold!
         expect(stub_line_item_1_gravity_undeduct).to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -183,7 +183,7 @@ describe OrderProcessor, type: :services do
 
       it 'does not call stripe' do
         stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:create_and_capture_charge)
+        expect(PaymentService).not_to receive(:immediate_capture_payment)
         order_processor.charge!
         expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -195,7 +195,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:create_and_capture_charge)
+        expect(PaymentService).not_to receive(:immediate_capture_payment)
         order_processor.charge!
         expect(stub_line_item_1_gravity_undeduct).to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -70,7 +70,7 @@ describe OrderProcessor, type: :services do
       it 'does not call stripe' do
         stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:immediate_capture_payment)
+        expect(PaymentService).not_to receive(:capture_without_hold)
         order_processor.hold!
         expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -81,7 +81,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:immediate_capture_payment)
+        expect(PaymentService).not_to receive(:capture_without_hold)
         order_processor.hold!
         expect(stub_line_item_1_gravity_undeduct).to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -182,7 +182,7 @@ describe OrderProcessor, type: :services do
 
       it 'does not call stripe' do
         stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:immediate_capture_payment)
+        expect(PaymentService).not_to receive(:capture_without_hold)
         order_processor.charge!
         expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
@@ -194,7 +194,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:immediate_capture_payment)
+        expect(PaymentService).not_to receive(:capture_without_hold)
         order_processor.charge!
         expect(stub_line_item_1_gravity_undeduct).to have_been_requested
         expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 require 'support/gravity_helper'
-require 'support/use_stripe_mock'
 
 describe OrderProcessor, type: :services do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   let(:buyer_id) { 'buyer1' }
   let(:seller_id) { 'seller1' }
   let(:order) { Fabricate(:order, buyer_id: buyer_id, fulfillment_type: Order::PICKUP, credit_card_id: 'cc1', seller_id: seller_id) }
@@ -19,7 +18,7 @@ describe OrderProcessor, type: :services do
   let(:stub_gravity_partner) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/partner/seller1/all").to_return(body: gravity_partner.to_json) }
   let(:gravity_merchant_accounts) { [{ external_id: 'ma-1' }] }
   let(:stub_gravity_merchant_account_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/merchant_accounts?partner_id=seller1").to_return(body: gravity_merchant_accounts.to_json) }
-  let(:gravity_credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+  let(:gravity_credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
   let(:stub_gravity_card_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/credit_card/cc1").to_return(body: gravity_credit_card.to_json) }
   let(:order_processor) { OrderProcessor.new(order, buyer_id) }
 
@@ -99,7 +98,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        StripeMock.prepare_card_error(:card_declined)
+        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
         order_processor.hold!
       end
 
@@ -124,7 +123,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        expect(Stripe::Charge).to receive(:create).and_return(uncaptured_charge)
+        prepare_payment_intent_create_success(amount: 20_00)
       end
 
       it 'deducts inventory' do
@@ -212,7 +211,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        StripeMock.prepare_card_error(:card_declined)
+        prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
         order_processor.charge!
       end
 
@@ -237,7 +236,7 @@ describe OrderProcessor, type: :services do
         stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        expect(Stripe::Charge).to receive(:create).and_return(captured_charge)
+        prepare_payment_intent_create_success(amount: 20_00)
         order_processor.charge!
       end
 

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -84,6 +84,85 @@ describe OrderApproveService, type: :services do
       end
     end
     context 'capture a payment_intent' do
+      before do
+        Fabricate(:transaction, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT, order: order)
+        order.update!(external_charge_id: 'pi_1')
+      end
+      context 'with failed stripe capture' do
+        before do
+          prepare_payment_intent_capture_failure(charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
+        end
+
+        it 'adds failed transaction' do
+          expect { service.process! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
+          transaction = order.transactions.order(created_at: :desc).first
+          expect(transaction).to have_attributes(
+            status: Transaction::FAILURE,
+            failure_code: 'card_declined',
+            failure_message: 'The card was declined',
+            decline_code: 'do_not_honor',
+            external_id: 'pi_1',
+            external_type: Transaction::PAYMENT_INTENT
+          )
+        end
+
+        it 'keeps order in submitted state' do
+          expect { service.process! }.to raise_error(Errors::ProcessingError)
+          expect(order.reload.state).to eq Order::SUBMITTED
+        end
+
+        it 'does not queue any followup job' do
+          expect(OrderEvent).not_to receive(:delay_post)
+          expect(OrderFollowUpJob).not_to receive(:set)
+          expect(RecordSalesTaxJob).not_to receive(:perform_later)
+        end
+      end
+
+      context 'with failed post_process' do
+        it 'is in approved state' do
+          prepare_payment_intent_capture_success
+          allow(OrderEvent).to receive(:delay_post).and_raise('Perform what later?!')
+          expect { service.process! }.to raise_error(RuntimeError).and change(order.transactions, :count).by(1)
+          expect(order.reload.state).to eq Order::APPROVED
+        end
+      end
+
+      context 'with a successful order approval' do
+        before do
+          prepare_payment_intent_capture_success
+          ActiveJob::Base.queue_adapter = :test
+          expect { service.process! }.to change(order.transactions, :count).by(1)
+        end
+
+        it 'adds successful transaction' do
+          expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+            status: Transaction::SUCCESS,
+            external_id: 'pi_1',
+            external_type: Transaction::PAYMENT_INTENT
+          )
+        end
+
+        it 'queues PostEvent' do
+          expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
+        end
+
+        it 'queues OrderFollowUpJob' do
+          expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::APPROVED)
+        end
+
+        it 'enqueues a RecordSalesTaxJob for each line item' do
+          line_items.each { |li| expect(RecordSalesTaxJob).to have_been_enqueued.with(li.id) }
+        end
+      end
+
+      context 'with an order that was paid for by wire transfer' do
+        it 'raises an error' do
+          order.update!(payment_method: Order::WIRE_TRANSFER)
+          expect { service.process! }.to raise_error do |e|
+            expect(e.code).to eq :unsupported_payment_method
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/order_approve_service_spec.rb
+++ b/spec/services/order_approve_service_spec.rb
@@ -8,69 +8,77 @@ describe OrderApproveService, type: :services do
   let(:service) { OrderApproveService.new(order, user_id) }
 
   describe '#process!' do
-    context 'with failed stripe capture' do
+    context 'capture a charge - LEGACY' do
       before do
-        StripeMock.prepare_card_error(:card_declined, :capture_charge)
+        Fabricate(:transaction, external_id: 'ch_1', external_type: Transaction::CHARGE)
+        order.update!(external_charge_id: 'ch_1')
       end
+      context 'with failed stripe capture' do
+        before do
+          StripeMock.prepare_card_error(:card_declined, :capture_charge)
+        end
 
-      it 'adds failed transaction' do
-        expect { service.process! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
-        expect(order.transactions.first.status).to eq Transaction::FAILURE
-        expect(order.transactions.first.failure_code).to eq 'card_declined'
-        expect(order.transactions.first.failure_message).to eq 'The card was declined'
-        expect(order.transactions.first.decline_code).to eq 'do_not_honor'
-      end
+        it 'adds failed transaction' do
+          expect { service.process! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
+          expect(order.transactions.first.status).to eq Transaction::FAILURE
+          expect(order.transactions.first.failure_code).to eq 'card_declined'
+          expect(order.transactions.first.failure_message).to eq 'The card was declined'
+          expect(order.transactions.first.decline_code).to eq 'do_not_honor'
+        end
 
-      it 'keeps order in submitted state' do
-        expect { service.process! }.to raise_error(Errors::ProcessingError)
-        expect(order.reload.state).to eq Order::SUBMITTED
-      end
+        it 'keeps order in submitted state' do
+          expect { service.process! }.to raise_error(Errors::ProcessingError)
+          expect(order.reload.state).to eq Order::SUBMITTED
+        end
 
-      it 'does not queue any followup job' do
-        expect(OrderEvent).not_to receive(:delay_post)
-        expect(OrderFollowUpJob).not_to receive(:set)
-        expect(RecordSalesTaxJob).not_to receive(:perform_later)
-      end
-    end
-
-    context 'with failed post_process' do
-      it 'is in approved state' do
-        allow(OrderEvent).to receive(:delay_post).and_raise('Perform what later?!')
-        expect { service.process! }.to raise_error(RuntimeError).and change(order.transactions, :count).by(1)
-        expect(order.reload.state).to eq Order::APPROVED
-      end
-    end
-
-    context 'with a successful order approval' do
-      before do
-        ActiveJob::Base.queue_adapter = :test
-        expect { service.process! }.to change(order.transactions, :count).by(1)
-      end
-
-      it 'adds successful transaction' do
-        expect(order.transactions.last.status).to eq Transaction::SUCCESS
-      end
-
-      it 'queues PostEvent' do
-        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
-      end
-
-      it 'queues OrderFollowUpJob' do
-        expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::APPROVED)
-      end
-
-      it 'enqueues a RecordSalesTaxJob for each line item' do
-        line_items.each { |li| expect(RecordSalesTaxJob).to have_been_enqueued.with(li.id) }
-      end
-    end
-
-    context 'with an order that was paid for by wire transfer' do
-      it 'raises an error' do
-        order.update!(payment_method: Order::WIRE_TRANSFER)
-        expect { service.process! }.to raise_error do |e|
-          expect(e.code).to eq :unsupported_payment_method
+        it 'does not queue any followup job' do
+          expect(OrderEvent).not_to receive(:delay_post)
+          expect(OrderFollowUpJob).not_to receive(:set)
+          expect(RecordSalesTaxJob).not_to receive(:perform_later)
         end
       end
+
+      context 'with failed post_process' do
+        it 'is in approved state' do
+          allow(OrderEvent).to receive(:delay_post).and_raise('Perform what later?!')
+          expect { service.process! }.to raise_error(RuntimeError).and change(order.transactions, :count).by(1)
+          expect(order.reload.state).to eq Order::APPROVED
+        end
+      end
+
+      context 'with a successful order approval' do
+        before do
+          ActiveJob::Base.queue_adapter = :test
+          expect { service.process! }.to change(order.transactions, :count).by(1)
+        end
+
+        it 'adds successful transaction' do
+          expect(order.transactions.last.status).to eq Transaction::SUCCESS
+        end
+
+        it 'queues PostEvent' do
+          expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.approved')
+        end
+
+        it 'queues OrderFollowUpJob' do
+          expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::APPROVED)
+        end
+
+        it 'enqueues a RecordSalesTaxJob for each line item' do
+          line_items.each { |li| expect(RecordSalesTaxJob).to have_been_enqueued.with(li.id) }
+        end
+      end
+
+      context 'with an order that was paid for by wire transfer' do
+        it 'raises an error' do
+          order.update!(payment_method: Order::WIRE_TRANSFER)
+          expect { service.process! }.to raise_error do |e|
+            expect(e.code).to eq :unsupported_payment_method
+          end
+        end
+      end
+    end
+    context 'capture a payment_intent' do
     end
   end
 end

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -1,17 +1,21 @@
 require 'rails_helper'
 
 describe OrderCancellationService, type: :services do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
   let(:order_state) { Order::SUBMITTED }
   let(:order_mode) { Order::BUY }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
+  let(:order) { Fabricate(:order, external_charge_id: 'pi_1', state: order_state, mode: order_mode, buyer_id: 'buyer', buyer_type: Order::USER) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
 
   describe '#reject!' do
+    before do
+      Fabricate(:transaction, order: order, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
+    end
     context 'with a successful refund' do
       before do
+        prepare_payment_intent_refund_success()
         service.reject!
       end
 
@@ -20,9 +24,8 @@ describe OrderCancellationService, type: :services do
       end
 
       it 'records the transaction' do
-        expect(order.transactions.last.external_id).to_not eq nil
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::SUCCESS
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction).to have_attributes(external_id: 're_1', transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
       end
 
       it 'updates the order state' do
@@ -37,16 +40,13 @@ describe OrderCancellationService, type: :services do
 
     context 'with an unsuccessful refund' do
       before do
-        allow(Stripe::Refund).to receive(:create)
-          .with(hash_including(charge: captured_charge.id))
-          .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+        prepare_payment_intent_refund_failure(code: 'something', message: 'refund failed', decline_code: 'failed_refund')
         expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
       end
 
       it 'raises a ProcessingError and records the transaction' do
-        expect(order.transactions.last.external_id).to eq captured_charge.id
-        expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-        expect(order.transactions.last.status).to eq Transaction::FAILURE
+        transaction = order.transactions.order(created_at: :desc).first
+        expect(transaction).to have_attributes(external_id: 'pi_1', transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
       end
 
       it 'does not queue undeduct inventory job' do
@@ -114,6 +114,7 @@ describe OrderCancellationService, type: :services do
     context 'Buy Order' do
       context 'with a successful refund' do
         before do
+          prepare_payment_intent_refund_success()
           service.seller_lapse!
         end
 
@@ -122,9 +123,8 @@ describe OrderCancellationService, type: :services do
         end
 
         it 'records the transaction' do
-          expect(order.transactions.last.external_id).to_not eq nil
-          expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-          expect(order.transactions.last.status).to eq Transaction::SUCCESS
+          transaction = order.transactions.order(created_at: :desc).first
+          expect(transaction).to have_attributes(external_id: 're_1', transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
         end
 
         it 'updates the order state' do
@@ -139,16 +139,13 @@ describe OrderCancellationService, type: :services do
 
       context 'with an unsuccessful refund' do
         before do
-          allow(Stripe::Refund).to receive(:create)
-            .with(hash_including(charge: captured_charge.id))
-            .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+          prepare_payment_intent_refund_failure(code: 'something', message: 'refund failed', decline_code: 'failed_refund')
           expect { service.reject! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
         end
 
         it 'raises a ProcessingError and records the transaction' do
-          expect(order.transactions.last.external_id).to eq captured_charge.id
-          expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-          expect(order.transactions.last.status).to eq Transaction::FAILURE
+          transaction = order.transactions.order(created_at: :desc).first
+          expect(transaction).to have_attributes(external_id: 'pi_1', transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
         end
 
         it 'does not queue undeduct inventory job' do
@@ -162,6 +159,7 @@ describe OrderCancellationService, type: :services do
       let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
 
       before do
+        prepare_payment_intent_refund_success()
         service.seller_lapse!
       end
 
@@ -182,6 +180,7 @@ describe OrderCancellationService, type: :services do
       let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
 
       before do
+        prepare_payment_intent_refund_success()
         service.buyer_lapse!
       end
 
@@ -203,6 +202,7 @@ describe OrderCancellationService, type: :services do
 
         context 'with a successful refund' do
           before do
+            prepare_payment_intent_refund_success()
             service.refund!
           end
 
@@ -211,9 +211,8 @@ describe OrderCancellationService, type: :services do
           end
 
           it 'records the transaction' do
-            expect(order.transactions.last.external_id).to_not eq nil
-            expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-            expect(order.transactions.last.status).to eq Transaction::SUCCESS
+            transaction = order.transactions.order(created_at: :desc).first
+            expect(transaction).to have_attributes(external_id: 're_1', transaction_type: Transaction::REFUND, status: Transaction::SUCCESS)
           end
 
           it 'updates the order state' do
@@ -227,16 +226,13 @@ describe OrderCancellationService, type: :services do
 
         context 'with an unsuccessful refund' do
           before do
-            allow(Stripe::Refund).to receive(:create)
-              .with(hash_including(charge: captured_charge.id))
-              .and_raise(Stripe::StripeError.new('too late to refund buddy...', json_body: { error: { code: 'something', message: 'refund failed' } }))
+            prepare_payment_intent_refund_failure(code: 'something', message: 'refund failed', decline_code: 'failed_refund')
             expect { service.refund! }.to raise_error(Errors::ProcessingError).and change(order.transactions, :count).by(1)
           end
 
           it 'raises a ProcessingError and records the transaction' do
-            expect(order.transactions.last.external_id).to eq captured_charge.id
-            expect(order.transactions.last.transaction_type).to eq Transaction::REFUND
-            expect(order.transactions.last.status).to eq Transaction::FAILURE
+            transaction = order.transactions.order(created_at: :desc).first
+            expect(transaction).to have_attributes(external_id: 'pi_1', transaction_type: Transaction::REFUND, status: Transaction::FAILURE)
           end
 
           it 'does not queue undeduct inventory job' do

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -15,7 +15,7 @@ describe OrderCancellationService, type: :services do
     end
     context 'with a successful refund' do
       before do
-        prepare_payment_intent_refund_success()
+        prepare_payment_intent_refund_success
         service.reject!
       end
 
@@ -114,7 +114,7 @@ describe OrderCancellationService, type: :services do
     context 'Buy Order' do
       context 'with a successful refund' do
         before do
-          prepare_payment_intent_refund_success()
+          prepare_payment_intent_refund_success
           service.seller_lapse!
         end
 
@@ -159,7 +159,7 @@ describe OrderCancellationService, type: :services do
       let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
 
       before do
-        prepare_payment_intent_refund_success()
+        prepare_payment_intent_refund_success
         service.seller_lapse!
       end
 
@@ -180,7 +180,7 @@ describe OrderCancellationService, type: :services do
       let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
 
       before do
-        prepare_payment_intent_refund_success()
+        prepare_payment_intent_refund_success
         service.buyer_lapse!
       end
 
@@ -202,7 +202,7 @@ describe OrderCancellationService, type: :services do
 
         context 'with a successful refund' do
           before do
-            prepare_payment_intent_refund_success()
+            prepare_payment_intent_refund_success
             service.refund!
           end
 

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -9,10 +9,11 @@ describe OrderCancellationService, type: :services do
   let(:user_id) { 'user-id' }
   let(:service) { OrderCancellationService.new(order, user_id) }
 
+  before do
+    Fabricate(:transaction, order: order, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
+  end
+
   describe '#reject!' do
-    before do
-      Fabricate(:transaction, order: order, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
-    end
     context 'with a successful refund' do
       before do
         prepare_payment_intent_refund_success

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -70,7 +70,7 @@ describe PaymentService, type: :services do
       )
     end
     it 'stores failures on transaction' do
-      prepare_payment_intent_capture_failure(status: 'requires_payment_method', charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
+      prepare_payment_intent_capture_failure(charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
       transaction = PaymentService.capture_authorized_payment('pi_1')
       expect(transaction).to have_attributes(
         external_id: 'pi_1',

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -56,10 +56,10 @@ describe PaymentService, type: :services do
     end
   end
 
-  describe '#capture_authorized_payment' do
+  describe '#capture_authorized_hold' do
     it 'captures a payment_intent' do
       prepare_payment_intent_capture_success(amount: 20_00)
-      transaction = PaymentService.capture_authorized_payment('pi_1')
+      transaction = PaymentService.capture_authorized_hold('pi_1')
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
         amount_cents: 20_00,
@@ -71,7 +71,7 @@ describe PaymentService, type: :services do
     end
     it 'stores failures on transaction' do
       prepare_payment_intent_capture_failure(charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
-      transaction = PaymentService.capture_authorized_payment('pi_1')
+      transaction = PaymentService.capture_authorized_hold('pi_1')
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
 require 'support/gravity_helper'
-require 'support/use_stripe_mock'
 
 describe PaymentService, type: :services do
-  include_context 'use stripe mock'
+  include_context 'include stripe helper'
 
   let(:currency_code) { 'usd' }
   let(:buyer_amount) { 20_00 }
   let(:seller_amount) { 10_00 }
-  let(:credit_card) { { external_id: stripe_customer.default_source, customer_account: { external_id: stripe_customer.id } } }
+  let(:credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
   let(:merchant_account) { { external_id: 'ma-1' } }
   let(:params) do
     {
@@ -24,62 +23,76 @@ describe PaymentService, type: :services do
 
   describe '#hold_payment' do
     it "authorizes a charge on the user's credit card" do
+      prepare_payment_intent_create_success(amount: 20_00)
       transaction = PaymentService.hold_payment(params)
-      expect(transaction.amount_cents).to eq(20_00)
-      expect(transaction.source_id).to eq(stripe_customer.default_source)
-      expect(transaction.status).to eq(Transaction::SUCCESS)
-      expect(transaction.transaction_type).to eq Transaction::HOLD
-      expect(transaction.failure_code).to be_nil
-      expect(transaction.failure_message).to be_nil
-      expect(transaction.decline_code).to be_nil
+      expect(transaction).to have_attributes(
+        external_id: 'pi_1',
+        external_type: Transaction::PAYMENT_INTENT,
+        amount_cents: 20_00,
+        source_id: 'cc_1',
+        status: Transaction::SUCCESS,
+        transaction_type: Transaction::HOLD,
+        failure_code: nil,
+        failure_message: nil,
+        decline_code: nil
+      )
     end
-    it 'catches Stripe errors and returns a failed transaction' do
-      StripeMock.prepare_card_error(:card_declined, :new_charge)
+    it 'stores failed attempt data on transaction' do
+      prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
       transaction = PaymentService.hold_payment(params)
-      expect(transaction.amount_cents).to eq buyer_amount
-      expect(transaction.source_id).to eq stripe_customer.default_source
-      expect(transaction.destination_id).to eq 'ma-1'
-      expect(transaction.failure_code).to eq 'card_declined'
-      expect(transaction.failure_message).to eq 'The card was declined'
-      expect(transaction.decline_code).to eq 'do_not_honor'
-      expect(transaction.transaction_type).to eq Transaction::HOLD
-      expect(transaction.status).to eq Transaction::FAILURE
+      expect(transaction).to have_attributes(
+        amount_cents: buyer_amount,
+        source_id: 'cc_1',
+        destination_id: 'ma-1',
+        failure_code: 'card_declined',
+        failure_message: 'The card was declined',
+        decline_code: 'do_not_honor',
+        transaction_type: Transaction::HOLD,
+        status: Transaction::FAILURE
+      )
     end
   end
 
   describe '#capture_authorized_payment' do
-    it 'captures a charge' do
-      transaction = PaymentService.capture_authorized_payment(uncaptured_charge.id)
-      expect(transaction.amount_cents).to eq(uncaptured_charge.amount)
-      expect(transaction.transaction_type).to eq Transaction::CAPTURE
-      expect(transaction.source_id).to eq 'test_cc_2'
-      expect(transaction.status).to eq Transaction::SUCCESS
+    it 'captures a payment_intent' do
+      prepare_payment_intent_capture_success(amount: 20_00)
+      transaction = PaymentService.capture_authorized_payment('pi_1')
+      expect(transaction).to have_attributes(
+        amount_cents: 20_00,
+        transaction_type: Transaction::CAPTURE,
+        source_id: 'cc_1',
+        status: Transaction::SUCCESS
+      )
     end
-    it 'catches Stripe errors and returns a failed transaction' do
-      StripeMock.prepare_card_error(:card_declined, :capture_charge)
-      transaction = PaymentService.capture_authorized_payment(uncaptured_charge.id)
-      expect(transaction.external_id).to eq uncaptured_charge.id
-      expect(transaction.failure_code).to eq 'card_declined'
-      expect(transaction.failure_message).to eq 'The card was declined'
-      expect(transaction.decline_code).to eq 'do_not_honor'
-      expect(transaction.transaction_type).to eq Transaction::CAPTURE
-      expect(transaction.status).to eq Transaction::FAILURE
+    it 'stores failures on transaction' do
+      prepare_payment_intent_capture_failure(status: 'requires_payment_method', charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
+      transaction = PaymentService.capture_authorized_payment('pi_1')
+      expect(transaction).to have_attributes(
+        external_id: 'pi_1',
+        failure_code: 'capture_charge',
+        failure_message: 'The card was declined',
+        decline_code: 'do_not_honor',
+        transaction_type: Transaction::CAPTURE,
+        status: Transaction::FAILURE
+      )
     end
   end
 
   describe '#refund_payment' do
     it 'refunds a charge for the full amount' do
-      transaction = PaymentService.refund_payment(captured_charge.id)
-      expect(transaction.external_id).to match(/test_re/i)
+      prepare_payment_intent_refund_success()
+      transaction = PaymentService.refund_payment('pi_1')
+      expect(transaction.external_id).to eq 're_1'
       expect(transaction.transaction_type).to eq Transaction::REFUND
       expect(transaction.status).to eq Transaction::SUCCESS
     end
     it 'catches Stripe errors and returns a failed transaction' do
-      StripeMock.prepare_card_error(:processing_error, :new_refund)
-      transaction = PaymentService.refund_payment(captured_charge.id)
-      expect(transaction.external_id).to eq captured_charge.id
+      prepare_payment_intent_refund_failure(code: 'processing_error', message: 'The card was declined', decline_code: 'failed_refund')
+      transaction = PaymentService.refund_payment('pi_1')
+      expect(transaction.external_id).to eq 'pi_1'
       expect(transaction.failure_code).to eq 'processing_error'
-      expect(transaction.failure_message).to eq 'An error occurred while processing the card'
+      expect(transaction.failure_message).to eq 'The card was declined'
+      expect(transaction.decline_code).to eq 'failed_refund'
       expect(transaction.transaction_type).to eq Transaction::REFUND
       expect(transaction.status).to eq Transaction::FAILURE
     end

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -38,7 +38,7 @@ describe PaymentService, type: :services do
       )
     end
     it 'stores failed attempt data on transaction' do
-      prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: {code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined'})
+      prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
       transaction = PaymentService.hold_payment(params)
       expect(transaction).to have_attributes(
         amount_cents: buyer_amount,
@@ -80,7 +80,7 @@ describe PaymentService, type: :services do
 
   describe '#refund_payment' do
     it 'refunds a charge for the full amount' do
-      prepare_payment_intent_refund_success()
+      prepare_payment_intent_refund_success
       transaction = PaymentService.refund_payment('pi_1')
       expect(transaction.external_id).to eq 're_1'
       expect(transaction.transaction_type).to eq Transaction::REFUND

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -26,8 +26,8 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:create, payment_intent)
   end
 
-  def prepare_payment_intent_capture_failure(status:, charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', status: status, transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
+  def prepare_payment_intent_capture_failure(charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'requires_payment_method')
     allow(payment_intent).to receive(:capture)
     mock_payment_intent_call(:retrieve, payment_intent)

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -3,9 +3,9 @@ RSpec.shared_context 'include stripe helper' do
   after { StripeMock.stop }
 
   def prepare_charge_capture_failure(charge_id, code, decline_code)
-    error = Stripe::StripeError.new()
-    allow(error).to receive(:json_body).and_return({error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code)})
-    fail_charge = double()
+    error = Stripe::StripeError.new
+    allow(error).to receive(:json_body).and_return(error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code))
+    fail_charge = double
     allow(fail_charge).to receive(:capture).and_raise(error)
     allow(Stripe::Charge).to receive(:retrieve).and_return(fail_charge)
   end
@@ -17,24 +17,24 @@ RSpec.shared_context 'include stripe helper' do
   end
 
   def prepare_payment_intent_create_failure(status:, charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: status, last_payment_error: double(charge_error))
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, capture_method: capture ? 'automatic' : 'manual', amount: amount, status: status, last_payment_error: double(charge_error))
     mock_payment_intent_call(:create, payment_intent)
   end
 
   def prepare_payment_intent_create_success(capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: 'succeeded')
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', status: 'succeeded')
     mock_payment_intent_call(:create, payment_intent)
   end
 
   def prepare_payment_intent_capture_failure(status:, charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: status, transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', status: status, transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'requires_payment_method')
     allow(payment_intent).to receive(:capture)
     mock_payment_intent_call(:retrieve, payment_intent)
   end
 
   def prepare_payment_intent_capture_success(capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'))
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', transfer_data: double(destination: 'ma_1'))
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
     allow(payment_intent).to receive(:capture)
     mock_payment_intent_call(:retrieve, payment_intent)
@@ -48,9 +48,9 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:retrieve, payment_intent)
   end
 
-  def prepare_payment_intent_refund_failure(charge_id: 'ch_1', payment_method: 'cc_1',  amount: 20_00, code:, decline_code:, message:)
-    refund_error = Stripe::StripeError.new()
-    allow(refund_error).to receive(:json_body).and_return({error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code)})
+  def prepare_payment_intent_refund_failure(charge_id: 'ch_1', payment_method: 'cc_1', amount: 20_00, code:, decline_code:, message:)
+    refund_error = Stripe::StripeError.new
+    allow(refund_error).to receive(:json_body).and_return(error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code, message: message))
     payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'), charges: [double(id: 'ch_1')])
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
     allow(Stripe::Refund).to receive(:create).with(charge: 'ch_1', reverse_transfer: true).and_raise(refund_error)
@@ -58,7 +58,7 @@ RSpec.shared_context 'include stripe helper' do
   end
 
   def mock_payment_intent_call(method, payment_intent)
-    allow(payment_intent).to receive(:to_h).and_return({id: 'pi_1'})
+    allow(payment_intent).to receive(:to_h).and_return(id: 'pi_1')
     allow(Stripe::PaymentIntent).to receive(method).and_return(payment_intent)
   end
 
@@ -69,63 +69,5 @@ RSpec.shared_context 'include stripe helper' do
       decline_code: 'do_not_honor',
       message: 'The card was declined'
     }.merge(props)
-  end
-
-
-  def basic_payment_intent
-    {
-      id: payment_intent_id,
-      object: "payment_intent",
-      amount: 49900,
-      amount_capturable: 0,
-      amount_received: 0,
-      application: nil,
-      application_fee_amount: nil,
-      canceled_at: nil,
-      cancellation_reason: nil,
-      capture_method: "automatic",
-      charges: {
-        object: "list",
-        data: [],
-        has_more: false,
-        total_count: 0,
-        url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
-      },
-      client_secret: "pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v",
-      confirmation_method: "manual",
-      created: 1563208901,
-      currency: "gbp",
-      customer: nil,
-      description: nil,
-      invoice: nil,
-      last_payment_error: nil,
-      livemode: false,
-      metadata: {},
-      next_action: nil,
-      on_behalf_of: nil,
-      payment_method: nil,
-      payment_method_types: [
-        "card"
-      ],
-      receipt_email: nil,
-      review: nil,
-      setup_future_usage: nil,
-      shipping: nil,
-      source: nil,
-      statement_descriptor: nil,
-      status: "requires_action",
-      transfer_data: nil,
-      transfer_group: nil
-    }
-  end
-
-  def charges_data(data = [])
-    {
-      data: data,
-      object: 'list',
-      has_more: false,
-      total_count: data.count,
-      url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
-    }
   end
 end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -1,0 +1,69 @@
+module StripeHelper
+  def succeeded_payment_intent(params)
+    charge = Stripe::Charge.create()
+    basic_payment_intent.merge(charges: [charge], status: 'succeeded').merge(params)
+  end
+
+  def requires_capture_payment_intent(params)
+    charge = Stripe::Charge.create()
+    basic_payment_intent.merge(charges: [], status: 'requires_capture').merge(params)
+  end
+
+
+  def basic_payment_intent
+    {
+      id: payment_intent_id,
+      object: "payment_intent",
+      amount: 49900,
+      amount_capturable: 0,
+      amount_received: 0,
+      application: nil,
+      application_fee_amount: nil,
+      canceled_at: nil,
+      cancellation_reason: nil,
+      capture_method: "automatic",
+      charges: {
+        object: "list",
+        data: [],
+        has_more: false,
+        total_count: 0,
+        url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
+      },
+      client_secret: "pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v",
+      confirmation_method: "manual",
+      created: 1563208901,
+      currency: "gbp",
+      customer: nil,
+      description: nil,
+      invoice: nil,
+      last_payment_error: nil,
+      livemode: false,
+      metadata: {},
+      next_action: nil,
+      on_behalf_of: nil,
+      payment_method: nil,
+      payment_method_types: [
+        "card"
+      ],
+      receipt_email: nil,
+      review: nil,
+      setup_future_usage: nil,
+      shipping: nil,
+      source: nil,
+      statement_descriptor: nil,
+      status: "requires_action",
+      transfer_data: nil,
+      transfer_group: nil
+    }
+  end
+
+  def charges_data(data: [])
+    {
+      data: data,
+      object: 'list',
+      has_more: false,
+      total_count: data.count,
+      url: "/v1/charges?payment_intent=pi_1EwXFB2eZvKYlo2CggNnFBo8"
+    }
+  end
+end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -44,6 +44,7 @@ RSpec.shared_context 'include stripe helper' do
     payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'), charges: [double(id: 'ch_1')])
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
     refund = double(id: 're_1')
+    allow(refund).to receive(:to_h).and_return(id: 're_1')
     allow(Stripe::Refund).to receive(:create).with(charge: 'ch_1', reverse_transfer: true).and_return(refund)
     mock_payment_intent_call(:retrieve, payment_intent)
   end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -1,12 +1,74 @@
-module StripeHelper
-  def succeeded_payment_intent(params)
-    charge = Stripe::Charge.create()
-    basic_payment_intent.merge(charges: [charge], status: 'succeeded').merge(params)
+RSpec.shared_context 'include stripe helper' do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  def prepare_charge_capture_failure(charge_id, code, decline_code)
+    error = Stripe::StripeError.new()
+    allow(error).to receive(:json_body).and_return({error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code)})
+    fail_charge = double()
+    allow(fail_charge).to receive(:capture).and_raise(error)
+    allow(Stripe::Charge).to receive(:retrieve).and_return(fail_charge)
   end
 
-  def requires_capture_payment_intent(params)
-    charge = Stripe::Charge.create()
-    basic_payment_intent.merge(charges: [], status: 'requires_capture').merge(params)
+  def prepare_charge_capture_success(charge_id = 'ch_1', destination_id = 'ac_1', amount = 200_00)
+    charge = double(id: charge_id, payment_method: 'cc_1', destination: destination_id, amount: amount)
+    allow(Stripe::Charge).to receive(:retrieve).and_return(charge)
+    allow(charge).to receive(:capture)
+  end
+
+  def prepare_payment_intent_create_failure(status:, charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: status, last_payment_error: double(charge_error))
+    mock_payment_intent_call(:create, payment_intent)
+  end
+
+  def prepare_payment_intent_create_success(capture: false, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: 'succeeded')
+    mock_payment_intent_call(:create, payment_intent)
+  end
+
+  def prepare_payment_intent_capture_failure(status:, charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, status: status, transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
+    allow(payment_intent).to receive(:status).and_return('requires_capture', 'requires_payment_method')
+    allow(payment_intent).to receive(:capture)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
+  def prepare_payment_intent_capture_success(capture: false, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'))
+    allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
+    allow(payment_intent).to receive(:capture)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
+  def prepare_payment_intent_refund_success(payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'), charges: [double(id: 'ch_1')])
+    allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
+    refund = double(id: 're_1')
+    allow(Stripe::Refund).to receive(:create).with(charge: 'ch_1', reverse_transfer: true).and_return(refund)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
+  def prepare_payment_intent_refund_failure(charge_id: 'ch_1', payment_method: 'cc_1',  amount: 20_00, code:, decline_code:, message:)
+    refund_error = Stripe::StripeError.new()
+    allow(refund_error).to receive(:json_body).and_return({error: stripe_exception_json_body(charge_id: charge_id, code: code, decline_code: decline_code)})
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'), charges: [double(id: 'ch_1')])
+    allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')
+    allow(Stripe::Refund).to receive(:create).with(charge: 'ch_1', reverse_transfer: true).and_raise(refund_error)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
+  def mock_payment_intent_call(method, payment_intent)
+    allow(payment_intent).to receive(:to_h).and_return({id: 'pi_1'})
+    allow(Stripe::PaymentIntent).to receive(method).and_return(payment_intent)
+  end
+
+  def stripe_exception_json_body(props)
+    {
+      charge: 'ch_1',
+      code: 'card_declined',
+      decline_code: 'do_not_honor',
+      message: 'The card was declined'
+    }.merge(props)
   end
 
 
@@ -57,7 +119,7 @@ module StripeHelper
     }
   end
 
-  def charges_data(data: [])
+  def charges_data(data = [])
     {
       data: data,
       object: 'list',


### PR DESCRIPTION
# Change
https://artsyproduct.atlassian.net/browse/PURCHASE-1331
As part of our path to support for SCA, we need to switch to Stripe's [`PaymentIntent` API](https://stripe.com/docs/payments/payment-intents). 
This means we need to move way from directly using `Charge` API. We need to create a `PaymentIntent` at the time we are trying hold or capture a charge and confirm it. 

* A successfully confirmed `PaymentIntent` will lead to a charge.
* PaymentIntents can fail for different reason when we confirm:
  - They can fail confirmation: Payment intent goes to `require_action` state (not supported in this PR) meaning we need to ask buyer to go through SCA.
  - They can fail processing charge: (think of insufficient funds and etc.) Payment intent goes to `require_payment_method` state (maps to our current charge failures cases)
 
# Stripe API version update?
We are currently on a relatively old version `2017-08-15` which is also our default version on Stripe dashboard. We need to update to latest version `2019-05-16` so we can use these statuses mentioned ☝️. In the older version they are set to different statuses.
We don't want to update our default version in Stripe dashboard since that impacts all places we use Stripe in our services. but we can manually set the version for Exchange by configuring `Stripe` in `stripe.rb`.

# Migration?
We now store `PaymentIntent` in our `Transaction` table, this means now transaction table can have different external types, for that we added `external_type` to `Transaction` and we have a data migration to set it for existing records. 
During capture already held charges and also for refunds, we check to see whats the type of the existing transaction and based on that we decide if we need to use old Charge API or fancy shiny new Payment Intent.
We now also store `payload` of the response coming back from Stripe in `transaction` as `jsonb` for possible later use.

# What this PR is NOT
We don't yet support payment intent in `requires_action` state. This is the state needed for SCA support and will be supported in follow up PRs, this PR is purely switching to PaymentIntent for existing functionality.

# stripe-ruby-mock?
On our first attempt #440 for SCA, we ran into lot of issues with `stripe-ruby-mock` which didn't support `PaymentIntent`s yet. We tried to add support to it by submitting 2 PRs but it was slowing us down, so in this PR we tried to move away from it and use plain Ruby mocks to mock Stripe's calls during tests.
This normally would be worrisome since it feels less realistic when we mock our calls, but now after 2 PRs knowing how `stripe-ruby-mock` works, i don't think our tests are much less realistic than using `stripe-ruby-mock`. This way of testing is def lot easier and less magical.