### PR TITLE
Rollback when requires_action

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 9
 
 Metrics/AbcSize:
-  Max: 54
+  Max: 59
   Exclude:
     - "db/migrate/*"
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/ClassLength:
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:
-  Max: 7
+  Max: 8
 
 # Offense count: 26
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/submit_order_mutation_request_spec.rb
@@ -225,6 +225,11 @@ describe Api::GraphqlController, type: :request do
           client.execute(mutation, submit_order_input)
           expect(undeduct_inventory_request).to have_been_requested
         end
+
+        it 'does not change order state' do
+          client.execute(mutation, submit_order_input)
+          expect(order.reload.state).to eq Order::PENDING
+        end
       end
 
       it 'submits the order' do


### PR DESCRIPTION
This is follow up on #455 where we missed rollback on case of `reuqires_action` payment intents.

Things get more complicated in `submit` method with this change, so im thinking of attempting the refactor after this PR but for now this should fix existing bug on `master` and staging.