### PR TITLE
Add support for `requires_action` payment_intent state

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 9
 
 Metrics/AbcSize:
-  Max: 52
+  Max: 54
   Exclude:
     - "db/migrate/*"
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -518,11 +518,6 @@ type FulfillmentEdge {
 }
 
 """
-Represents untyped JSON
-"""
-scalar JSON
-
-"""
 A Line Item
 """
 type LineItem {
@@ -827,6 +822,13 @@ interface Order {
 }
 
 """
+Order Action data
+"""
+type OrderActionData {
+  clientSecret: String!
+}
+
+"""
 Fields to sort by
 """
 enum OrderConnectionSortEnum {
@@ -952,7 +954,7 @@ type OrderRequiresAction {
   """
   Data related to action needed
   """
-  actionData: JSON!
+  actionData: OrderActionData!
 }
 
 enum OrderStateEnum {

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -518,6 +518,11 @@ type FulfillmentEdge {
 }
 
 """
+Represents untyped JSON
+"""
+scalar JSON
+
+"""
 A Line Item
 """
 type LineItem {
@@ -921,7 +926,7 @@ enum OrderModeEnum {
 """
 Represents either a resolved Order or a potential failure
 """
-union OrderOrFailureUnion = OrderWithMutationFailure | OrderWithMutationSuccess
+union OrderOrFailureUnion = OrderRequiresAction | OrderWithMutationFailure | OrderWithMutationSuccess
 
 enum OrderParticipantEnum {
   """
@@ -939,6 +944,16 @@ enum OrderParticipantEnum {
 Represents either a partner or a user
 """
 union OrderPartyUnion = Partner | User
+
+"""
+Data reflecting actions required
+"""
+type OrderRequiresAction {
+  """
+  Data related to action needed
+  """
+  actionData: JSON!
+}
 
 enum OrderStateEnum {
   """

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -58,6 +58,7 @@ module Errors
       capture_failed
       charge_authorization_failed
       insufficient_inventory
+      payment_requires_action
       received_partial_refund
       refund_failed
       tax_calculator_failure

--- a/app/controllers/errors/payment_requires_action_error.rb
+++ b/app/controllers/errors/payment_requires_action_error.rb
@@ -1,0 +1,9 @@
+module Errors
+  class PaymentRequiresActionError < ProcessingError
+    attr_reader :action_data
+    def initialize(action_data)
+      @action_data = action_data
+      super(:payment_requires_action, @action_data)
+    end
+  end
+end

--- a/app/graphql/mutations/order_or_failure_union_type.rb
+++ b/app/graphql/mutations/order_or_failure_union_type.rb
@@ -10,7 +10,7 @@ end
 
 class Mutations::OrderRequiresAction < Types::BaseObject
   description 'Data reflecting actions required'
-  field :action_data, GraphQL::Types::JSON, null: false, description: 'Data related to action needed'
+  field :action_data, Types::OrderActionDataType, null: false, description: 'Data related to action needed'
 end
 
 class Mutations::OrderOrFailureUnionType < Types::BaseUnion

--- a/app/graphql/mutations/order_or_failure_union_type.rb
+++ b/app/graphql/mutations/order_or_failure_union_type.rb
@@ -8,15 +8,22 @@ class Mutations::OrderWithMutationFailure < Types::BaseObject
   field :error, Types::ApplicationErrorType, null: false
 end
 
+class Mutations::OrderRequiresAction < Types::BaseObject
+  description 'Data reflecting actions required'
+  field :action_data, GraphQL::Types::JSON, null: false, description: 'Data related to action needed'
+end
+
 class Mutations::OrderOrFailureUnionType < Types::BaseUnion
   description 'Represents either a resolved Order or a potential failure'
-  possible_types Mutations::OrderWithMutationSuccess, Mutations::OrderWithMutationFailure
+  possible_types Mutations::OrderWithMutationSuccess, Mutations::OrderWithMutationFailure, Mutations::OrderRequiresAction
 
   def self.resolve_type(object, _context)
     if object.key?(:order)
       Mutations::OrderWithMutationSuccess
     elsif object.key?(:error)
       Mutations::OrderWithMutationFailure
+    elsif object.key?(:action_data)
+      Mutations::OrderRequiresAction
     else
       raise "Unexpected Return value: #{object.inspect}"
     end

--- a/app/graphql/mutations/submit_order.rb
+++ b/app/graphql/mutations/submit_order.rb
@@ -9,6 +9,8 @@ class Mutations::SubmitOrder < Mutations::BaseMutation
     order = Order.find(id)
     authorize_buyer_request!(order)
     { order_or_error: { order: OrderService.submit!(order, current_user_id) } }
+  rescue Errors::PaymentRequiresActionError => e
+    { order_or_error: { action_data: e.action_data } }
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
   end

--- a/app/graphql/types/order_action_data_type.rb
+++ b/app/graphql/types/order_action_data_type.rb
@@ -1,0 +1,6 @@
+class Types::OrderActionDataType < Types::BaseObject
+  description 'Order Action data'
+  graphql_name 'OrderActionData'
+
+  field :client_secret, String, null: false
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -29,6 +29,10 @@ class Transaction < ApplicationRecord
     status == FAILURE
   end
 
+  def requires_action?
+    status == REQUIRES_ACTION
+  end
+
   def failure_data
     {
       id: id,

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -68,6 +68,7 @@ module OrderService
     order.transactions << order_processor.transaction
     PostTransactionNotificationJob.perform_later(order_processor.transaction.id, user_id)
     raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction) if order_processor.failed_payment?
+    raise Errors::PaymentRequiresActionError, order_processor.action_data if order_processor.requires_action?
 
     OrderEvent.delay_post(order, Order::SUBMITTED, user_id)
     OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)

--- a/hokusai/sca.yml
+++ b/hokusai/sca.yml
@@ -1,0 +1,189 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sca
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: exchange-web
+  namespace: sca
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: exchange
+        component: web
+        layer: application
+      name: exchange-web
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+            weight: 1
+      containers:
+      - env:
+        - name: PORT
+          value: '8080'
+        - name: RAILS_SERVE_STATIC_FILES
+          value: 'true'
+        - name: RAILS_LOG_TO_STDOUT
+          value: 'true'
+        - name: RAILS_ENV
+          value: production
+        - name: DATADOG_TRACE_AGENT_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        envFrom:
+        - configMapRef:
+            name: exchange-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:sca
+        imagePullPolicy: Always
+        name: exchange-web
+        ports:
+        - containerPort: 8080
+          name: exchange-http
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: X-Forwarded-Proto
+              value: https
+            path: /api/health
+            port: exchange-http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+      - env:
+        - name: NGINX_DEFAULT_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: default
+              name: nginx-config
+        image: artsy/docker-nginx:1.14.2
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/sbin/nginx
+              - -s
+              - quit
+        name: exchange-nginx
+        ports:
+        - containerPort: 80
+          name: nginx-http
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          tcpSocket:
+            port: nginx-http
+          timeoutSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/nginx/ssl
+          name: nginx-secrets
+      volumes:
+      - name: nginx-secrets
+        secret:
+          defaultMode: 420
+          secretName: nginx-secrets
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: exchange-sidekiq
+  namespace: sca
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: exchange
+        component: sidekiq
+        layer: application
+      name: exchange-sidekiq
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - background
+            weight: 1
+      containers:
+      - command:
+        - bundle
+        - exec
+        - sidekiq
+        envFrom:
+        - configMapRef:
+            name: exchange-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/exchange:sca
+        imagePullPolicy: Always
+        name: exchange-sidekiq
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
+  labels:
+    app: exchange
+    component: web
+    layer: application
+  name: exchange-web
+  namespace: sca
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: nginx-http
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: nginx-http
+  selector:
+    app: exchange
+    component: web
+    layer: application
+  type: LoadBalancer
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: exchange-web
+  namespace: sca
+spec:
+  maxReplicas: 6
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: exchange-web
+  targetCPUUtilizationPercentage: 70

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -43,11 +43,11 @@ class OrderProcessor
   end
 
   def failed_payment?
-    @transaction.present? && @transaction.failed?
+    @transaction&.failed?
   end
 
   def requires_action?
-    @transaction.present? && @transaction.requires_action?
+    @transaction&.requires_action?
   end
 
   def action_data

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -94,6 +94,8 @@ module PaymentService
     case payment_intent.status # https://stripe.com/docs/payments/intents#intent-statuses
     when 'requires_capture'
       transaction.status = Transaction::REQUIRES_CAPTURE
+    when 'requires_action'
+      transaction.status = Transaction::REQUIRES_ACTION
     when 'succeeded'
       transaction.status = Transaction::SUCCESS
     else

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -64,7 +64,9 @@ describe Api::GraphqlController, type: :request do
                 }
               }
               ... on OrderRequiresAction {
-                actionData
+                actionData {
+                  clientSecret
+                }
               }
             }
           }
@@ -208,7 +210,7 @@ describe Api::GraphqlController, type: :request do
 
         it 'returns action data' do
           response = client.execute(mutation, submit_order_input)
-          expect(response.data.submit_order.order_or_error.action_data['client_secret']).to eq 'pi_test1'
+          expect(response.data.submit_order.order_or_error.action_data.client_secret).to eq 'pi_test1'
         end
 
         it 'stores failed transaction' do

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -63,6 +63,9 @@ describe Api::GraphqlController, type: :request do
                   type
                 }
               }
+              ... on OrderRequiresAction {
+                actionData
+              }
             }
           }
         }
@@ -184,6 +187,36 @@ describe Api::GraphqlController, type: :request do
           end.to change(order.transactions.where(status: Transaction::FAILURE), :count).by(1)
           expect(order.reload.external_charge_id).to be_nil
           expect(order.transactions.last.failed?).to be true
+        end
+
+        it 'undeducts inventory' do
+          client.execute(mutation, submit_order_input)
+          expect(undeduct_inventory_request).to have_been_requested
+        end
+      end
+
+      context 'with payment requires action' do
+        before do
+          deduct_inventory_request
+          merchant_account_request
+          credit_card_request
+          artwork_request
+          partner_account_request
+          undeduct_inventory_request
+          prepare_payment_intent_create_failure(status: 'requires_action')
+        end
+
+        it 'returns action data' do
+          response = client.execute(mutation, submit_order_input)
+          expect(response.data.submit_order.order_or_error.action_data['client_secret']).to eq 'pi_test1'
+        end
+
+        it 'stores failed transaction' do
+          expect do
+            client.execute(mutation, submit_order_input)
+          end.to change(order.transactions.where(status: Transaction::REQUIRES_ACTION), :count).by(1)
+          expect(order.reload.external_charge_id).to eq 'pi_1'
+          expect(order.transactions.last.requires_action?).to be true
         end
 
         it 'undeducts inventory' do

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -16,10 +16,10 @@ RSpec.shared_context 'include stripe helper' do
     allow(charge).to receive(:capture)
   end
 
-  def prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00)
+  def prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00, client_secret: 'pi_test1')
     case status
     when 'requires_action'
-      payment_intent = double(id: 'pi_1', payment_method: payment_method, capture_method: capture ? 'automatic' : 'manual', amount: amount, status: status, last_payment_error: double(charge_error))
+      payment_intent = double(id: 'pi_1', payment_method: payment_method, capture_method: capture ? 'automatic' : 'manual', amount: amount, status: status, client_secret: client_secret)
       mock_payment_intent_call(:create, payment_intent)
     when 'requires_payment_method'
       error = Stripe::CardError.new(charge_error[:message], charge_error[:decline_code], charge_error[:code])
@@ -67,7 +67,7 @@ RSpec.shared_context 'include stripe helper' do
   end
 
   def mock_payment_intent_call(method, payment_intent)
-    allow(payment_intent).to receive(:to_h).and_return(id: 'pi_1')
+    allow(payment_intent).to receive(:to_h).and_return(id: 'pi_1', client_secret: 'pi_test1')
     allow(Stripe::PaymentIntent).to receive(method).and_return(payment_intent)
   end
 


### PR DESCRIPTION
# Change
during #443 we switched over to `PaymentIntent` instead of charge. But that change yet doesn't support new status we could get back from that API where PaymentIntent was not `succeeded` and needed `requires_action`.

## What does it mean transaction-wise?
In `requires_action` case, we store a transaction in `Transaction` with status being newly added `Transaction::REQUIRES_ACTION`.
We also update the order's `external_charge_id` to be this payment intent's id so we can reuse it later when user was done with 3d auth.

## Exposing this state via GraphQL
When a `PaymentIntent` goes to `requires_action` state, we need to return `client_secret` of the `payementIntent` back to the client, so client can use it to call Stripe.js to open popup and go through 3d auth process. The way we do this is by updating our existing `OrderOrFailureUnion` type to also now possibly return `OrderPaymentRequiresAction` type which would have a  `actionData` with new `orderActionData` type that exposes `client_secret`.

# What this PR is NOT
this PR doesn't support re-submitting an order after user been through 3d auth. Meaning if this goes live, we can get data about this state so client can show the pop up but once they passed that and re-submit we'd create a new payment intent which would go through the same state. This will be covered in a follow up PR.