### PR TITLE
#FF Include Shipping Info in Transaction Event Payload

### DIFF
--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -44,7 +44,9 @@ class TransactionEvent < Events::BaseEvent
       state_reason: order.state_reason,
       state_expires_at: order.state_expires_at,
       updated_at: order.updated_at,
-      last_offer: last_offer_details(order)
+      last_offer: last_offer_details(order),
+      shipping_country: order.shipping_country,
+      shipping_name: order.shipping_name,
     }
   end
 

--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -46,7 +46,7 @@ class TransactionEvent < Events::BaseEvent
       updated_at: order.updated_at,
       last_offer: last_offer_details(order),
       shipping_country: order.shipping_country,
-      shipping_name: order.shipping_name,
+      shipping_name: order.shipping_name
     }
   end
 

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -10,7 +10,7 @@ describe TransactionEvent, type: :events do
       shipping_address_line1: '123 Main St',
       shipping_address_line2: 'Apt 2',
       shipping_city: 'Chicago',
-      shipping_country: 'USA',
+      shipping_country: 'US',
       shipping_postal_code: '60618',
       shipping_region: 'IL'
     }
@@ -106,6 +106,8 @@ describe TransactionEvent, type: :events do
       expect(event.properties[:order][:line_items]).to match_array(line_item_properties)
       expect(event.properties[:order][:last_offer][:from_participant]).to eq 'buyer'
       expect(event.properties[:order][:last_offer][:amount_cents]).to eq 100000
+      expect(event.properties[:order][:shipping_country]).to eq 'US'
+      expect(event.properties[:order][:shipping_name]).to eq 'Fname Lname'
       expect(event.properties[:failure_code]).to eq 'stolen_card'
       expect(event.properties[:failure_message]).to eq 'who stole it?'
       expect(event.properties[:status]).to eq Transaction::FAILURE


### PR DESCRIPTION
This PR updates the `TransactionEvent` event to include shipping information in the data that it publishes to a messaging queue when a transaction fails. This change allows CRT to have access to the shipping address' country and name fields when they are notified of a failed transaction, which will help them determine if there is a potential fraud case faster.