### PR TITLE
Fix data migration to actually use prefix

### DIFF
--- a/db/migrate/20190723204947_populate_transaction_external_type.rb
+++ b/db/migrate/20190723204947_populate_transaction_external_type.rb
@@ -1,7 +1,7 @@
 class PopulateTransactionExternalType < ActiveRecord::Migration[5.2]
   def up
-    Transaction.where('external_id LIKE :prefix', prefix: 'ch_').update_all(external_type: Transaction::CHARGE)
-    Transaction.where('external_id LIKE :prefix', prefix: 're_').update_all(external_type: Transaction::REFUND)
+    Transaction.where('external_id LIKE :prefix', prefix: 'ch_%').update_all(external_type: Transaction::CHARGE)
+    Transaction.where('external_id LIKE :prefix', prefix: 're_%').update_all(external_type: Transaction::REFUND)
   end
 
   def down


### PR DESCRIPTION
Update data migration that was missing `%` when doing a prefix matching for `external_id`.