### PR TITLE
Fix missing shipping_region in TransactionEvent.properties.order

### DIFF
--- a/app/events/transaction_event.rb
+++ b/app/events/transaction_event.rb
@@ -48,7 +48,8 @@ class TransactionEvent < Events::BaseEvent
       updated_at: order.updated_at,
       last_offer: last_offer_details(order),
       shipping_country: order.shipping_country,
-      shipping_name: order.shipping_name
+      shipping_name: order.shipping_name,
+      shipping_region: order.shipping_region
     }
   end
 

--- a/spec/events/transaction_event_spec.rb
+++ b/spec/events/transaction_event_spec.rb
@@ -113,6 +113,7 @@ describe TransactionEvent, type: :events do
       expect(event.properties[:order][:last_offer][:amount_cents]).to eq 100000
       expect(event.properties[:order][:shipping_country]).to eq 'US'
       expect(event.properties[:order][:shipping_name]).to eq 'Fname Lname'
+      expect(event.properties[:order][:shipping_region]).to eq 'IL'
       expect(event.properties[:failure_code]).to eq 'stolen_card'
       expect(event.properties[:failure_message]).to eq 'who stole it?'
       expect(event.properties[:status]).to eq Transaction::FAILURE


### PR DESCRIPTION
# Problem
Looking at APR events, we don't see shipping region for any of our failed transaction events.

# Cause
`shipping_region` was not in list of order fields exposed in `TransactionEvent`.

# Solution
Add it.