### PR TITLE
clear external_charge_id when updating payment_method

### DIFF
--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -11,6 +11,7 @@ class Types::MutationType < Types::BaseObject
   field :submit_order_with_offer, mutation: Mutations::SubmitOrderWithOffer
   field :buyer_counter_offer, mutation: Mutations::BuyerCounterOffer
   field :submit_pending_offer, mutation: Mutations::SubmitPendingOffer
+  field :fix_failed_payment, mutation: Mutations::FixFailedPayment
 
   # Seller
   field :approve_order, mutation: Mutations::ApproveOrder
@@ -21,5 +22,4 @@ class Types::MutationType < Types::BaseObject
   field :fulfill_at_once, mutation: Mutations::FulfillAtOnce
   field :confirm_pickup, mutation: Mutations::ConfirmPickup
   field :confirm_fulfillment, mutation: Mutations::ConfirmFulfillment
-  field :fix_failed_payment, mutation: Mutations::FixFailedPayment
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -34,7 +34,8 @@ module OrderService
     credit_card = Gravity.get_credit_card(credit_card_id)
     raise Errors::ValidationError.new(:invalid_credit_card, credit_card_id: credit_card_id) unless credit_card.dig(:user, :_id) == order.buyer_id
 
-    order.update!(credit_card_id: credit_card_id)
+    # nilify external_charge_id in case we had in progress payment intent so we create a new one
+    order.update!(credit_card_id: credit_card_id, external_charge_id: nil)
     order
   end
 


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1369

# Solution
Went with easier solution in which we basically clean `external_charge_id` on the order which would lead to create new payment intent when user tries to submit again with new payment method.