### PR TITLE
PURCHASE-1474: Wrong expiration on offers with failed payment flow

### DIFF
--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -11,6 +11,7 @@ class OrderProcessor
     @validated = false
     @totals_set = false
     @state_changed = false
+    @original_state_expires_at = nil
   end
 
   def revert!
@@ -19,10 +20,12 @@ class OrderProcessor
     return unless @state_changed
 
     order.revert!
+    order.update!(state_expires_at: @original_state_expires_at)
     @state_changed = false
   end
 
   def advance_state(action)
+    @original_state_expires_at = order.state_expires_at
     order.send(action)
     @state_changed = true
   end

--- a/spec/integration/fix_failed_payment_flow_with_sca_card.rb
+++ b/spec/integration/fix_failed_payment_flow_with_sca_card.rb
@@ -112,7 +112,7 @@ describe Api::GraphqlController, type: :request do
         commission_fee_cents: 50_00
       )
 
-      submitted_state_expiration = order.state_expires_at # setting things up to test for https://artsyproduct.atlassian.net/browse/PURCHASE-1474
+      submitted_state_expiration = order.state_expires_at # setting things up to make sure we don't reset expiration when payment fails.
 
       # seller accepts offer but off-session charge fails
       prepare_payment_intent_create_failure(status: 'requires_action')
@@ -132,7 +132,7 @@ describe Api::GraphqlController, type: :request do
         credit_card_id: 'cc-1',
         commission_fee_cents: 50_00,
         external_charge_id: nil,
-        state_expires_at: submitted_state_expiration # https://artsyproduct.atlassian.net/browse/PURCHASE-1474
+        state_expires_at: submitted_state_expiration
       )
 
       # Buyer resubmits with same card now its on-session needs sca

--- a/spec/integration/fix_failed_payment_flow_with_sca_card.rb
+++ b/spec/integration/fix_failed_payment_flow_with_sca_card.rb
@@ -112,6 +112,8 @@ describe Api::GraphqlController, type: :request do
         commission_fee_cents: 50_00
       )
 
+      submitted_state_expiration = order.state_expires_at # setting things up to test for https://artsyproduct.atlassian.net/browse/PURCHASE-1474
+
       # seller accepts offer but off-session charge fails
       prepare_payment_intent_create_failure(status: 'requires_action')
       expect do
@@ -129,7 +131,8 @@ describe Api::GraphqlController, type: :request do
         shipping_country: 'US',
         credit_card_id: 'cc-1',
         commission_fee_cents: 50_00,
-        external_charge_id: nil
+        external_charge_id: nil,
+        state_expires_at: submitted_state_expiration # https://artsyproduct.atlassian.net/browse/PURCHASE-1474
       )
 
       # Buyer resubmits with same card now its on-session needs sca

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -133,17 +133,21 @@ describe OrderProcessor, type: :services do
     it 'it reverts submitted order to pending' do
       order_processor.instance_variable_set(:@deducted_inventory, [])
       order.submit!
+      original_state_expires_at = order.reload.state_expires_at
       order_processor.instance_variable_set(:@state_changed, true)
+      order_processor.instance_variable_set(:@original_state_expires_at, original_state_expires_at)
       order_processor.revert!
-      expect(order.reload.state).to eq Order::PENDING
+      expect(order.reload).to have_attributes(state: Order::PENDING, state_expires_at: original_state_expires_at)
       expect(order_processor.instance_variable_get(:@state_changed)).to eq false
     end
     it 'it reverts approved order to pending' do
       order.submit!
       order.approve!
+      original_state_expires_at = order.reload.state_expires_at
       order_processor.instance_variable_set(:@state_changed, true)
+      order_processor.instance_variable_set(:@original_state_expires_at, original_state_expires_at)
       order_processor.revert!
-      expect(order.reload.state).to eq Order::SUBMITTED
+      expect(order.reload).to have_attributes(state: Order::SUBMITTED, state_expires_at: original_state_expires_at)
       expect(order_processor.instance_variable_get(:@state_changed)).to eq false
     end
   end


### PR DESCRIPTION
# Problem
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-1474
As part of [the famous "refactor"](https://github.com/artsy/exchange/pull/475), its possible for an order to go to some state and then go back to previous one of the attempt to create charge or deduct failed on the order.

This seems to have cause a new bug where we update the `state_expires_at` on the orders and extend them in failed payment flow. Meaning if the order's expiration was tomorrow, and seller tries to accept the offer, order goes to `approved` for a sec, charge fails, and order goes back to `submitted` state, but because of new transition to `submitted` expiration will now be 3 days from now instead of original 1 day.

# Solution
In `OrderProcessor` before transitioning order state, keep track of current `state_expires_at` and if order failed and we wanted to `revert!` update `OrderProcessor.revert!` to set expiration back to original one. 