### PR TITLE
Reuse payment intent on resubmitting during failed payment flow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 11
 
 Metrics/ClassLength:
-  Max: 120
+  Max: 130
 
 Metrics/AbcSize:
   Max: 61

--- a/app/graphql/mutations/fix_failed_payment.rb
+++ b/app/graphql/mutations/fix_failed_payment.rb
@@ -16,7 +16,7 @@ class Mutations::FixFailedPayment < Mutations::BaseMutation
       order.last_transaction_failed? &&
       offer.id == order.last_offer.id
 
-    order = OrderService.set_payment!(order, credit_card_id)
+    order = OrderService.set_payment!(order, credit_card_id) if credit_card_id != order.credit_card_id
 
     # Note that the buyer might be 'accepting' their own offer here.
     # If they are, we know the seller attepted to accept it before

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -59,12 +59,10 @@ module OfferService
       order_processor.revert!
       raise Errors::InsufficientInventoryError
     end
-    order_processor.set_totals!
-
     # this is an off-session if offer is from buyer and seller is accepting it (in case of failed payment buyer could accept their own offer)
     off_session = offer.from_participant == Order::BUYER && user_id != order.buyer_id
     order_processor.charge(off_session)
-    order_processor.store_transaction
+    order_processor.store_transaction(off_session)
     if order_processor.failed_payment?
       order_processor.revert!
       raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction)

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -56,7 +56,11 @@ class OrderProcessor
   end
 
   def charge(off_session = false)
-    @transaction = PaymentService.capture_without_hold(construct_charge_params.merge(off_session: off_session))
+    @transaction = if @order.external_charge_id
+      PaymentService.confirm_payment_intent(@order.external_charge_id)
+    else
+      PaymentService.capture_without_hold(construct_charge_params.merge(off_session: off_session))
+    end
   end
 
   def failed_payment?

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -100,9 +100,9 @@ class OrderProcessor
     false
   end
 
-  def store_transaction
+  def store_transaction(off_session = false)
     order.transactions << transaction
-    order.update!(external_charge_id: transaction.external_id) unless transaction.failed?
+    order.update!(external_charge_id: transaction.external_id) unless transaction.failed? || (transaction.requires_action? && off_session)
     PostTransactionNotificationJob.perform_later(transaction.id, @user_id)
   end
 

--- a/spec/integration/fix_failed_payment_flow_with_sca_card.rb
+++ b/spec/integration/fix_failed_payment_flow_with_sca_card.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+# create order -> set initial offer -> set payment to a card that always requires 3d auth -> set shipping -> submit offer -> seller accept but it fails processing -> buyer: reuse the same card -> buyer: fixFailedPayment -> buyer goes through SCA -> buyer resubmits -> should get accepted
+
+describe Api::GraphqlController, type: :request do
+  include_context 'include stripe helper'
+  include_context 'GraphQL Client Helpers'
+  describe 'make offer happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        undeduct_inventory: nil,
+        get_merchant_account: seller_merchant_account
+      )
+    end
+
+    it 'succeeds the process of buyer create -> add initial offer -> set shipping -> set payment(sca) -> submit -> seller accepts (requires action) -> buyer resubmits with sca card -> sca -> resubmit succeeds' do
+      # Buyer creates the offer order
+      expect do
+        buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # adds initial offer to order
+      expect do
+        buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+      end.to change(Offer, :count).by(1)
+      offer = Offer.last
+      expect(order.reload).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+      expect(offer.amount_cents).to eq 500_00
+      expect(offer.order_id).to eq order.id
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: nil,
+        shipping_total_cents: nil,
+        tax_total_cents: nil,
+        buyer_total_cents: nil,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        shipping_city: 'New York',
+        shipping_address_line1: '401 Broadway',
+        shipping_address_line2: 'Suite 80',
+        shipping_postal_code: '10012'
+      )
+
+      expect(offer.reload).to have_attributes(
+        amount_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits offer order
+      prepare_setup_intent_create(status: 'succeeded')
+      expect do
+        buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, status: Transaction::SUCCESS, transaction_type: Transaction::CONFIRM)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00,
+        seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 50_00
+      )
+
+      # seller accepts offer but off-session charge fails
+      prepare_payment_intent_create_failure(status: 'requires_action')
+      expect do
+        seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT, status: Transaction::REQUIRES_ACTION, transaction_type: Transaction::CAPTURE)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00,
+        #seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        #commission_fee_cents: 50_00,
+        external_charge_id: 'pi_1'
+      )
+
+      # Buyer resubmits with same card now its on-session needs sca
+      prepare_payment_intent_create_failure(status: 'requires_action', id: 'pi_2')
+      expect do
+        response = buyer_client.execute(OfferQueryHelper::FAILED_PAYMENT_QUERY, input: { offerId: offer.id.to_s, creditCardId: 'cc-1'})
+      end.to change(order.transactions, :count).by(1)
+      # @TODO: it sets external charge id on the order
+      expect(order.reload).to have_attributes(external_charge_id: 'pi_2', status: Order::SUBMITTED)
+
+      # Buyer does SCA and now resubmits
+      mock_retrieve_payment_intent(status: 'requires_confirmation')
+      prepare_payment_intent_confirm_success(id: 'pi_2')
+      expect do
+        buyer_client.execute(OfferQueryHelper::FAILED_PAYMENT_QUERY, input: { offer_id: offer.id.to_s, credit_card_id: 'cc-1'})
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 800_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 50_00,
+        transaction_fee_cents: 23_50,
+        seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        external_charge_id: 'pi_1'
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/fix_failed_payment_flow_with_sca_card.rb
+++ b/spec/integration/fix_failed_payment_flow_with_sca_card.rb
@@ -137,7 +137,6 @@ describe Api::GraphqlController, type: :request do
       expect do
         buyer_client.execute(OfferQueryHelper::FAILED_PAYMENT_QUERY, input: { offerId: offer.id.to_s, creditCardId: 'cc-1' })
       end.to change(order.transactions, :count).by(1)
-      # @TODO: it sets external charge id on the order
       expect(order.reload).to have_attributes(external_charge_id: 'pi_2', state: Order::SUBMITTED)
 
       # Buyer does SCA and now resubmits

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -264,6 +264,11 @@ describe OrderProcessor, type: :services do
       order_processor.store_transaction
       expect(order.reload.external_charge_id).to be_nil
     end
+    it 'does not store external_id on the order when off_session transaction requires action' do
+      order_processor.instance_variable_set(:@transaction, Fabricate(:transaction, order: order, external_id: 'pi_1', status: Transaction::REQUIRES_ACTION))
+      order_processor.store_transaction(true)
+      expect(order.reload.external_charge_id).to be_nil
+    end
   end
 
   describe 'on success' do

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -507,7 +507,7 @@ describe OfferService, type: :services do
     let(:order) { Fabricate(:order, buyer_id: 'user_1', buyer_type: 'user', seller_id: 'gal_1', seller_type: 'gallery') }
     let(:seller_offer) { Fabricate(:offer, order: order, from_id: 'gal_1', from_type: 'gallery') }
     let(:buyer_offer) { Fabricate(:offer, order: order, from_id: 'user_1', from_type: 'user') }
-    it 'calls charge with off_session true when the seller accepts an offer from the buyer' do
+    it 'calls charge and  with off_session true when the seller accepts an offer from the buyer' do
       order.update!(last_offer: buyer_offer)
       allow_any_instance_of(OrderProcessor).to receive_messages(
         valid?: true,
@@ -520,6 +520,7 @@ describe OfferService, type: :services do
         charge: Fabricate(:transaction)
       )
       expect_any_instance_of(OrderProcessor).to receive(:charge).with(true)
+      expect_any_instance_of(OrderProcessor).to receive(:store_transaction).with(true)
       OfferService.accept_offer(buyer_offer, 'gal_1')
     end
     it 'calls charge with off_session false when the buyer accepts an offer from the seller' do

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -163,4 +163,42 @@ module OfferQueryHelper
       }
     }
   ).freeze
+
+  FAILED_PAYMENT_QUERY = <<-GRAPHQL
+    mutation($input: FixFailedPaymentInput!) {
+      fixFailedPayment(input: $input) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              id
+              state
+              creditCardId
+              buyer {
+                ... on Partner {
+                  id
+                }
+              }
+              seller {
+                ... on User {
+                  id
+                }
+              }
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              code
+              data
+              type
+            }
+          }
+          ... on OrderRequiresAction {
+            actionData {
+              clientSecret
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
 end

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -164,7 +164,7 @@ module OfferQueryHelper
     }
   ).freeze
 
-  FAILED_PAYMENT_QUERY = <<-GRAPHQL
+  FAILED_PAYMENT_QUERY = %(
     mutation($input: FixFailedPaymentInput!) {
       fixFailedPayment(input: $input) {
         orderOrError {
@@ -200,5 +200,5 @@ module OfferQueryHelper
         }
       }
     }
-  GRAPHQL
+  ).freeze
 end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -16,10 +16,10 @@ RSpec.shared_context 'include stripe helper' do
     allow(charge).to receive(:capture)
   end
 
-  def prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00, client_secret: 'pi_test1')
+  def prepare_payment_intent_create_failure(id: 'pi_1', status: 'requires_payment_method', charge_error: nil, capture: false, payment_method: 'cc_1', amount: 20_00, client_secret: 'pi_test1')
     case status
     when 'requires_action'
-      payment_intent = double(id: 'pi_1', payment_method: payment_method, capture_method: capture ? 'automatic' : 'manual', amount: amount, status: status, client_secret: client_secret)
+      payment_intent = double(id: id, payment_method: payment_method, capture_method: capture ? 'automatic' : 'manual', amount: amount, status: status, client_secret: client_secret)
       mock_payment_intent_call(:create, payment_intent)
     when 'requires_payment_method'
       error = Stripe::CardError.new(charge_error[:message], charge_error[:decline_code], charge_error[:code])
@@ -28,8 +28,8 @@ RSpec.shared_context 'include stripe helper' do
     end
   end
 
-  def prepare_payment_intent_create_success(capture: false, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', status: 'succeeded')
+  def prepare_payment_intent_create_success(capture: false, payment_method: 'cc_1', amount: 20_00, id: 'pi_1')
+    payment_intent = double(id: id, payment_method: payment_method, amount: amount, capture_method: capture ? 'automatic' : 'manual', status: 'succeeded')
     mock_payment_intent_call(:create, payment_intent)
   end
 

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -41,8 +41,8 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:retrieve, payment_intent)
   end
 
-  def prepare_payment_intent_confirm_success(payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: 'manual', transfer_data: double(destination: 'ma_1'))
+  def prepare_payment_intent_confirm_success(id: 'pi_1', payment_method: 'cc_1', amount: 20_00)
+    payment_intent = double(id: id, payment_method: payment_method, amount: amount, capture_method: 'manual', transfer_data: double(destination: 'ma_1'))
     allow(payment_intent).to receive(:status).and_return('requires_confirmation', 'requires_capture')
     allow(payment_intent).to receive(:confirm)
     mock_payment_intent_call(:retrieve, payment_intent)


### PR DESCRIPTION
# Problem
Current fix failed payment flow is currently broken when using a card that needs SCA.

# Cause
When buyer uses a SCA card during failed payment flow, it currently creates a new payment intent instead of using the one that was just confirmed as part of SCA popup. 

# Solution
Update `order_processor.charge` to do same thing as `hold` where we check if there is already `external_charge_id` on the `order`, instead of creating new payment intent, confirm the existing one.
This change above though brought up a new bug where we realized currently we set `external_charge_id` on the `order` if transaction didn't fail, so in case transaction `requires_action` we would set it on the `order` so we can reuse it later. BUT in case of `off-session` (seller accepting offer) we don't want to reuse that payment intent anymore so we don't want to set it on the `Order`. We basically ended up updating `OrderProcessor.store_transaction` to get `off_session` as an input and if it was set it would not update `external_charge_id` when transaction is in the `require_action` state.