### PR TITLE
Cancel payment intent instead of refund when un-captured

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,9 @@ Metrics/MethodLength:
     - "db/migrate/*"
 
 Metrics/ModuleLength:
-  Max: 151
+  Max: 160
+  Exclude:
+    - "spec/**/*"
 
 Style/Documentation:
   Enabled: false

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,7 +12,8 @@ class Transaction < ApplicationRecord
     HOLD = 'hold'.freeze,
     CAPTURE = 'capture'.freeze,
     REFUND = 'refund'.freeze,
-    CONFIRM = 'confirm'.freeze
+    CONFIRM = 'confirm'.freeze,
+    CANCEL = 'cancel'.freeze
   ].freeze
 
   STATUSES = [

--- a/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/reject_order_mutation_request_spec.rb
@@ -79,14 +79,14 @@ describe Api::GraphqlController, type: :request do
         order.update_attributes! state: Order::SUBMITTED
       end
       it 'rejects the order' do
-        prepare_payment_intent_refund_success
+        prepare_payment_intent_cancel_success
         response = client.execute(mutation, reject_order_input)
         expect(response.data.reject_order.order_or_error.order.id).to eq order.id.to_s
         expect(response.data.reject_order.order_or_error.order.state).to eq 'CANCELED'
         expect(response.data.reject_order.order_or_error).not_to respond_to(:error)
         expect(order.reload.state).to eq Order::CANCELED
         transaction = order.transactions.order(created_at: :desc).first
-        expect(transaction).to have_attributes(external_id: 're_1', external_type: Transaction::REFUND, transaction_type: Transaction::REFUND)
+        expect(transaction).to have_attributes(external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT, transaction_type: Transaction::CANCEL)
       end
     end
   end

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -1,4 +1,4 @@
-module OfferQueryHelper # rubocop:disable Metrics/ModuleLength
+module OfferQueryHelper
   CREATE_OFFER_ORDER = %(
     mutation($input: CreateOfferOrderWithArtworkInput!) {
       createOfferOrderWithArtwork(input: $input) {

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -63,6 +63,21 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:retrieve, payment_intent)
   end
 
+  def prepare_payment_intent_cancel_failure(charge_error:, payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: 'manual', status: 'requires_capture', transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
+    error = Stripe::CardError.new(charge_error[:message], charge_error[:decline_code], charge_error[:code])
+    allow(payment_intent).to receive(:cancel).and_raise(error)
+    allow(error).to receive(:json_body).and_return(error: { payment_intent: basic_payment_intent(status: 'requires_payment_method', capture: true, amount: amount, code: charge_error[:code], decline_code: charge_error[:decline_code]) })
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
+  def prepare_payment_intent_cancel_success(payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: 'manual', transfer_data: double(destination: 'ma_1'))
+    allow(payment_intent).to receive(:status).and_return('requires_capture', 'canceled')
+    allow(payment_intent).to receive(:cancel)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
   def prepare_payment_intent_refund_success(payment_method: 'cc_1', amount: 20_00)
     payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, transfer_data: double(destination: 'ma_1'), charges: [double(id: 'ch_1')])
     allow(payment_intent).to receive(:status).and_return('requires_capture', 'succeeded')


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1379
We learned the hard way that when a payment intent is not captured yet, we need to use `payment_intent.cancel` and if payment intent was captured, then we need to first find the charge associated with that payment intent and use refund API to refund it.
We were under impression that we can always refund the charge associated with payment intent knowing that a uncaptured payment intent will still have charge associated with it.

# Solution
In case of `seller_lapse`, `seller_reject` and buyer reject (only for BN), we now call newly added `cancel_payment_intent` method instead of calling refund. 