### PR TITLE
Fix failed payment with required action

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -200,7 +200,10 @@ class Order < ApplicationRecord
   end
 
   def last_transaction_failed?
-    transactions.present? && transactions.order(created_at: :desc).first.failed?
+    return false unless transactions.present?
+
+    last_transaction = transactions.order(created_at: :desc).first
+    last_transaction.failed? || last_transaction.requires_action?
   end
 
   private


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1453
Current failed payment flow checks to make sure `last_transaction_failed` if it was not _failed_ it would raise error and wont allow going through this flow. In case the last transaction was in `require_action` state which is the state out of SCA, on the front end it would redirect you to status page https://github.com/artsy/reaction/blob/152acf20c68fdb7ebcc367f798a03bb2fdf74305/src/Apps/Order/redirects.tsx#L123

# Solution
Updated `last_transaction_failed?` to also consider `require_actions` cases and added tests around it.