### PR TITLE
Reuse Confirmed SteupIntent

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1391,6 +1391,7 @@ input SubmitOrderWithOfferInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  confirmedSetupIntentId: String
   offerId: ID!
 }
 

--- a/app/graphql/mutations/submit_order_with_offer.rb
+++ b/app/graphql/mutations/submit_order_with_offer.rb
@@ -2,14 +2,15 @@ class Mutations::SubmitOrderWithOffer < Mutations::BaseMutation
   null true
 
   argument :offer_id, ID, required: true
+  argument :confirmed_setup_intent_id, String, required: false
 
   field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
-  def resolve(offer_id:)
+  def resolve(offer_id:, confirmed_setup_intent_id: nil)
     offer = Offer.find(offer_id)
     authorize_offer_owner_request!(offer)
 
-    OfferService.submit_order_with_offer(offer, current_user_id)
+    OfferService.submit_order_with_offer(offer, current_user_id, confirmed_setup_intent_id)
 
     { order_or_error: { order: offer.order } }
   rescue Errors::PaymentRequiresActionError => e

--- a/app/graphql/mutations/submit_order_with_offer.rb
+++ b/app/graphql/mutations/submit_order_with_offer.rb
@@ -10,7 +10,7 @@ class Mutations::SubmitOrderWithOffer < Mutations::BaseMutation
     offer = Offer.find(offer_id)
     authorize_offer_owner_request!(offer)
 
-    OfferService.submit_order_with_offer(offer, current_user_id, confirmed_setup_intent_id)
+    OfferService.submit_order_with_offer(offer, user_id: current_user_id, confirmed_setup_intent_id: confirmed_setup_intent_id)
 
     { order_or_error: { order: offer.order } }
   rescue Errors::PaymentRequiresActionError => e

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -34,7 +34,7 @@ module OfferService
     offer
   end
 
-  def self.submit_order_with_offer(offer, user_id: user_id, confirmed_setup_intent_id: confirmed_setup_intent_id)
+  def self.submit_order_with_offer(offer, user_id:, confirmed_setup_intent_id: nil)
     op = OfferProcessor.new(offer, user_id)
     op.validate_offer!
     op.validate_order!

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -34,12 +34,12 @@ module OfferService
     offer
   end
 
-  def self.submit_order_with_offer(offer, user_id)
+  def self.submit_order_with_offer(offer, user_id: user_id, confirmed_setup_intent_id: confirmed_setup_intent_id)
     op = OfferProcessor.new(offer, user_id)
     op.validate_offer!
     op.validate_order!
     op.check_inventory!
-    op.confirm_payment_method!
+    op.confirm_payment_method!(confirmed_setup_intent_id)
     op.submit_order!
     op.update_offer_submission_timestamp
     op.set_order_totals!

--- a/lib/offer_processor.rb
+++ b/lib/offer_processor.rb
@@ -33,8 +33,12 @@ class OfferProcessor
     @state_changed = true
   end
 
-  def confirm_payment_method!
-    @transaction = PaymentMethodService.confirm_payment_method!(offer.order)
+  def confirm_payment_method!(confirmed_setup_intent_id)
+    @transaction = if confirmed_setup_intent_id
+      PaymentMethodService.verify_setup_intent(confirmed_setup_intent_id)
+    else
+      PaymentMethodService.confirm_payment_method!(offer.order)
+    end
     order.transactions << transaction
     return unless @transaction.requires_action?
 

--- a/lib/offer_processor.rb
+++ b/lib/offer_processor.rb
@@ -33,9 +33,9 @@ class OfferProcessor
     @state_changed = true
   end
 
-  def confirm_payment_method!(confirmed_setup_intent_id)
+  def confirm_payment_method!(confirmed_setup_intent_id = nil)
     @transaction = if confirmed_setup_intent_id
-      PaymentMethodService.verify_setup_intent(confirmed_setup_intent_id)
+      PaymentMethodService.verify_payment_method(confirmed_setup_intent_id)
     else
       PaymentMethodService.confirm_payment_method!(offer.order)
     end

--- a/lib/payment_method_service.rb
+++ b/lib/payment_method_service.rb
@@ -1,13 +1,12 @@
 module PaymentMethodService
-
-  def self.verify_setup_intent(setup_intent_id)
-    setup_intent = Stripe::SetupIntent.retrive(setup_intent_id)
+  def self.verify_payment_method(setup_intent_id)
+    setup_intent = Stripe::SetupIntent.retrieve(setup_intent_id)
     Transaction.new(
       external_id: setup_intent.id,
       external_type: Transaction::SETUP_INTENT,
       source_id: setup_intent.payment_method,
       destination_id: setup_intent.on_behalf_of,
-      amount_cents: order.items_total_cents,
+      amount_cents: nil,
       transaction_type: Transaction::CONFIRM,
       status: transaction_status_from_intent(setup_intent),
       payload: setup_intent.to_h

--- a/lib/payment_method_service.rb
+++ b/lib/payment_method_service.rb
@@ -1,4 +1,19 @@
 module PaymentMethodService
+
+  def self.verify_setup_intent(setup_intent_id)
+    setup_intent = Stripe::SetupIntent.retrive(setup_intent_id)
+    Transaction.new(
+      external_id: setup_intent.id,
+      external_type: Transaction::SETUP_INTENT,
+      source_id: setup_intent.payment_method,
+      destination_id: setup_intent.on_behalf_of,
+      amount_cents: order.items_total_cents,
+      transaction_type: Transaction::CONFIRM,
+      status: transaction_status_from_intent(setup_intent),
+      payload: setup_intent.to_h
+    )
+  end
+
   def self.confirm_payment_method!(order)
     credit_card = order.credit_card
     merchant_account = order.merchant_account

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -199,12 +199,12 @@ describe OfferService, type: :services do
         prepare_setup_intent_create
       end
 
-      it 'submits the offer' do
+      it 'submits offer and order' do
         expect do
           call_service
           expect(order.reload.state).to eq(Order::SUBMITTED)
           expect(offer.reload.submitted_at).not_to be_nil
-        end.to change(order.state_histories, :count).by(1)
+        end.to change(order.state_histories, :count).by(1).and change(order.transactions, :count).by(1)
       end
 
       it 'queues related jobs' do
@@ -225,6 +225,51 @@ describe OfferService, type: :services do
         expect(order.tax_total_cents).to eq 20_00
         expect(order.buyer_total_cents).to eq 1000_00 + 30_00 + 20_00
         expect(order.transaction_fee_cents).to eq(offer.buyer_total_cents * 2.9 / 100 + 30)
+      end
+    end
+
+    describe 'resubmitting with confirmed_setup_intent' do
+      context 'succeeded setup_intent' do
+        before do
+          dd_statsd = stub_ddstatsd_instance
+          allow(dd_statsd).to receive(:increment).with('order.submit')
+          allow(dd_statsd).to receive(:increment).with('offer.submit')
+          allow(Gravity).to receive_messages(
+            get_artwork: artwork,
+            fetch_partner: gravity_v1_partner,
+            get_credit_card: credit_card,
+            get_merchant_account: seller_merchant_account
+          )
+          expect(OrderEvent).to receive(:delay_post).once.with(order, Order::SUBMITTED, buyer_id)
+          expect(OfferEvent).to receive(:delay_post).once.with(offer, OfferEvent::SUBMITTED)
+          prepare_setup_intent_retrieve(status: 'succeeded')
+        end
+        it 'submits the order and offer' do
+          expect do
+            OfferService.submit_order_with_offer(offer, user_id: buyer_id, confirmed_setup_intent_id: 'si_1')
+            expect(order.reload.state).to eq(Order::SUBMITTED)
+            expect(offer.reload.submitted_at).not_to be_nil
+          end.to change(order.state_histories, :count).by(1).and change(order.transactions, :count).by(1)
+        end
+      end
+      context 'requires_action setup_intent' do
+        before do
+          allow(Gravity).to receive_messages(
+            get_artwork: artwork,
+            fetch_partner: gravity_v1_partner,
+            get_credit_card: credit_card,
+            get_merchant_account: seller_merchant_account
+          )
+          prepare_setup_intent_retrieve(status: 'requires_action')
+        end
+        it 'stores transaction and raises error' do
+          expect do
+            OfferService.submit_order_with_offer(offer, user_id: buyer_id, confirmed_setup_intent_id: 'si_1')
+            expect(order.reload.state).to eq(Order::PENDING)
+            expect(offer.reload.submitted_at).to be_nil
+          end.to raise_error(Errors::PaymentRequiresActionError).and change(order.state_histories, :count).by(0).and change(order.transactions, :count).by(1)
+          expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::REQUIRES_ACTION)
+        end
       end
     end
   end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -71,7 +71,7 @@ describe OfferService, type: :services do
     let(:order) { Fabricate(:order, buyer_id: buyer_id, seller_id: seller_id, mode: order_mode, state: order_state, credit_card_id: credit_card_id, **shipping_info) }
     let!(:offer) { Fabricate(:offer, order: order, submitted_at: offer_submitted_at, amount_cents: 1000_00, tax_total_cents: 20_00, shipping_total_cents: 30_00, creator_id: buyer_id, from_id: buyer_id) }
     let!(:line_item) { Fabricate(:line_item, order: order, list_price_cents: 2000_00, artwork_id: artwork[:_id], artwork_version_id: line_item_artwork_version, quantity: 2) }
-    let(:call_service) { OfferService.submit_order_with_offer(offer, buyer_id) }
+    let(:call_service) { OfferService.submit_order_with_offer(offer, user_id: buyer_id) }
 
     describe 'failed process' do
       before do

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -102,6 +102,12 @@ RSpec.shared_context 'include stripe helper' do
     allow(Stripe::SetupIntent).to receive(:create).and_return(setup_intent)
   end
 
+  def prepare_setup_intent_retrieve(payment_method: 'cc_1', status: 'succeeded', on_behalf_of: 'acc_123')
+    setup_intent = double(id: 'si_1', payment_method: payment_method, status: status, on_behalf_of: on_behalf_of)
+    allow(setup_intent).to receive(:to_h).and_return(id: 'si_1', client_secret: 'si_test1')
+    allow(Stripe::SetupIntent).to receive(:retrieve).and_return(setup_intent)
+  end
+
   def mock_retrieve_payment_intent(status:)
     payment_intent = double(id: 'pi_1', status: status)
     mock_payment_intent_call(:retrieve, payment_intent)


### PR DESCRIPTION
# Change
Currently when a user submits a Make Offer order, we initiate a `SetupIntent` with Stripe, if buyer had to go through SCA, we open the pop up on front end. Once they successfully finish auth, we will resubmit the order.
Current treats resubmit the same way as original submission, it will create a new `SetupIntent` and try to confirm it, because user has already confirmed previous setup intent, this second one goes through without needing SCA BUT we are creating extra SetupIntents and possibly involving the bank.
Stripe suggested that instead, when we resubmit, pass along the Setup intent ID (which is available in `handleCardSetup` js callback) and on the server side if thats available, instead of creating a new intent, just verify the one passed in.

https://artsyproduct.atlassian.net/browse/PURCHASE-1446

# This PR
Adds new optional `confirmed_setup_intent_id` param to `SubmitOrderWithOffer`, if passed we try to verify that intent instead of creating a new one.