### PR TITLE
Add artist ids and names to charge metadata

### DIFF
--- a/lib/line_item_helper.rb
+++ b/lib/line_item_helper.rb
@@ -1,9 +1,7 @@
 module LineItemHelper
   def artwork
     @artwork ||= begin
-      artwork = Gravity.get_artwork(artwork_id)
-      validate_artwork!(artwork)
-      artwork
+      Gravity.get_artwork(artwork_id) || raise(Errors::ValidationError, :unknown_artwork)
     end
   end
 
@@ -31,12 +29,5 @@ module LineItemHelper
 
   def current_commission_fee_cents
     total_list_price_cents * order.current_commission_rate
-  end
-
-  private
-
-  def validate_artwork!(artwork)
-    raise Errors::ValidationError, :unknown_artwork unless artwork
-    raise Errors::ValidationError, :missing_artwork_location if artwork[:location].blank?
   end
 end

--- a/lib/offer_totals.rb
+++ b/lib/offer_totals.rb
@@ -18,8 +18,7 @@ class OfferTotals
 
   def artwork
     @artwork ||= begin
-      artwork_id = @order.line_items.first.artwork_id # this is with assumption of Offer order only having one lineItem
-      @order.artworks[artwork_id]
+      @order.line_items.first&.artwork # this is with assumption of Offer order only having one lineItem
     end
   end
 

--- a/lib/order_helper.rb
+++ b/lib/order_helper.rb
@@ -12,7 +12,11 @@ module OrderHelper
   end
 
   def artworks
-    @artworks ||= line_items.uniq.map { |li| [li.artwork_id, li.artwork] }.to_h
+    @artworks ||= line_items.map(&:artwork)
+  end
+
+  def artists
+    @artists ||= artworks.map { |a| a[:artist] }
   end
 
   def credit_card

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -143,7 +143,9 @@ class OrderProcessor
       seller_id: @order.seller_id,
       seller_type: @order.seller_type,
       type: @order.auction_seller? ? 'auction-bn' : 'bn-mo',
-      mode: @order.mode
+      mode: @order.mode,
+      artist_ids: @order.artists.map { |a| a[:_id] }.join(','),
+      artist_names: @order.artists.map { |a| a[:name] }.join(',')
     }
   end
 end

--- a/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
@@ -45,7 +45,7 @@ describe Api::GraphqlController, type: :request do
       Fabricate(:line_item, order: order, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
     end
     let(:offer) { Fabricate(:offer, order: order, from_id: seller_id, from_type: 'gallery', amount_cents: 800_00, shipping_total_cents: 100_00, tax_total_cents: 300_00) }
-    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1') }
 
     let(:mutation) do
       <<-GRAPHQL

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -35,7 +35,7 @@ describe Api::GraphqlController, type: :request do
       Fabricate(:line_item, order: order, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1')
     end
     let(:offer) { Fabricate(:offer, order: order, from_id: order_seller_id, from_type: 'gallery', amount_cents: 800_00, shipping_total_cents: 100_00, tax_total_cents: 300_00) }
-    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1') }
 
     let(:mutation) do
       <<-GRAPHQL

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -45,7 +45,7 @@ describe Api::GraphqlController, type: :request do
         tax_total_cents: 300_00
       )
     end
-    let(:artwork) { { _id: 'a-1', current_version_id: '1' } }
+    let(:artwork) { gravity_v1_artwork(_id: 'a-1', current_version_id: '1') }
 
     let(:mutation) do
       <<-GRAPHQL

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -280,6 +280,7 @@ describe OrderProcessor, type: :services do
 
   describe '#hold' do
     before do
+      stub_artwork_request
       stub_gravity_card_request
       stub_gravity_merchant_account_request
       stub_gravity_partner
@@ -328,6 +329,7 @@ describe OrderProcessor, type: :services do
 
   describe '#charge' do
     before do
+      stub_artwork_request
       stub_gravity_card_request
       stub_gravity_merchant_account_request
       stub_gravity_partner
@@ -363,6 +365,9 @@ describe OrderProcessor, type: :services do
   end
 
   describe '#charge_metadata' do
+    before do
+      stub_artwork_request
+    end
     it 'includes all expected metadata' do
       metadata = order_processor.send(:charge_metadata)
       expect(metadata).to match(
@@ -372,7 +377,9 @@ describe OrderProcessor, type: :services do
         seller_id: 'seller1',
         seller_type: 'gallery',
         type: 'bn-mo',
-        mode: 'buy'
+        mode: 'buy',
+        artist_ids: 'artist-id',
+        artist_names: 'BNMOsy'
       )
     end
   end


### PR DESCRIPTION
# Problème
https://artsyproduct.atlassian.net/browse/PURCHASE-1567
We want to be able to add Radar rules possibly based on artists. We can do this by adding `artist_ids` and `artist_names` to metadata passed to Stripe.

Nous voulons pouvoir ajouter des règles de radar basées éventuellement sur des artistes. Nous pouvons le faire en ajoutant `artist_ids` et` artist_names` aux métadonnées transmises à Stripe.

# Soluzione
Add `artist_ids` and `artist_names` for this order to metadata passed to stripe.

Aggiungi `artist_ids` e` artist_names` per questo ordine ai metadati passati a stripe.

