### PR TITLE
Add external_charge_id to order event

### DIFF
--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -30,6 +30,7 @@ class OrderEvent < Events::BaseEvent
     transaction_fee_cents
     updated_at
     total_list_price_cents
+    external_charge_id
   ].freeze
 
   def self.post(order, action, user_id)

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -32,6 +32,7 @@ describe OrderEvent, type: :events do
       items_total_cents: 300,
       buyer_total_cents: 380,
       state: 'submitted',
+      external_charge_id: 'pi_1',
       **shipping_info
     )
   end
@@ -111,6 +112,7 @@ describe OrderEvent, type: :events do
         expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-19 15:48:00 -0400')
         expect(event.properties[:total_list_price_cents]).to eq(400)
         expect(event.properties[:last_offer]).to be_nil
+        expect(event.properties[:external_charge_id]).to eq 'pi_1'
       end
     end
     context 'with last_offer' do


### PR DESCRIPTION
# Change
We need this value on the APR side to be able to fetch payment intent from Stripe.

cc: @sepans @zephraph going to self-merge since we talked about this and trying to test this on staging since APR side was already merged with this assumption.