### PR TITLE
Make sure payment service returns failed transaction on failed confirm

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Metrics/MethodLength:
     - "db/migrate/*"
 
 Metrics/ModuleLength:
-  Max: 170
+  Max: 180
   Exclude:
     - "spec/**/*"
 

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -55,7 +55,6 @@ module Errors
     processing: %i[
       artwork_version_mismatch
       cannot_capture
-      cannot_confirm
       capture_failed
       charge_authorization_failed
       insufficient_inventory

--- a/app/jobs/undeduct_line_item_inventory_job.rb
+++ b/app/jobs/undeduct_line_item_inventory_job.rb
@@ -1,7 +1,7 @@
 class UndeductLineItemInventoryJob < ApplicationJob
   queue_as :default
   discard_on(Errors::ValidationError) do |job, _error|
-    Rails.warn.info "Line item #{job.line_item.id} has deleted artwork, skipping inventory undeduction"
+    Rails.logger.warn("Line item #{job.line_item.id} has deleted artwork, skipping inventory undeduction")
   end
 
   attr_accessor :line_item

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -58,11 +58,9 @@ module OrderService
     order_processor.hold
     order_processor.store_transaction
 
-    if order_processor.failed_payment?
-      order_processor.revert!
-      raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction)
-    elsif order_processor.requires_action?
-      order_processor.revert!
+    raise Errors::FailedTransactionError.new(:charge_authorization_failed, order_processor.transaction) if order_processor.failed_payment?
+
+    if order_processor.requires_action?
       Exchange.dogstatsd.increment 'submit.requires_action'
       raise Errors::PaymentRequiresActionError, order_processor.action_data
     end

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -65,16 +65,7 @@ module PaymentService
 
   def self.confirm_payment_intent(payment_intent_id)
     payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
-    if payment_intent.status != 'requires_confirmation'
-      return Transaction.new(
-        external_id: payment_intent_id,
-        external_type: Transaction::PAYMENT_INTENT,
-        transaction_type: Transaction::CONFIRM,
-        failure_code: 'cannot_confirm',
-        failure_message: 'Payment intent is not in a confirmable state',
-        status: Transaction::FAILURE
-      )
-    end
+    return payment_intent_transaction_failure(payment_intent_id: payment_intent_id, transaction_type: Transaction::CONFIRM, failure_code: 'cannot_confirm', failure_message: 'Payment intent is not in a confirmable state') if payment_intent.status != 'requires_confirmation'
 
     payment_intent.confirm
     Transaction.new(
@@ -189,6 +180,17 @@ module PaymentService
       failure_message: pi[:last_payment_error][:message],
       decline_code: pi[:last_payment_error][:decline_code],
       payload: exc.json_body
+    )
+  end
+
+  def self.payment_intent_transaction_failure(payment_intent_id:, transaction_type:, failure_code:, failure_message:)
+    Transaction.new(
+      external_id: payment_intent_id,
+      external_type: Transaction::PAYMENT_INTENT,
+      transaction_type: transaction_type,
+      failure_code: failure_code,
+      failure_message: failure_message,
+      status: Transaction::FAILURE
     )
   end
 end

--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -291,9 +291,16 @@ describe PaymentService, type: :services do
   end
 
   describe '#confirm_payment_intent' do
-    it 'raises error if payment_intent not in expected state' do
+    it 'returns failed transaction if payment_intent is not in expected state' do
       mock_retrieve_payment_intent(status: 'requires_action')
-      expect { PaymentService.confirm_payment_intent('pi_1') }.to raise_error(Errors::ProcessingError)
+      transaction = PaymentService.confirm_payment_intent('pi_1')
+      expect(transaction).to have_attributes(
+        external_id: 'pi_1',
+        external_type: Transaction::PAYMENT_INTENT,
+        transaction_type: Transaction::CONFIRM,
+        status: Transaction::FAILURE,
+        failure_code: 'cannot_confirm'
+      )
     end
 
     it 'confirms the payment intent and stores transaction' do


### PR DESCRIPTION
# Problem
We fixed a scary bug in #510 where we now check for other Stripe errors. But in case payment intent is not even in the state that we attempt confirming (which seems to be the bug we actually ran into) while our previous fix actually works in this case since we added the catch all, at the moment we don't track the fact that we attempted to confirm the payment intent.

# Solution
Instead of raising `ProcessingError`, actually create a proper `Transaction` in failed state so we can track the fact that user attempted to confirm a payment intent not ready in to be confirmed.

# Extra Changes
- In `OrderService` as part of #510 we do a `order_processor.revert` in our new catch all block, this potentially means we call revert twice since we get into this block in case of failed payment and requires action, remove the revert from those 2 checks. While current approach is still safe since `revert` is smart enough to not double revert, new approach seems safer.
- Fix https://sentry.io/organizations/artsynet/issues/851534327