### PR TITLE
PURCHASE-1428: Get failed payment flow working with case where payment intent of a already confirmed setupintent fails when seller accepts offer

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -61,7 +61,8 @@ module OfferService
     end
     order_processor.set_totals!
     # if seller is accepting the offer, this is an off-session
-    off_session = offer.to_participant == Order::SELLER
+    # for failed payment flow buyer is accepting their own offer, so its on-session
+    off_session = offer.to_participant == Order::SELLER && user_id !== order.seller_id
     order_processor.charge(off_session)
     order_processor.store_transaction
     if order_processor.failed_payment?

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -62,7 +62,6 @@ module OfferService
     order_processor.set_totals!
     # if seller is accepting the offer, this is an off-session
     # for failed payment flow buyer is accepting their own offer, so its on-session
-
     off_session = offer.to_participant == Order::SELLER && user_id == order.seller_id
     order_processor.charge(off_session)
     order_processor.store_transaction

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -60,9 +60,9 @@ module OfferService
       raise Errors::InsufficientInventoryError
     end
     order_processor.set_totals!
-    # if seller is accepting the offer, this is an off-session
-    # for failed payment flow buyer is accepting their own offer, so its on-session
-    off_session = offer.to_participant == Order::SELLER && user_id != order.buyer_id
+    
+    # this is an off-session if offer is from buyer and seller is accepting it (in case of failed payment buyer could accept their own offer)
+    off_session = offer.from_participant == Order::BUYER && user_id != order.buyer_id
     order_processor.charge(off_session)
     order_processor.store_transaction
     if order_processor.failed_payment?

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -62,7 +62,8 @@ module OfferService
     order_processor.set_totals!
     # if seller is accepting the offer, this is an off-session
     # for failed payment flow buyer is accepting their own offer, so its on-session
-    off_session = offer.to_participant == Order::SELLER && user_id !== order.seller_id
+
+    off_session = offer.to_participant == Order::SELLER && user_id == order.seller_id
     order_processor.charge(off_session)
     order_processor.store_transaction
     if order_processor.failed_payment?

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -60,7 +60,7 @@ module OfferService
       raise Errors::InsufficientInventoryError
     end
     order_processor.set_totals!
-    
+
     # this is an off-session if offer is from buyer and seller is accepting it (in case of failed payment buyer could accept their own offer)
     off_session = offer.from_participant == Order::BUYER && user_id != order.buyer_id
     order_processor.charge(off_session)

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -62,7 +62,7 @@ module OfferService
     order_processor.set_totals!
     # if seller is accepting the offer, this is an off-session
     # for failed payment flow buyer is accepting their own offer, so its on-session
-    off_session = offer.to_participant == Order::SELLER && user_id == order.seller_id
+    off_session = offer.to_participant == Order::SELLER && user_id != order.buyer_id
     order_processor.charge(off_session)
     order_processor.store_transaction
     if order_processor.failed_payment?

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -6,7 +6,7 @@ describe Api::GraphqlController, type: :request do
     include_context 'GraphQL Client'
     let(:partner) { { effective_commission_rate: 0.1 } }
     let(:order_seller_id) { jwt_partner_ids.first }
-    let(:order_buyer_id) { jwt_user_id }
+    let(:order_buyer_id) { 'buyer-id' }
     let(:order_state) { Order::SUBMITTED }
     let(:credit_card_id) { 'cc-1' }
     let(:merchant_account) { { external_id: 'ma-1' } }


### PR DESCRIPTION
# [PURCHASE-1428] Get failed payment flow working with case where payment intent of a already confirmed setupintent fails when seller accepts offer

current failed payment flow works when a seller accepts an offer and payment doesn't go through, we send email to buyer about the failed payment and they fix their issue.
we need to make sure this works also for the case were we confirmed setupintent and later when seller accepts offer we tried to process off-session payment intent but that fails

# Problem
Currently, whenever an offer is directed to a seller, the PaymentIntent is always off-session. However, for our existing failed payment flow, the buyer is technically accepting their own offer, which will be to a seller. Because of this, the PaymentIntent created has `off-session: true` when its really on-session. 

# Solution
I changed the logic in `accept_offer` so that a payment is off session when the offer is directed to the seller AND the `user_id` equals the `seller_id`.


[PURCHASE-1428]: https://artsyproduct.atlassian.net/browse/PURCHASE-1428