### PR TITLE
Confirm payment intent

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -55,6 +55,7 @@ module Errors
     processing: %i[
       artwork_version_mismatch
       cannot_capture
+      cannot_confirm
       capture_failed
       charge_authorization_failed
       insufficient_inventory

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -11,7 +11,8 @@ class Transaction < ApplicationRecord
   TYPES = [
     HOLD = 'hold'.freeze,
     CAPTURE = 'capture'.freeze,
-    REFUND = 'refund'.freeze
+    REFUND = 'refund'.freeze,
+    CONFIRM = 'confirm'.freeze
   ].freeze
 
   STATUSES = [

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -25,7 +25,7 @@ class OrderProcessor
 
     deduct_inventory
     @transaction = if @order.external_charge_id
-      # here are are assuming this external_charge_id is a PaymentIntent id.
+      # here we are assuming this external_charge_id is a PaymentIntent id.
       # we already have a payment intent on this order
       PaymentService.confirm_payment_intent(@order.external_charge_id)
     else

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -24,7 +24,12 @@ class OrderProcessor
     raise Errors::ValidationError, @validation_error unless valid?
 
     deduct_inventory
-    @transaction = PaymentService.hold_payment(construct_charge_params)
+    @transaction = if @order.external_charge_id
+      # we already have a payment intent on this order
+      PaymentService.confirm(@order.external_charge_id)
+    else
+      PaymentService.hold_payment(construct_charge_params)
+    end
     undeduct_inventory if @transaction.failed? || @transaction.requires_action?
   rescue Errors::InsufficientInventoryError
     undeduct_inventory

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -26,7 +26,7 @@ class OrderProcessor
     deduct_inventory
     @transaction = if @order.external_charge_id
       # we already have a payment intent on this order
-      PaymentService.confirm(@order.external_charge_id)
+      PaymentService.confirm_payment_intent(@order.external_charge_id)
     else
       PaymentService.hold_payment(construct_charge_params)
     end

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -25,6 +25,7 @@ class OrderProcessor
 
     deduct_inventory
     @transaction = if @order.external_charge_id
+      # here are are assuming this external_charge_id is a PaymentIntent id.
       # we already have a payment intent on this order
       PaymentService.confirm_payment_intent(@order.external_charge_id)
     else

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -60,7 +60,15 @@ module PaymentService
     raise Errors::ProcessingError, :cannot_confirm unless payment_intent.status == 'processing'
 
     payment_intent.confirm
-    Transaction.new(external_id: payment_intent.id, external_type: Transaction::PAYMENT_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::SUCCESS, payload: payment_intent.to_h)
+    Transaction.new(
+      external_id: payment_intent.id,
+      external_type: Transaction::PAYMENT_INTENT,
+      transaction_type: Transaction::CONFIRM,
+      status: Transaction::SUCCESS,
+      amount_cents: payment_intent.amount,
+      source_id: payment_intent.payment_method,
+      payload: payment_intent.to_h
+    )
   rescue Stripe::CardError => e
     transaction_from_payment_intent_failure(e)
   end

--- a/spec/integration/buy_now_sca_path.rb
+++ b/spec/integration/buy_now_sca_path.rb
@@ -1,0 +1,169 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'include stripe helper'
+  include_context 'GraphQL Client Helpers'
+  describe 'buy now happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        undeduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds the process of buyer create -> set shipping -> set payment -> submit -> requires_action -> seller accept' do
+      # Buyer creates the order
+      expect do
+        buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, items_total_cents: 1000_00, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US'
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits order but requires action
+      prepare_payment_intent_create_failure(status: 'requires_action', amount: 1300_00)
+      expect do
+        buyer_client.execute(QueryHelper::SUBMIT_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        commission_fee_cents: nil,
+        transaction_fee_cents: nil,
+        seller_total_cents: nil,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.last).to have_attributes(
+        transaction_type: Transaction::HOLD,
+        external_id: 'pi_1',
+        external_type: Transaction::PAYMENT_INTENT,
+        amount_cents: 1300_00,
+        status: Transaction::REQUIRES_ACTION,
+        source_id: 'cc_1'
+      )
+
+      # Buyer re-submits the order
+      prepare_payment_intent_confirm_success(amount: 1300_00)
+      expect do
+        buyer_client.execute(QueryHelper::SUBMIT_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 100_00
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CONFIRM,
+        external_id: 'pi_1',
+        external_type: Transaction::PAYMENT_INTENT,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS,
+        source_id: 'cc_1'
+      )
+
+      # seller accepts order
+      prepare_payment_intent_capture_success(amount: 1300_00)
+      expect do
+        seller_client.execute(QueryHelper::APPROVE_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1300_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 100_00,
+        transaction_fee_cents: 38_00,
+        seller_total_cents: 1162_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end


### PR DESCRIPTION
# Change
In #455 we started supporting `requires_action` state of `PaymentIntent`. In this case, we notify clients about this state and provide them with `client_secret` for this specific PaymentIntent which will be used to call `stripe.js`'s method to open 3D auth process.

Once 3D auth was successful, we call Exchange to submit the order again. In this case, we don't want to create a new payment intent, we have to confirm the existing one assuming its in `processing` [state](https://stripe.com/docs/payments/intents#intent-statuses).

This PR checks to see if during submission, order has `external_charge_id` set, we will confirm that payment intent instead of creating a new one.

# Follow up
When we get to requires action case, it's possible that user instead of going through 3D auth, they decide to change their payment method, in this case we cant just reuse existing payment intent and we need to either update existing one to use new payment method or create a whole new payment intent.

# Ultimate follow up ;)
`OrderService` code is getting super complicated and hard to read, planning to do some cleanup and explorations to make it more readable, for now trying to unblock client side work with existing structure.
