### PR TITLE
PURCHASE-1428: Get failed payment flow working with case where payment intent of a already confirmed setupintent fails when seller accepts offer

### DIFF
--- a/app/graphql/mutations/fix_failed_payment.rb
+++ b/app/graphql/mutations/fix_failed_payment.rb
@@ -24,6 +24,8 @@ class Mutations::FixFailedPayment < Mutations::BaseMutation
     OfferService.accept_offer(offer, current_user_id)
 
     { order_or_error: { order: order.reload } }
+  rescue Errors::PaymentRequiresActionError => e
+    { order_or_error: { action_data: e.action_data } }
   rescue Errors::ApplicationError => e
     { order_or_error: { error: Types::ApplicationErrorType.from_application(e) } }
   end

--- a/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
@@ -264,12 +264,12 @@ describe Api::GraphqlController, type: :request do
                   undeduct_inventory_request
                   prepare_payment_intent_create_failure(status: 'requires_action')
                 end
-        
+
                 it 'returns action data' do
                   response = client.execute(mutation, mutation_input)
                   expect(response.data.fix_failed_payment.order_or_error.action_data.client_secret).to eq 'pi_test1'
                 end
-        
+
                 it 'stores failed transaction' do
                   expect do
                     client.execute(mutation, mutation_input)
@@ -277,13 +277,12 @@ describe Api::GraphqlController, type: :request do
                   expect(order.reload.external_charge_id).to eq 'pi_1'
                   expect(order.transactions.last.requires_action?).to be true
                 end
-        
+
                 it 'undeducts inventory' do
                   client.execute(mutation, mutation_input)
                   expect(undeduct_inventory_request).to have_been_requested
                 end
               end
-
             end
 
             it 'sets payments on the order' do


### PR DESCRIPTION
# [PURCHASE-1428] 
current failed payment flow works when a seller accepts an offer and payment doesn't go through, we send email to buyer about the failed payment and they fix their issue.
we need to make sure this works also for the case were we confirmed setupintent and later when seller accepts offer we tried to process off-session payment intent but that fails

# Problem
fix failed payment mutation isn't set up to return a requires action response

# Solution
Make the mutation return requires action response if submitting during failed payment flow fails

[PURCHASE-1428]: https://artsyproduct.atlassian.net/browse/PURCHASE-1428