### PR TITLE
Restrict order access to just trusted admin roles

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -76,12 +76,13 @@ class Types::QueryType < Types::BaseObject
     context[:current_user][:roles].include?('trusted')
   end
 
-  def admin?
-    context[:current_user][:roles].include?('admin')
+  def trusted_admin?
+    user_roles = context[:current_user][:roles]
+    ArtsyAuthToken.trusted_admin?(user_roles)
   end
 
   def validate_order_request!(order)
-    return if trusted? || admin? ||
+    return if trusted? || trusted_admin? ||
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
               (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
@@ -94,7 +95,7 @@ class Types::QueryType < Types::BaseObject
   end
 
   def validate_orders_request!(params)
-    return if trusted? || admin?
+    return if trusted? || trusted_admin?
 
     if params[:buyer_id].present?
       raise ActiveRecord::RecordNotFound unless params[:buyer_id] == context[:current_user][:id]

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -77,7 +77,7 @@ class Types::QueryType < Types::BaseObject
   end
 
   def trusted_admin?
-    user_roles = context[:current_user][:roles]
+    user_roles = Array(context[:current_user][:roles])
     ArtsyAuthToken.trusted_admin?(user_roles)
   end
 

--- a/lib/artsy_auth_token.rb
+++ b/lib/artsy_auth_token.rb
@@ -1,5 +1,10 @@
 class ArtsyAuthToken
-  ADMIN_ROLE = 'admin'.freeze
+  TRUSTED_ADMIN_ROLES = %w[partner_support sales_admin].freeze
+
+  def self.trusted_admin?(user_roles)
+    (TRUSTED_ADMIN_ROLES & user_roles).any?
+  end
+
   def initialize(jwt)
     @jwt = jwt
     @decoded_token = decode_token
@@ -8,7 +13,7 @@ class ArtsyAuthToken
   def admin?
     return false unless @decoded_token
 
-    @decoded_token['roles'].include? ADMIN_ROLE
+    self.class.trusted_admin?(@decoded_token['roles'])
   end
 
   def current_user

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -396,6 +396,22 @@ describe Api::GraphqlController, type: :request do
         end
       end
 
+      context 'normal admin accessing an order' do
+        let(:jwt_roles) { 'admin' }
+
+        it 'raises error' do
+          expect do
+            client.execute(query, id: user2_order1.id)
+          end.to raise_error do |error|
+            expect(error).to be_a(Graphlient::Errors::ServerError)
+            expect(error.message).to eq 'the server responded with status 404'
+            expect(error.status_code).to eq 404
+            expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
+            expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
+          end
+        end
+      end
+
       context "sales admin accessing another account's order" do
         let(:jwt_roles) { 'sales_admin' }
 

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -397,7 +397,26 @@ describe Api::GraphqlController, type: :request do
       end
 
       context "sales admin accessing another account's order" do
-        let(:jwt_roles) { 'admin' }
+        let(:jwt_roles) { 'sales_admin' }
+
+        it 'allows action' do
+          expect do
+            client.execute(query, id: user2_order1.id)
+          end.to_not raise_error
+        end
+
+        it 'returns expected payload' do
+          result = client.execute(query, id: user2_order1.id)
+          expect(result.data.order.buyer.id).to eq user2_order1.buyer_id
+          expect(result.data.order.seller.id).to eq user2_order1.seller_id
+          expect(result.data.order.currency_code).to eq 'USD'
+          expect(result.data.order.state).to eq 'PENDING'
+          expect(result.data.order.items_total_cents).to eq 0
+        end
+      end
+
+      context "liaison accessing another account's order" do
+        let(:jwt_roles) { 'partner_support' }
 
         it 'allows action' do
           expect do

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -189,6 +189,22 @@ describe Api::GraphqlController, type: :request do
       end
     end
 
+    context 'normal admin accessing orders' do
+      let(:jwt_roles) { 'admin' }
+
+      it 'raises error' do
+        expect do
+          client.execute(query, buyerId: 'someone-elses-userid')
+        end.to raise_error do |error|
+          expect(error).to be_a(Graphlient::Errors::ServerError)
+          expect(error.status_code).to eq 404
+          expect(error.message).to eq 'the server responded with status 404'
+          expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
+          expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
+        end
+      end
+    end
+
     context "sales admin accessing another account's order" do
       let(:jwt_roles) { 'sales_admin' }
 

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -190,7 +190,24 @@ describe Api::GraphqlController, type: :request do
     end
 
     context "sales admin accessing another account's order" do
-      let(:jwt_roles) { 'admin' }
+      let(:jwt_roles) { 'sales_admin' }
+
+      it 'allows action' do
+        expect do
+          client.execute(query, buyerId: second_user)
+        end.to_not raise_error
+      end
+
+      it 'returns expected payload' do
+        result = client.execute(query, buyerId: second_user)
+        expect(result.data.orders.edges.count).to eq 1
+        ids = ids_from_result_data(result)
+        expect(ids).to match_array([user2_order1.id])
+      end
+    end
+
+    context "liaison accessing another account's order" do
+      let(:jwt_roles) { 'partner_support' }
 
       it 'allows action' do
         expect do


### PR DESCRIPTION
Hot on the heels of my other PR #498, I'm following up here with one that restricts order access to admins with either `partner_support` or `sales_admin` roles. While I was at it, I added tests for both of these.