### PR TITLE
GALL-2120: Relax admin check

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -76,12 +76,12 @@ class Types::QueryType < Types::BaseObject
     context[:current_user][:roles].include?('trusted')
   end
 
-  def sales_admin?
-    context[:current_user][:roles].include?('sales_admin')
+  def admin?
+    context[:current_user][:roles].include?('admin')
   end
 
   def validate_order_request!(order)
-    return if trusted? || sales_admin? ||
+    return if trusted? || admin? ||
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
               (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
@@ -94,7 +94,7 @@ class Types::QueryType < Types::BaseObject
   end
 
   def validate_orders_request!(params)
-    return if trusted? || sales_admin?
+    return if trusted? || admin?
 
     if params[:buyer_id].present?
       raise ActiveRecord::RecordNotFound unless params[:buyer_id] == context[:current_user][:id]

--- a/lib/artsy_auth_token.rb
+++ b/lib/artsy_auth_token.rb
@@ -1,5 +1,5 @@
 class ArtsyAuthToken
-  ADMIN_ROLE = 'sales_admin'.freeze
+  ADMIN_ROLE = 'admin'.freeze
   def initialize(jwt)
     @jwt = jwt
     @decoded_token = decode_token

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -397,7 +397,7 @@ describe Api::GraphqlController, type: :request do
       end
 
       context "sales admin accessing another account's order" do
-        let(:jwt_roles) { 'sales_admin' }
+        let(:jwt_roles) { 'admin' }
 
         it 'allows action' do
           expect do

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -190,7 +190,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     context "sales admin accessing another account's order" do
-      let(:jwt_roles) { 'sales_admin' }
+      let(:jwt_roles) { 'admin' }
 
       it 'allows action' do
         expect do


### PR DESCRIPTION
In order to allow admins into the order pages in CMS, they have to be able to see the order data at the GQL layer. Without a change like this nothing would be returned to Volt for them to look at!

Note: I believe that what this PR does is allow admins access to query for orders, but does not allow them access to mutate them, but would love confirmation of this!