### PR TITLE
Refactor order_processor to be less dependent to db transactions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
 Metrics/ParameterLists:
   Max: 10
 
+Metrics/ClassLength:
+  Max: 120
+
 Metrics/AbcSize:
   Max: 61
   Exclude:

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -66,7 +66,7 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  ACTIONS = %i[abandon submit approve reject fulfill seller_lapse buyer_lapse refund].freeze
+  ACTIONS = %i[abandon rollback submit approve reject fulfill seller_lapse buyer_lapse refund].freeze
   ACTION_REASONS = {
     seller_lapse: REASONS[CANCELED][:seller_lapsed],
     buyer_lapse: REASONS[CANCELED][:buyer_lapsed],
@@ -247,6 +247,7 @@ class Order < ApplicationRecord
     machine = MicroMachine.new(state)
     machine.when(:abandon, PENDING => ABANDONED)
     machine.when(:submit, PENDING => SUBMITTED)
+    machine.when(:rollback, APPROVED => SUBMITTED, SUBMITTED => PENDING)
     machine.when(:approve, SUBMITTED => APPROVED)
     machine.when(:reject, SUBMITTED => CANCELED)
     machine.when(:seller_lapse, SUBMITTED => CANCELED)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -66,7 +66,7 @@ class Order < ApplicationRecord
     SHIP = 'ship'.freeze
   ].freeze
 
-  ACTIONS = %i[abandon rollback submit approve reject fulfill seller_lapse buyer_lapse refund].freeze
+  ACTIONS = %i[abandon revert submit approve reject fulfill seller_lapse buyer_lapse refund].freeze
   ACTION_REASONS = {
     seller_lapse: REASONS[CANCELED][:seller_lapsed],
     buyer_lapse: REASONS[CANCELED][:buyer_lapsed],
@@ -247,7 +247,7 @@ class Order < ApplicationRecord
     machine = MicroMachine.new(state)
     machine.when(:abandon, PENDING => ABANDONED)
     machine.when(:submit, PENDING => SUBMITTED)
-    machine.when(:rollback, APPROVED => SUBMITTED, SUBMITTED => PENDING)
+    machine.when(:revert, APPROVED => SUBMITTED, SUBMITTED => PENDING)
     machine.when(:approve, SUBMITTED => APPROVED)
     machine.when(:reject, SUBMITTED => CANCELED)
     machine.when(:seller_lapse, SUBMITTED => CANCELED)

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -83,10 +83,8 @@ module OfferService
 
     elsif order_processor.requires_action?
       order_processor.revert!
-      order_processor.set_external_payment!
       raise Errors::PaymentRequiresActionError, order_processor.action_data
     end
-    order_processor.set_external_payment!
     order_processor.on_success
     order
   end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -66,33 +66,29 @@ module OfferService
     raise Errors::ValidationError, :not_last_offer unless offer.last_offer?
 
     order = offer.order
-    order_processor = OrderProcessor.new(order, user_id)
+    order_processor = OrderProcessor.new(order, user_id, offer)
     raise Errors::ValidationError, order_processor.validation_error unless order_processor.valid?
-
-    order.approve! do
-      totals = OfferOrderTotals.new(offer)
-      order.update!(
-        transaction_fee_cents: totals.transaction_fee_cents,
-        commission_rate: totals.commission_rate,
-        commission_fee_cents: totals.commission_fee_cents,
-        seller_total_cents: totals.seller_total_cents
-      )
-      order_processor.charge!
-      raise Errors::InsufficientInventoryError if order_processor.failed_inventory?
-      # in case of failed transaction, we need to rollback this block,
-      # but still need to add transaction, so we raise an ActiveRecord::Rollback
-      raise ActiveRecord::Rollback if order_processor.failed_payment?
-
-      order.update!(external_charge_id: order_processor.transaction.external_id)
+    order_processor.transition(:approve!)
+    order_processor.deduct_inventory!
+    if order_processor.failed_inventory?
+      order_processor.rollback!
+      raise Errors::InsufficientInventoryError
     end
-    order.transactions << order_processor.transaction
-    PostTransactionNotificationJob.perform_later(order_processor.transaction.id, user_id)
-    raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction) if order_processor.failed_payment?
-
-    OrderEvent.delay_post(order, Order::APPROVED, user_id)
-    OrderFollowUpJob.set(wait_until: order.state_expires_at).perform_later(order.id, order.state)
-    ReminderFollowUpJob.set(wait_until: order.state_expiration_reminder_time).perform_later(order.id, order.state)
-    Exchange.dogstatsd.increment 'order.approved'
+    order_processor.set_totals!
+    order_processor.charge!
+    order_processor.store_transaction
+    if order_processor.failed_payment?
+      order_processor.rollback!
+      raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction)
+    elsif order_processor.requires_action?
+      order_processor.rollback!
+      order_processor.set_payment!
+      raise Errors::PaymentRequiresActionError.new(order_processor.action_data)
+    else
+      order_processor.set_payment!
+      order_processor.set_follow_ups
+    end
+    order
   end
 
   class << self

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -63,11 +63,9 @@ module OrderService
       raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction)
     elsif order_processor.requires_action?
       order_processor.revert!
-      order_processor.set_external_payment!
       Exchange.dogstatsd.increment 'submit.requires_action'
       raise Errors::PaymentRequiresActionError, order_processor.action_data
     end
-    order_processor.set_external_payment!
     order_processor.on_success
     order
   end

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -98,11 +98,8 @@ class OrderProcessor
 
   def store_transaction
     order.transactions << transaction
+    order.update!(external_charge_id: transaction.external_id) unless transaction.failed?
     PostTransactionNotificationJob.perform_later(transaction.id, @user_id)
-  end
-
-  def set_external_payment!
-    @order.update!(external_charge_id: transaction.external_id)
   end
 
   def on_success

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -18,7 +18,7 @@ class OrderProcessor
     reset_totals! if @totals_set
     return unless @state_changed
 
-    order.rollback!
+    order.revert!
     @state_changed = false
   end
 

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -5,11 +5,30 @@ describe OrderProcessor, type: :services do
   include_context 'include stripe helper'
   let(:buyer_id) { 'buyer1' }
   let(:seller_id) { 'seller1' }
-  let(:order) { Fabricate(:order, buyer_id: buyer_id, fulfillment_type: Order::PICKUP, credit_card_id: 'cc1', seller_id: seller_id) }
-  let!(:line_item1) { Fabricate(:line_item, order: order, artwork_id: 'a1', quantity: 1) }
-  let(:stub_line_item_1_gravity_deduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a1/inventory").with(body: { deduct: 1 }) }
-  let(:stub_line_item_1_gravity_undeduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a1/inventory").with(body: { undeduct: 1 }) }
-  let!(:line_item2) { Fabricate(:line_item, order: order, artwork_id: 'a2', quantity: 2) }
+  let(:order_mode) { Order::BUY }
+  let(:order) do
+    Fabricate(
+      :order,
+      mode: order_mode,
+      buyer_id: buyer_id,
+      fulfillment_type: Order::SHIP,
+      credit_card_id: 'cc1',
+      seller_id: seller_id,
+      shipping_name: 'Fname Lname',
+      shipping_address_line1: '12 Vanak St',
+      shipping_address_line2: 'P 80',
+      shipping_city: 'Tehran',
+      shipping_postal_code: '02198',
+      buyer_phone_number: '00123456',
+      shipping_country: 'IR'
+    )
+  end
+  let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1') }
+  let(:stub_artwork_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1").to_return(status: 200, body: artwork.to_json) }
+  let!(:line_item1) { Fabricate(:line_item, order: order, quantity: 1, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1') }
+  let(:line_item2) { Fabricate(:line_item, order: order, artwork_id: 'a2', quantity: 2) }
+  let(:stub_line_item_1_gravity_deduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { deduct: 1 }) }
+  let(:stub_line_item_1_gravity_undeduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a-1/inventory").with(body: { undeduct: 1 }) }
   let(:stub_line_item_2_gravity_deduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a2/inventory").with(body: { deduct: 2 }) }
   let(:stub_line_item_2_gravity_undeduct) { stub_request(:put, "#{Rails.application.config_for(:gravity)['api_v1_root']}/artwork/a2/inventory").with(body: { undeduct: 2 }) }
 
@@ -20,93 +39,169 @@ describe OrderProcessor, type: :services do
   let(:stub_gravity_merchant_account_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/merchant_accounts?partner_id=seller1").to_return(body: gravity_merchant_accounts.to_json) }
   let(:gravity_credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
   let(:stub_gravity_card_request) { stub_request(:get, "#{Rails.application.config_for(:gravity)['api_v1_root']}/credit_card/cc1").to_return(body: gravity_credit_card.to_json) }
-  let(:order_processor) { OrderProcessor.new(order, buyer_id) }
+  let(:offer) { nil }
+  let(:order_processor) { OrderProcessor.new(order, buyer_id, offer) }
+
+  describe 'set_totals!' do
+    before do
+      stub_gravity_partner
+      stub_artwork_request
+      order_processor.set_totals!
+    end
+    context 'buy order' do
+      it 'sets correct totals on order' do
+        expect(order.reload).to have_attributes(
+          transaction_fee_cents: 29_30,
+          commission_rate: 0.8,
+          commission_fee_cents: 800_00,
+          seller_total_cents: 170_70
+        )
+      end
+      it 'sets correct totals on line items' do
+        expect(line_item1.reload.commission_fee_cents).to eq 800_00
+      end
+      it 'sets totals_set' do
+        expect(order_processor.instance_variable_get(:@totals_set)).to be true
+      end
+    end
+    context 'offer order' do
+      let(:order_mode) { Order::OFFER }
+      let(:offer) { Fabricate(:offer, order: order, amount_cents: 1000_00, shipping_total_cents: 200_00, tax_total_cents: 100_00) }
+      it 'sets correct totals on order' do
+        expect(order.reload).to have_attributes(
+          transaction_fee_cents: 38_00,
+          commission_rate: 0.8,
+          commission_fee_cents: 800_00,
+          seller_total_cents: 462_00
+        )
+      end
+      it 'does not set totals on line items' do
+        expect(line_item1.reload.commission_fee_cents).to be_nil
+      end
+      it 'sets totals_set' do
+        expect(order_processor.instance_variable_get(:@totals_set)).to be true
+      end
+    end
+  end
+
+  describe 'reset_totals!' do
+    it 'resets totals on an order' do
+      order.update!(
+        transaction_fee_cents: 38_00,
+        commission_rate: 0.8,
+        commission_fee_cents: 800_00,
+        seller_total_cents: 462_00
+      )
+      order_processor.reset_totals!
+      expect(order.reload).to have_attributes(
+        transaction_fee_cents: nil,
+        commission_rate: nil,
+        commission_fee_cents: nil,
+        seller_total_cents: nil
+      )
+    end
+    it 'sets totals_set' do
+      expect(order_processor.instance_variable_get(:@totals_set)).to be false
+    end
+  end
+
+  describe 'revert!' do
+  end
+
+  describe 'failed_payment?' do
+  end
+
+  describe 'requires_action?' do
+  end
+
+  describe 'action_data' do
+  end
+
+  describe 'valid?' do
+    it 'returns false and sets error missing shipping info' do
+      order.update!(fulfillment_type: nil)
+      expect(order_processor.valid?).to eq false
+      expect(order_processor.validation_error).to eq :missing_required_info
+    end
+
+    it 'returns false and sets error when missing payment info' do
+      order.update!(credit_card_id: nil)
+      expect(order_processor.valid?).to eq false
+      expect(order_processor.validation_error).to eq :missing_required_info
+    end
+
+    it 'returns false and sets error if you try to process an order that was paid for by wire transfer' do
+      order.update!(payment_method: Order::WIRE_TRANSFER)
+      expect(order_processor.valid?).to eq false
+      expect(order_processor.validation_error).to eq :unsupported_payment_method
+    end
+
+    context 'missing credit card info' do
+      let(:gravity_credit_card) { { external_id: nil } }
+      before do
+        stub_gravity_card_request
+      end
+
+      it 'returns false and sets error' do
+        expect(order_processor.valid?).to eq false
+        expect(order_processor.validation_error).to eq :credit_card_missing_external_id
+        expect(stub_gravity_card_request).to have_been_requested
+      end
+    end
+  end
+
+  describe 'deduct_inventory' do
+    before do
+      line_item2
+    end
+    it 'returns true when fully deducted inventory' do
+      stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
+      stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
+      expect(order_processor.deduct_inventory).to be true
+      expect(stub_line_item_1_gravity_deduct).to have_been_requested
+      expect(stub_line_item_2_gravity_deduct).to have_been_requested
+    end
+    it 'returns false on insufficient inventory' do
+      stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
+      stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
+      expect(order_processor.deduct_inventory).to be false
+      expect(stub_line_item_1_gravity_deduct).to have_been_requested
+      expect(stub_line_item_2_gravity_deduct).to have_been_requested
+    end
+  end
+
+  describe 'undedudct_inventory!' do
+    before do
+      order_processor.instance_variable_set(:@deducted_inventory, [line_item1, line_item2])
+    end
+    it 'calls undeduct for line items' do
+      stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
+      stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
+      order_processor.undeduct_inventory!
+      expect(stub_line_item_1_gravity_undeduct).to have_been_requested
+      expect(stub_line_item_2_gravity_undeduct).to have_been_requested
+    end
+  end
+
+  describe 'store_transaction' do
+  end
+
+  describe 'set_external_payment!' do
+  end
+
+  describe 'on success' do
+  end
 
   describe '#hold' do
-    context 'invalid order' do
-      it 'raises validation error missing shipping info' do
-        order.update!(fulfillment_type: nil)
-        expect { order_processor.hold! }.to raise_error do |e|
-          expect(e.code).to eq :missing_required_info
-        end
-      end
-
-      it 'raises validation error when missing payment info' do
-        order.update!(credit_card_id: nil)
-        expect { order_processor.hold! }.to raise_error do |e|
-          expect(e.code).to eq :missing_required_info
-        end
-      end
-
-      it 'raises validation error if you try to process an order that was paid for by wire transfer' do
-        order.update!(payment_method: Order::WIRE_TRANSFER)
-        expect { order_processor.hold! }.to raise_error do |e|
-          expect(e.code).to eq :unsupported_payment_method
-        end
-      end
-
-      context 'missing credit card info' do
-        let(:gravity_credit_card) { { external_id: nil } }
-        before do
-          stub_gravity_card_request
-        end
-
-        it 'raises validation error' do
-          expect { order_processor.hold! }.to raise_error do |e|
-            expect(e.code).to eq :credit_card_missing_external_id
-          end
-          expect(stub_gravity_card_request).to have_been_requested
-        end
-      end
+    before do
+      stub_gravity_card_request
+      stub_gravity_merchant_account_request
+      stub_gravity_partner
     end
-
-    context 'failed deduct inventory' do
-      before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-      end
-
-      it 'does not call stripe' do
-        stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:capture_without_hold)
-        order_processor.hold!
-        expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
-      end
-
-      it 'handles partial failure' do
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:capture_without_hold)
-        order_processor.hold!
-        expect(stub_line_item_1_gravity_undeduct).to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
-        expect(order_processor.failed_inventory?).to be true
-      end
-    end
-
     context 'failed hold' do
       before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
-        order_processor.hold!
-      end
-
-      it 'deducts and undeducts inventory' do
-        expect(stub_line_item_1_gravity_deduct).to have_been_requested
-        expect(stub_line_item_2_gravity_deduct).to have_been_requested
-        expect(stub_line_item_1_gravity_undeduct).to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).to have_been_requested
+        order_processor.hold
       end
 
       it 'sets processor transaction' do
@@ -116,22 +211,8 @@ describe OrderProcessor, type: :services do
 
     context 'hold requires action' do
       before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         prepare_payment_intent_create_failure(status: 'requires_action')
-        order_processor.hold!
-      end
-
-      it 'deducts and undeducts inventory' do
-        expect(stub_line_item_1_gravity_deduct).to have_been_requested
-        expect(stub_line_item_2_gravity_deduct).to have_been_requested
-        expect(stub_line_item_1_gravity_undeduct).to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).to have_been_requested
+        order_processor.hold
       end
 
       it 'sets processor transaction' do
@@ -149,135 +230,40 @@ describe OrderProcessor, type: :services do
 
     context 'successful hold' do
       before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         prepare_payment_intent_create_success(amount: 20_00)
+        order_processor.hold
       end
 
-      it 'deducts inventory' do
-        order_processor.hold!
-        expect(stub_line_item_1_gravity_deduct).to have_been_requested
-        expect(stub_line_item_2_gravity_deduct).to have_been_requested
-        expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
+      it 'sets order_processor.transaction' do
+        expect(order_processor.transaction).to have_attributes(status: Transaction::SUCCESS, transaction_type: Transaction::HOLD)
       end
     end
   end
 
   describe '#charge' do
-    context 'invalid order' do
-      it 'raises validation error when missing shipping info' do
-        order.update!(fulfillment_type: nil)
-        expect { order_processor.charge! }.to raise_error do |e|
-          expect(e.code).to eq :missing_required_info
-        end
-      end
-
-      it 'raises validation error when missing payment info' do
-        order.update!(credit_card_id: nil)
-        expect { order_processor.charge! }.to raise_error do |e|
-          expect(e.code).to eq :missing_required_info
-        end
-      end
-
-      it 'raises validation error if you try to process an order that was paid for by wire transfer' do
-        order.update!(payment_method: Order::WIRE_TRANSFER)
-        expect { order_processor.charge! }.to raise_error do |e|
-          expect(e.code).to eq :unsupported_payment_method
-        end
-      end
-
-      context 'missing credit card info' do
-        let(:gravity_credit_card) { { external_id: nil } }
-        before do
-          stub_gravity_card_request
-        end
-
-        it 'raises validation error' do
-          expect { order_processor.charge! }.to raise_error do |e|
-            expect(e.code).to eq :credit_card_missing_external_id
-          end
-          expect(stub_gravity_card_request).to have_been_requested
-        end
-      end
+    before do
+      stub_gravity_card_request
+      stub_gravity_merchant_account_request
+      stub_gravity_partner
     end
-    context 'failed deduct inventory' do
-      before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-      end
-
-      it 'does not call stripe' do
-        stub_line_item_1_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        expect(PaymentService).not_to receive(:capture_without_hold)
-        order_processor.charge!
-        expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
-        expect(order_processor.failed_inventory?).to be true
-      end
-
-      it 'handles partial failure' do
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct
-        expect(PaymentService).not_to receive(:capture_without_hold)
-        order_processor.charge!
-        expect(stub_line_item_1_gravity_undeduct).to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
-        expect(order_processor.failed_inventory?).to be true
-      end
-    end
-
     context 'failed charge' do
       before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
-        order_processor.charge!
+        order_processor.charge
       end
-
-      it 'deducts and undeducts inventory' do
-        expect(stub_line_item_1_gravity_deduct).to have_been_requested
-        expect(stub_line_item_2_gravity_deduct).to have_been_requested
-        expect(stub_line_item_1_gravity_undeduct).to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).to have_been_requested
-      end
-
-      it 'raises failed transaction error' do
+      it 'sets order_processor.transaction' do
         expect(order_processor.transaction).to have_attributes(failure_code: 'card_declined', decline_code: 'do_not_honor')
       end
     end
 
     context 'successful charge' do
       before do
-        stub_gravity_card_request
-        stub_gravity_merchant_account_request
-        stub_gravity_partner
-        stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
-        stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
         prepare_payment_intent_create_success(amount: 20_00)
-        order_processor.charge!
+        order_processor.charge
       end
 
-      it 'deducts inventory' do
-        expect(stub_line_item_1_gravity_deduct).to have_been_requested
-        expect(stub_line_item_2_gravity_deduct).to have_been_requested
-        expect(stub_line_item_1_gravity_undeduct).not_to have_been_requested
-        expect(stub_line_item_2_gravity_undeduct).not_to have_been_requested
+      it 'sets order_processor.transaction' do
+        expect(order_processor.transaction).to have_attributes(status: Transaction::SUCCESS)
       end
     end
   end


### PR DESCRIPTION
# Problem
As we started building on top of existing code around submitting an `Order`, things got more complicated. Looking deeper at our process and after few brainstorming, it seems the part that complicates things the most is us having most of business logic during submit in a `order.submit!` or `order.approve!` block. Anything in that block is using `order.with_lock` and is part of one database transaction.
While having everything during wrapped in one db transaction helps our data integrity, because of external dependencies like inventory deduction in Gravity and charge processing in Stripe, we can easily get into a rollback scenario. Rollback case also gets pretty complicated because in some cases we want to store transactions in some cases we don't.

# Solution
Instead of wrapping everything in a transaction block, do things in more sequential way and provide a proper rollback method in case of rollback in different stages.

In this new approach we rely more on `OrderProcessor` which used to be this weird little service only dealing with inventory deduction and charge processing. Now `OrderProcessor`:
- provides separate methods for charge related methods and deduct and undeducting inventory
- provides new methods for setting totals on the order
- provides a `rollback!` method that can decide what needs to be rolled back at current stage.

The big difference in the flow is now we optimistically set the order in new state at the beginning of the process and if anything goes wrong we rollback the state to previous one. We used to not be able to go from `submitted` state to `pending` but with new approach if order processing fails after our optimistic state update, we'll be going back from `submitted` to `pending` and in case of approve, from `approved` to `submitted`. This should be ok since we don't post events yet for any of these.


# How confident are we? %87.3
As long as this PR doesn't change any request level spec, i feel %87.3 confident. The rest of confidence happens when we see things in real 🌏 with our own 👁.

https://twitter.com/i/status/1139548144390352897

## Photo of the rest of %12.7
![](https://media.giphy.com/media/1rf4hhXCoTQNa/giphy.gif)