### PR TITLE
Add new mode to charge metadata + undeduct in case of other errors

### DIFF
--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -35,6 +35,9 @@ class OrderProcessor
   rescue Errors::InsufficientInventoryError
     undeduct_inventory
     @insufficient_inventory = true
+  rescue Errors::ProcessingError => e
+    undeduct_inventory
+    raise e
   end
 
   def charge!
@@ -114,7 +117,8 @@ class OrderProcessor
       buyer_type: @order.buyer_type,
       seller_id: @order.seller_id,
       seller_type: @order.seller_type,
-      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo'
+      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo',
+      mode: @order.mode
     }
   end
 end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -281,4 +281,19 @@ describe OrderProcessor, type: :services do
       end
     end
   end
+
+  describe '#charge_metadata' do
+    it 'includes all expected metadata' do
+      metadata = order_processor.send(:charge_metadata)
+      expect(metadata).to match(
+        exchange_order_id: order.id,
+        buyer_id: 'buyer1',
+        buyer_type: 'user',
+        seller_id: 'seller1',
+        seller_type: 'gallery',
+        type: 'bn-mo',
+        mode: 'buy'
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Request
https://artsyproduct.atlassian.net/browse/PURCHASE-1403
We've started using Stripe Radar rules, we want to be able to have different rules for `bn` and `mo` cases, at the moment we can't do that wit our metadata.

# Solution
`type` is used by `fianance` to group `bn-mo` orders calculation together. Instead of separating them, we added a new `mode` metadata to capture the order mode.

# Another fix
As part of our QA we noticed if anything other than expected `Errors::InsufficientInventoryError` goes wrong we don't undeduct inventory. Not sure how many times this could have possibly happen in prodcution since the types of errors we've seen so far on staging are mostly because of our tests but adding this undeduct makes sense and def helps our tests.