### PR TITLE
Prevent Tax Calculation for Artworks Outside the United States (GALL-1942)

### DIFF
--- a/lib/tax/calculator_service.rb
+++ b/lib/tax/calculator_service.rb
@@ -18,7 +18,7 @@ class Tax::CalculatorService
     @seller_nexus_addresses = process_nexus_addresses!(nexus_addresses)
     @fulfillment_type = fulfillment_type
     @tax_client = tax_client
-    @artwork_location = artwork_location
+    @artwork_location = process_artwork_location!(artwork_location)
     @shipping_address = shipping_address
     @shipping_total_cents = shipping_total_cents
     @transaction = nil
@@ -107,5 +107,11 @@ class Tax::CalculatorService
 
   def validate_nexus_address!(nexus_address)
     raise Errors::ValidationError, :invalid_seller_address if nexus_address.region.nil?
+  end
+
+  def process_artwork_location!(artwork_location)
+    raise Errors::ValidationError, :no_taxable_addresses unless address_taxable?(artwork_location)
+
+    artwork_location
   end
 end

--- a/spec/integration/gbp/buy_now_happy_path_spec.rb
+++ b/spec/integration/gbp/buy_now_happy_path_spec.rb
@@ -147,14 +147,19 @@ describe Api::GraphqlController, type: :request do
     context 'seller also has a US location' do
       let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY'), Address.new(state: 'NY', country: 'US', postal_code: '10001')] }
 
-      it 'does not charge sales tax' do
-        [{ type: 'SHIP', address: buyer_shipping_address }, { type: 'PICKUP', address: nil }].each do |fulfillment|
-          buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
-          order = Order.last
+      it 'does not charge sales tax when fulfilled via shipping' do
+        buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+        order = Order.last
 
-          buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: fulfillment[:type], shipping: fulfillment[:address] })
-          expect(order.reload).to have_attributes(tax_total_cents: 0)
-        end
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+        expect(order.reload).to have_attributes(tax_total_cents: 0)
+      end
+      it 'does not charge sales tax when fulfilled via pickup' do
+        buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+        order = Order.last
+
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil })
+        expect(order.reload).to have_attributes(tax_total_cents: nil)
       end
     end
   end

--- a/spec/integration/gbp/buy_now_happy_path_spec.rb
+++ b/spec/integration/gbp/buy_now_happy_path_spec.rb
@@ -143,5 +143,19 @@ describe Api::GraphqlController, type: :request do
       expect(order.reload).to have_attributes(state: Order::FULFILLED)
       expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
     end
+
+    context 'seller also has a US location' do
+      let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY'), Address.new(state: 'NY', country: 'US', postal_code: '10001')] }
+
+      it 'does not charge sales tax' do
+        [{ type: 'SHIP', address: buyer_shipping_address }, { type: 'PICKUP', address: nil }].each do |fulfillment|
+          buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+          order = Order.last
+
+          buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: fulfillment[:type], shipping: fulfillment[:address] })
+          expect(order.reload).to have_attributes(tax_total_cents: 0)
+        end
+      end
+    end
   end
 end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -153,5 +153,23 @@ describe Api::GraphqlController, type: :request do
       expect(order.reload).to have_attributes(state: Order::FULFILLED)
       expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
     end
+
+    context 'seller also has a US location' do
+      let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY'), Address.new(state: 'NY', country: 'US', postal_code: '10001')] }
+
+      it 'does not charge sales tax' do
+        [{ type: 'SHIP', address: buyer_shipping_address }, { type: 'PICKUP', address: nil }].each do |fulfillment|
+          buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+          order = Order.last
+
+          buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+          offer = Offer.last
+
+          buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: fulfillment[:type], shipping: fulfillment[:address] })
+          expect(order.reload).to have_attributes(tax_total_cents: nil)
+          expect(offer.reload).to have_attributes(tax_total_cents: 0)
+        end
+      end
+    end
   end
 end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -157,18 +157,25 @@ describe Api::GraphqlController, type: :request do
     context 'seller also has a US location' do
       let(:seller_addresses) { [Address.new(city: 'London', country: 'GB', postal_code: 'SW3 4RY'), Address.new(state: 'NY', country: 'US', postal_code: '10001')] }
 
-      it 'does not charge sales tax' do
-        [{ type: 'SHIP', address: buyer_shipping_address }, { type: 'PICKUP', address: nil }].each do |fulfillment|
-          buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
-          order = Order.last
+      it 'does not charge sales tax when fulfilled via shipping' do
+        buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+        order = Order.last
 
-          buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
-          offer = Offer.last
+        buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+        offer = Offer.last
 
-          buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: fulfillment[:type], shipping: fulfillment[:address] })
-          expect(order.reload).to have_attributes(tax_total_cents: nil)
-          expect(offer.reload).to have_attributes(tax_total_cents: 0)
-        end
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+        expect(offer.reload).to have_attributes(tax_total_cents: 0)
+      end
+      it 'does not charge sales tax when fulfilled via pickup' do
+        buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+        order = Order.last
+
+        buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+        offer = Offer.last
+
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil })
+        expect(offer.reload).to have_attributes(tax_total_cents: nil)
       end
     end
   end


### PR DESCRIPTION
### Description

The purpose of this PR is to update the tax calculation logic in Exchange to prevent sales tax being calculated for an order (or offer-order) if the buyer is purchasing an artwork located outside of the United States. This is being done so that orders for artwork located in the UK aren't taxed once we enable NSO for UK partners.

### Diagram

This diagram explains what happens after a buyer enters their shipping information during the Buy Now flow, with a focus on how sales tax is calculated. This PR adds the section highlighted in red.

![Buy now shipping and tax (1)](https://user-images.githubusercontent.com/44589599/62295125-5fcec500-b43a-11e9-8693-a8a8c65ef169.png)