### PR TITLE
Fix missing setting external_charge_id on approved offers

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -82,6 +82,8 @@ module OfferService
       # in case of failed transaction, we need to rollback this block,
       # but still need to add transaction, so we raise an ActiveRecord::Rollback
       raise ActiveRecord::Rollback if order_processor.failed_payment?
+
+      order.update!(external_charge_id: order_processor.transaction.external_id)
     end
     order.transactions << order_processor.transaction
     PostTransactionNotificationJob.perform_later(order_processor.transaction.id, user_id)

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -196,11 +196,8 @@ describe Api::GraphqlController, type: :request do
         expect(response_order.state).to eq Order::APPROVED.upcase
 
         expect(response.data.buyer_accept_offer.order_or_error).not_to respond_to(:error)
-        expect(order.reload.state).to eq Order::APPROVED
-        expect(order.state_updated_at).not_to be_nil
-        expect(order.state_expires_at).to eq(order.state_updated_at + 7.days)
-        expect(order.reload.transactions.last.external_id).not_to be_nil
-        expect(order.reload.transactions.last.transaction_type).to eq Transaction::CAPTURE
+        expect(order.reload).to have_attributes(state: Order::APPROVED, state_expires_at: order.state_updated_at + 7.days, external_charge_id: 'pi_1')
+        expect(order.reload.transactions.last).to have_attributes(external_id: 'pi_1', transaction_type: Transaction::CAPTURE)
       end
     end
   end

--- a/spec/integration/make_offer_happy_path_spec.rb
+++ b/spec/integration/make_offer_happy_path_spec.rb
@@ -122,7 +122,8 @@ describe Api::GraphqlController, type: :request do
         seller_total_cents: 726_50,
         fulfillment_type: Order::SHIP,
         shipping_country: 'US',
-        credit_card_id: 'cc-1'
+        credit_card_id: 'cc-1',
+        external_charge_id: 'pi_1'
       )
       expect(order.transactions.order(created_at: :desc).first).to have_attributes(
         transaction_type: Transaction::CAPTURE,


### PR DESCRIPTION
# Problem
When we tried to refund our test offer orders on production we noticed the refund fails.

# Cause
During [our refactor](https://github.com/artsy/exchange/pull/442) we moved the responsibility of setting `external_charge_id` on an `Order` from `order_processor` to the caller. We fixed `order_service` to set it in a successful transaction but we missed it on the `offer_service`.

# Impact
Any offers approved after deploy https://github.com/artsy/exchange/pull/444 won't have `external_charge_id` so can't be refunded. 

NOTE BN orders are fine and also partner's don't have the option for refund, this all happens by our admins from exchange admin.

# Solution
Update `offer_service` to set `external_charge_id` in case of success and add tests for it.  

## Migration
for offers approved in last 4 days without `external_charge_id` we have to set them to their successful transaction external id.
