### PR TITLE
Fix role checking

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -77,7 +77,8 @@ class Types::QueryType < Types::BaseObject
   end
 
   def trusted_admin?
-    ArtsyAuthToken.trusted_admin?(context[:current_user][:roles])
+    user_roles = context[:current_user][:roles].split(',')
+    ArtsyAuthToken.trusted_admin?(user_roles)
   end
 
   def validate_order_request!(order)

--- a/lib/artsy_auth_token.rb
+++ b/lib/artsy_auth_token.rb
@@ -2,7 +2,7 @@ class ArtsyAuthToken
   TRUSTED_ADMIN_ROLES = %w[partner_support sales_admin].freeze
 
   def self.trusted_admin?(user_roles)
-    TRUSTED_ADMIN_ROLES.any? { |role| user_roles.include?(role) }
+    (TRUSTED_ADMIN_ROLES & user_roles).any?
   end
 
   def initialize(jwt)
@@ -13,7 +13,8 @@ class ArtsyAuthToken
   def admin?
     return false unless @decoded_token
 
-    self.class.trusted_admin?(@decoded_token['roles'])
+    user_roles = @decoded_token['roles'].split(',')
+    self.class.trusted_admin?(user_roles)
   end
 
   def current_user

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -413,7 +413,7 @@ describe Api::GraphqlController, type: :request do
       end
 
       context "sales admin accessing another account's order" do
-        let(:jwt_roles) { 'sales_admin' }
+        let(:jwt_roles) { 'admin,sales_admin' }
 
         it 'allows action' do
           expect do


### PR DESCRIPTION
The roles property is a string that is a comma separated list of roles. Need to split it up into an array in order to compare against trusted roles. I also updated a spec to more closely match how roles are passed in (as a string that's actually a comma separated list of roles).

Note: this is a re-open of #503 after rebasing.