### PR TITLE
Fix fail confirm payment intent issue

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -68,6 +68,10 @@ module OrderService
     end
     order_processor.on_success
     order
+  rescue StandardError => e
+    # catch all
+    order_processor&.revert!
+    raise e
   end
 
   def self.fulfill_at_once!(order, fulfillment, user_id)

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -79,7 +79,7 @@ module PaymentService
     )
   rescue Stripe::CardError => e
     transaction_from_payment_intent_failure(e)
-  rescue Stripe::InvalidRequestError => e
+  rescue Stripe::StripeError => e
     transaction_from_payment_intent_failure(e)
   end
 

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -79,6 +79,8 @@ module PaymentService
     )
   rescue Stripe::CardError => e
     transaction_from_payment_intent_failure(e)
+  rescue Stripe::InvalidRequestError => e
+    transaction_from_payment_intent_failure(e)
   end
 
   def self.create_payment_intent_params(credit_card, buyer_amount, seller_amount, merchant_account, currency_code, description, metadata, capture, shipping_address, shipping_name, off_session)

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -41,6 +41,22 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:retrieve, payment_intent)
   end
 
+  def prepare_payment_intent_confirm_raise_invalid(payment_method: 'cc_1', amount: 20_00, message: 'You cannot confirm this PaymentIntent because it’s missing a payment method.', code: 'payment_intent_unexpected_state')
+    payment_intent = double(
+      id: 'pi_1',
+      payment_method: payment_method,
+      amount: amount,
+      capture_method: 'manual',
+      status: 'requires_confirmation',
+      transfer_data: double(destination: 'ma_1'),
+      last_payment_error: double(message: message, code: code)
+    )
+    error = Stripe::InvalidRequestError.new(message, code)
+    allow(error).to receive(:json_body).and_return(error: { payment_intent: basic_payment_intent(status: 'requires_payment_method', capture: true, amount: amount, code: code, decline_code: nil) })
+    allow(payment_intent).to receive(:confirm).and_raise(error)
+    mock_payment_intent_call(:retrieve, payment_intent)
+  end
+
   def prepare_payment_intent_confirm_success(id: 'pi_1', payment_method: 'cc_1', amount: 20_00)
     payment_intent = double(id: id, payment_method: payment_method, amount: amount, capture_method: 'manual', transfer_data: double(destination: 'ma_1'))
     allow(payment_intent).to receive(:status).and_return('requires_confirmation', 'requires_capture')


### PR DESCRIPTION
# Problem
When a user is presented with SCA and does not go through with it (cancel or fail it), when they resubmit the order, the order goes to `submitted` state which means we send emails to both side and all that jazz without actually processing the charge.

# Cause
In this case, Order already has a payment intent assigned to it on its `external_charge_id` attribute, so when user resubmits the order, we try to `confirm` that existing payment intent, this leads to a `Stripe::InvalidRequestError` which we were not rescuing from. Since we are doing a optimistic `submit` in our latest code we were not reverting the order.

# Solution
Rescue from `Stripe::InvalidRequest` in `PaymentService` and create a failed transaction. This way we will revert in `order_service.submit!` and order should be back to `pending` state.

We also added a _catch all_ in `order_service.submit` which will always revert in case anything went wrong.

# Followup
Check other places we feel optimistic about things.