### PR TITLE
Send shipping address to stripe

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'db/migrate/**'
 
 Metrics/ParameterLists:
-  Max: 9
+  Max: 10
 
 Metrics/AbcSize:
   Max: 59
@@ -25,7 +25,7 @@ Metrics/BlockLength:
     - "spec/**/*"
 
 Metrics/MethodLength:
-  Max: 32
+  Max: 43
   Exclude:
     - "db/migrate/*"
 

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -90,7 +90,9 @@ class OrderProcessor
       seller_amount: @order.seller_total_cents,
       currency_code: @order.currency_code,
       metadata: charge_metadata,
-      description: charge_description
+      description: charge_description,
+      shipping_address: @order.shipping_address,
+      shipping_name: @order.shipping_name
     }
   end
 


### PR DESCRIPTION
# Problem
Send shipping address when creating payment intents.
part of https://artsyproduct.atlassian.net/browse/PURCHASE-1377

# Why?
Why not?!

# No, really!
well, giving stripe more info can help them (and ultimately us) to do better job detecting fraud.