### PR TITLE
Fix admin offer cancelation issue

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -214,6 +214,11 @@ type BuyerRejectOfferPayload {
 
 enum CancelReasonTypeEnum {
   """
+  cancelation reason is: admin_canceled
+  """
+  ADMIN_CANCELED
+
+  """
   cancelation reason is: buyer_lapsed
   """
   BUYER_LAPSED

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -45,9 +45,9 @@ ActiveAdmin.register Order do
     redirect_to resource_path, notice: "Refunded!"
   end
 
-  member_action :buyer_reject, method: :post do
-    OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:buyer_rejected])
-    redirect_to resource_path, notice: "Rejected on behalf of buyer!"
+  member_action :reject, method: :post do
+    OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:admin_canceled])
+    redirect_to resource_path, notice: "Canceled by Artsy admin!"
   end
 
   member_action :approve_order, method: :post do

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -45,9 +45,14 @@ ActiveAdmin.register Order do
     redirect_to resource_path, notice: "Refunded!"
   end
 
-  member_action :reject, method: :post do
+  member_action :cancel, method: :post do
     OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:admin_canceled])
     redirect_to resource_path, notice: "Canceled by Artsy admin!"
+  end
+
+  member_action :buyer_reject, method: :post do
+    OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:buyer_rejected])
+    redirect_to resource_path, notice: "Canceled on behalf of buyer!"
   end
 
   member_action :approve_order, method: :post do
@@ -89,6 +94,7 @@ ActiveAdmin.register Order do
   action_item :refund, only: :show do
     if order.state == Order::SUBMITTED
       link_to 'Buyer Reject', buyer_reject_admin_order_path(order), method: :post, data: {confirm: 'Are you sure you want to reject this order on behalf of buyer?'}
+      link_to 'Cancel Order', cancel_admin_order_path(order), method: :post, data: {confirm: 'Are you sure you want to cancel this order?'}
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -52,7 +52,8 @@ class Order < ApplicationRecord
       seller_rejected_other: 'seller_rejected_other'.freeze,
       seller_rejected: 'seller_rejected'.freeze,
       buyer_rejected: 'buyer_rejected'.freeze,
-      buyer_lapsed: 'buyer_lapsed'.freeze
+      buyer_lapsed: 'buyer_lapsed'.freeze,
+      admin_canceled: 'admin_canceled'.freeze
     }
   }.freeze
 

--- a/app/services/order_cancellation_service.rb
+++ b/app/services/order_cancellation_service.rb
@@ -24,8 +24,8 @@ class OrderCancellationService
     @order.reject!(rejection_reason) do
       cancel_payment_intent if @order.mode == Order::BUY
     end
+    process_inventory_undeduction if @order.mode == Order::BUY
     Exchange.dogstatsd.increment 'order.reject'
-    process_inventory_undeduction
     OrderEvent.delay_post(@order, @user_id)
   ensure
     @order.transactions << @transaction if @transaction.present?

--- a/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/reject_offer_mutation_request_spec.rb
@@ -53,6 +53,10 @@ RSpec.shared_examples 'rejecting an offer' do
         client.execute(mutation, input)
       end.to change { order.reload.state }.from(Order::SUBMITTED).to(Order::CANCELED)
     end
+    it 'does not queue jobs to undeduct inventory' do
+      client.execute(mutation, input)
+      expect(UndeductLineItemInventoryJob).not_to have_been_enqueued
+    end
   end
 
   def create_order_and_original_offer

--- a/spec/services/order_cancellation_service_spec.rb
+++ b/spec/services/order_cancellation_service_spec.rb
@@ -20,7 +20,7 @@ describe OrderCancellationService, type: :services do
         service.reject!
       end
 
-      it 'queues undeduct inventory job' do
+      it 'queues undeduct inventory job for buy now order' do
         expect(UndeductLineItemInventoryJob).to have_been_enqueued.with(line_items.first.id)
       end
 
@@ -36,6 +36,14 @@ describe OrderCancellationService, type: :services do
 
       it 'queues notification job' do
         expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.canceled')
+      end
+
+      context 'offer order' do
+        let(:order_mode) { Order::OFFER }
+        let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00)] }
+        it 'does not queue undeduct inventory job for make offer order' do
+          expect(UndeductLineItemInventoryJob).not_to have_been_enqueued
+        end
       end
     end
 


### PR DESCRIPTION
# Problem
When an offer order is canceled/rejected, we still queue jobs to undeduct the inventory. This is not correct because for an offer order at that stage we haven't deducted the inventory yet.
Because of this on the Gravity's end we may end up with artworks with `{"sold":-1,"count":2}` if an offer order on a unique artwork is canceled.

Jira: https://artsyproduct.atlassian.net/browse/PURCHASE-1641
Original slack conversation: https://artsy.slack.com/archives/CB110C6LE/p1572892624036100

# Solution
Only process undeduct if order is a `BUY` order.

Also added a new cancelation reason for `admin_canceled` to reflect the reality of the case that order was canceled by an admin and not by buyer.