### PR TITLE
Fix issue where SetupIntent.create could raise error and we were not …

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -1,12 +1,12 @@
 module Errors
   ERROR_TYPES = {
     validation: %i[
-      cannot_offer
-      cant_submit
       cannot_accept_offer
+      cannot_counter
+      cannot_offer
       cannot_reject_offer
       cannot_reject_own_offer
-      cannot_counter
+      cant_submit
       credit_card_deactivated
       credit_card_missing_customer
       credit_card_missing_external_id
@@ -59,6 +59,7 @@ module Errors
       capture_failed
       charge_authorization_failed
       insufficient_inventory
+      payment_method_confirmation_failed
       payment_requires_action
       received_partial_refund
       refund_failed

--- a/lib/offer_processor.rb
+++ b/lib/offer_processor.rb
@@ -40,7 +40,9 @@ class OfferProcessor
       PaymentMethodService.confirm_payment_method!(offer.order)
     end
     order.transactions << transaction
-    return unless @transaction.requires_action?
+    return unless transaction.requires_action? || transaction.failed?
+
+    raise Errors::FailedTransactionError.new(:payment_method_confirmation_failed, transaction) if transaction.failed?
 
     Exchange.dogstatsd.increment 'offer.requires_action'
     raise Errors::PaymentRequiresActionError, transaction.action_data

--- a/lib/payment_method_service.rb
+++ b/lib/payment_method_service.rb
@@ -35,6 +35,18 @@ module PaymentMethodService
       status: transaction_status_from_intent(setup_intent),
       payload: setup_intent.to_h
     )
+  rescue Stripe::CardError => e
+    body = e.json_body[:error]
+    Transaction.new(
+      external_id: body[:setup_intent][:id],
+      external_type: Transaction::SETUP_INTENT,
+      failure_code: body[:code],
+      failure_message: body[:message],
+      decline_code: body[:decline_code],
+      transaction_type: Transaction::CONFIRM,
+      status: Transaction::FAILURE,
+      payload: e.json_body
+    )
   end
 
   def self.metadata(order)

--- a/spec/lib/offer_processor_spec.rb
+++ b/spec/lib/offer_processor_spec.rb
@@ -78,7 +78,7 @@ describe OfferProcessor, type: :services do
         expect(order.transactions.first.id).to eq transaction.id
       end
     end
-    context 'verifying existing payment intent' do
+    context 'verifying existing setup intent' do
       it 'adds transaction to the order in case of success' do
         prepare_setup_intent_retrieve
         expect { op.confirm_payment_method!('si_1') }.to change(order.transactions, :count).by(1)
@@ -88,6 +88,14 @@ describe OfferProcessor, type: :services do
         prepare_setup_intent_retrieve(status: 'requires_action')
         expect { op.confirm_payment_method!('si_1') }.to raise_error(Errors::PaymentRequiresActionError).and change(order.transactions, :count).by(1)
         expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::REQUIRES_ACTION)
+      end
+    end
+    context 'setup intent fails with card_decline' do
+      it 'adds transaction to the order and raises error in case of require action' do
+        transaction = Fabricate(:transaction, status: Transaction::FAILURE, external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM)
+        expect(PaymentMethodService).to receive(:confirm_payment_method!).with(order).and_return(transaction)
+        expect { op.confirm_payment_method! }.to raise_error(Errors::FailedTransactionError).and change(order.transactions, :count).by(1)
+        expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::FAILURE)
       end
     end
   end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -102,6 +102,12 @@ RSpec.shared_context 'include stripe helper' do
     allow(Stripe::SetupIntent).to receive(:create).and_return(setup_intent)
   end
 
+  def prepare_setup_intent_create_failure(charge_error:)
+    error = Stripe::CardError.new(charge_error[:message], charge_error[:decline_code], charge_error[:code])
+    allow(error).to receive(:json_body).and_return(error: { setup_intent: basic_setup_intent(code: charge_error[:code], decline_code: charge_error[:decline_code]) })
+    allow(Stripe::SetupIntent).to receive(:create).and_raise(error)
+  end
+
   def prepare_setup_intent_retrieve(payment_method: 'cc_1', status: 'succeeded', on_behalf_of: 'acc_123')
     setup_intent = double(id: 'si_1', payment_method: payment_method, status: status, on_behalf_of: on_behalf_of)
     allow(setup_intent).to receive(:to_h).and_return(id: 'si_1', client_secret: 'si_test1')
@@ -305,6 +311,92 @@ RSpec.shared_context 'include stripe helper' do
         destination: 'ma_1'
       },
       transfer_group: nil
+    }
+  end
+
+  def basic_setup_intent(code: 'card_declined', decline_code: 'do_not_honor')
+    {
+      id: 'seti_1FJEY2GK3Gnpfa3OloLFhpiV',
+      object: 'setup_intent',
+      application: nil,
+      cancellation_reason: nil,
+      client_secret: 'seti_1FJEY2GK3Gnpfa3OloLFhpiV_secret_FosI3jo5pM0sXWNtJcK1YfGlqCuDq7F',
+      created: 1568618578,
+      customer: 'cus_9DPsU3LXXND065',
+      description: nil,
+      last_setup_error: {
+        code: code,
+        decline_code: decline_code,
+        doc_url: 'https://stripe.com/docs/error-codes/card-declined',
+        message: 'Your card was declined.',
+        param: '',
+        payment_method: {
+          id: 'card_1BfuyGGK3Gnpfa3OrYYQhDNk',
+          object: 'payment_method',
+          billing_details: {
+            address: {
+              city: 'Some City',
+              country: 'SWE',
+              line1: 'first address line',
+              line2: nil,
+              postal_code: '181 56',
+              state: ''
+            },
+            email: nil,
+            name: 'Random guy',
+            phone: nil
+          },
+          card: {
+            brand: 'amex',
+            checks: {
+              address_line1_check: 'pass',
+              address_postal_code_check: 'pass',
+              cvc_check: nil
+            },
+            country: 'SE',
+            exp_month: 1,
+            exp_year: 2020,
+            fingerprint: 'fingerprint',
+            funding: 'credit',
+            generated_from: nil,
+            last4: '1234',
+            three_d_secure_usage: {
+              supported: false
+            },
+            wallet: nil
+          },
+          created: 1514919524,
+          customer: 'cus_1',
+          livemode: true,
+          metadata: {
+          },
+          type: 'card'
+        },
+        type: 'card_error'
+      },
+      livemode: true,
+      metadata: {
+        exchange_order_id: 'exchange_test',
+        buyer_id: 'buyer_id',
+        buyer_type: 'user',
+        seller_id: 'seller_id',
+        seller_type: 'gallery',
+        type: 'bn-mo',
+        mode: 'offer'
+      },
+      next_action: nil,
+      on_behalf_of: 'acct_1234',
+      payment_method: nil,
+      payment_method_options: {
+        card: {
+          request_three_d_secure: 'automatic'
+        }
+      },
+      payment_method_types: [
+        'card'
+      ],
+      status: 'requires_payment_method',
+      usage: 'off_session'
     }
   end
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1487
We started getting [errors in Sentry](https://sentry.io/organizations/artsynet/issues/1210464066/?project=1275271&query=is%3Aunresolved&statsPeriod=14d) showing that some `SetupIntent.create` calls are leading to unhandled exception and eventually failing the actual request.

# Cause
Looking at [Stripe's documents](https://stripe.com/docs/api/setup_intents/create) we were under impression that `create` always return a setup intent and never raises error. But looking at real examples looks like the endpoint can return `402` which leads to exception in case of using Ruby client.

# Solution
Update `PaymentMethodService` to `rescue` from exception and properly create a `Transaction` in `failed` state and return it.
In `OfferService` we now check for failed transaction and in that case we raise a `Errors::FailedTransactionError` with new `payment_method_confirmation_failed` as `code`. 