### PR TITLE
Add internalID to all our types

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -85,6 +85,7 @@ type BuyOrder implements Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  internalID: ID!
 
   """
   Item total in cents, for Offer Orders this field reflects current offer
@@ -465,6 +466,7 @@ type Fulfillment {
   createdAt: DateTime!
   estimatedDelivery: Date
   id: ID!
+  internalID: ID!
   notes: String
   trackingId: String
   updatedAt: DateTime!
@@ -546,6 +548,7 @@ type LineItem {
     last: Int
   ): FulfillmentConnection
   id: ID!
+  internalID: ID!
   listPriceCents: Int!
   order: Order!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
@@ -627,6 +630,7 @@ type Offer {
   from: OrderPartyUnion!
   fromParticipant: OrderParticipantEnum
   id: ID!
+  internalID: ID!
   note: String
   order: Order!
   respondsTo: Offer
@@ -683,6 +687,7 @@ type OfferOrder implements Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  internalID: ID!
 
   """
   Item total in cents, for Offer Orders this field reflects current offer
@@ -771,6 +776,7 @@ interface Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  internalID: ID!
 
   """
   Item total in cents, for Offer Orders this field reflects current offer

--- a/app/graphql/types/fulfillment_type.rb
+++ b/app/graphql/types/fulfillment_type.rb
@@ -3,6 +3,7 @@ class Types::FulfillmentType < Types::BaseObject
   graphql_name 'Fulfillment'
 
   field :id, ID, null: false
+  field :internalID, ID, null: false, method: :id, camelize: false
   field :courier, String, null: false
   field :tracking_id, String, null: true
   field :estimated_delivery, Types::DateType, null: true

--- a/app/graphql/types/line_item_type.rb
+++ b/app/graphql/types/line_item_type.rb
@@ -3,6 +3,7 @@ class Types::LineItemType < Types::BaseObject
   graphql_name 'LineItem'
 
   field :id, ID, null: false
+  field :internalID, ID, null: false, method: :id, camelize: false
   field :price_cents, Integer, null: false, deprecation_reason: 'switch to use listPriceCents'
   field :list_price_cents, Integer, null: false
   field :shipping_total_cents, Integer, null: true

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -3,6 +3,7 @@ class Types::OfferType < Types::BaseObject
   graphql_name 'Offer'
 
   field :id, ID, null: false
+  field :internalID, ID, null: false, method: :id, camelize: false
   field :from, Types::OrderPartyUnionType, null: false
   field :amount_cents, Integer, null: false
   field :tax_total_cents, Integer, null: true

--- a/app/graphql/types/order_interface.rb
+++ b/app/graphql/types/order_interface.rb
@@ -6,6 +6,7 @@ module Types::OrderInterface
   graphql_name 'Order'
 
   field :id, ID, null: false
+  field :internalID, ID, null: false, method: :id, camelize: false
   field :mode, Types::OrderModeEnum, null: true
   field :code, String, null: false
   field :buyer_phone_number, String, null: true

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -37,6 +37,7 @@ describe Api::GraphqlController, type: :request do
         query($id: ID, $offerFromId: String, $offerFromType: String) {
           order(id: $id) {
             id
+            internalID
             mode
             buyer {
               ... on User {
@@ -363,6 +364,7 @@ describe Api::GraphqlController, type: :request do
 
         it 'returns expected payload' do
           result = client.execute(query, id: user2_order1.id)
+          expect(result.data.order.internal_id).to eq user2_order1.id
           expect(result.data.order.buyer.id).to eq user2_order1.buyer_id
           expect(result.data.order.seller.id).to eq user2_order1.seller_id
           expect(result.data.order.currency_code).to eq 'USD'


### PR DESCRIPTION
Follows https://artsyproduct.atlassian.net/browse/PLATFORM-1448 to add `internalID` to all our types pointing to ID.

# Possible follow ups
have our mutations/queries accept `internalID`