### PR TITLE
Fix `rspec` warning

### DIFF
--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe Order, type: :model do
 
   describe 'validate currency' do
     it 'raises invalid record for unsupported currencies' do
-      expect { order.update!(currency_code: 'USD') }.to_not raise_error(ActiveRecord::RecordInvalid)
-      expect { order.update!(currency_code: 'GBP') }.to_not raise_error(ActiveRecord::RecordInvalid)
+      order.currency_code = 'USD'
+      expect(order.valid?).to be true
+      order.currency_code = 'GBP'
+      expect(order.valid?).to be true
+      order.currency_code = 'CAD'
+      expect(order.valid?).to be false
       expect { order.update!(currency_code: 'CAD') }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Currency code is not included in the list')
     end
   end


### PR DESCRIPTION
# Problem
Exchange `rspec` was showing warnings about checking for not raising an error.

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /app/spec/models/order_spec.rb:10:in `block (3 levels) in <top (required)>'
``` 

# Change
instead of `update!` set the values for those attributes and check for `valid?` from `ActiveRecord`.