### PR TITLE
Expose currency_code in offer graphQL response

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -627,6 +627,7 @@ type Offer {
   buyerTotalCents: Int
   createdAt: DateTime!
   creatorId: String!
+  currencyCode: String!
   from: OrderPartyUnion!
   fromParticipant: OrderParticipantEnum
   id: ID!

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -16,11 +16,16 @@ class Types::OfferType < Types::BaseObject
   field :from_participant, Types::OrderParticipantEnum, null: true
   field :buyer_total_cents, Integer, null: true
   field :note, String, null: true
+  field :currency_code, String, null: false
 
   def from
     OpenStruct.new(
       id: object.from_id,
       type: object.from_type
     )
+  end
+
+  def currency_code
+    object.order.currency_code
   end
 end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -98,8 +98,10 @@ describe Api::GraphqlController, type: :request do
 
       # Buyer submits offer order
       expect do
-        buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+        response = buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+        expect(response.data.submit_order_with_offer.order_or_error.order.last_offer.currency_code).to eq('GBP')
       end.to change(order.transactions, :count).by(0)
+
       expect(order.reload).to have_attributes(
         state: Order::SUBMITTED,
         items_total_cents: 500_00,
@@ -118,6 +120,7 @@ describe Api::GraphqlController, type: :request do
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)
+
       expect(order.reload).to have_attributes(
         state: Order::APPROVED,
         items_total_cents: 500_00,

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -147,6 +147,7 @@ module OfferQueryHelper # rubocop:disable Metrics/ModuleLength
                 lastOffer {
                   id
                   submittedAt
+                  currencyCode
                 }
               }
             }


### PR DESCRIPTION
This adds `currency_code` as a field returned in an `Offer`'s graphQL response.

This will allow `amount` fields on `Offer` to be formatted correctly in metaphysics. 
