### PR TITLE
Ensure user can retry SCA after canceling

### DIFF
--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -56,7 +56,7 @@ module PaymentService
 
   def self.confirm_payment_intent(payment_intent_id)
     payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
-    return payment_intent_transaction_failure(payment_intent) if payment_intent.status != 'requires_confirmation'
+    return payment_intent_confirmation_failure(payment_intent) if payment_intent.status != 'requires_confirmation'
 
     payment_intent.confirm
     Transaction.new(
@@ -174,7 +174,7 @@ module PaymentService
     )
   end
 
-  def self.payment_intent_transaction_failure(payment_intent)
+  def self.payment_intent_confirmation_failure(payment_intent)
     Transaction.new(
       external_id: payment_intent.id,
       external_type: Transaction::PAYMENT_INTENT,

--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -298,7 +298,7 @@ describe PaymentService, type: :services do
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
         transaction_type: Transaction::CONFIRM,
-        status: Transaction::FAILURE,
+        status: Transaction::REQUIRES_ACTION,
         failure_code: 'cannot_confirm'
       )
     end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -33,8 +33,8 @@ RSpec.shared_context 'include stripe helper' do
     mock_payment_intent_call(:create, payment_intent)
   end
 
-  def prepare_payment_intent_confirm_failure(charge_error:, payment_method: 'cc_1', amount: 20_00)
-    payment_intent = double(id: 'pi_1', payment_method: payment_method, amount: amount, capture_method: 'manual', status: 'requires_confirmation', transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
+  def prepare_payment_intent_confirm_failure(id: 'pi_1', charge_error:, payment_method: 'cc_1', amount: 20_00, status: 'requires_confirmation')
+    payment_intent = double(id: id, payment_method: payment_method, amount: amount, capture_method: 'manual', status: status, transfer_data: double(destination: 'ma_1'), last_payment_error: double(charge_error))
     error = Stripe::CardError.new(charge_error[:message], charge_error[:decline_code], charge_error[:code])
     allow(payment_intent).to receive(:confirm).and_raise(error)
     allow(error).to receive(:json_body).and_return(error: { payment_intent: basic_payment_intent(status: 'requires_payment_method', capture: true, amount: amount, code: charge_error[:code], decline_code: charge_error[:decline_code]) })


### PR DESCRIPTION
Fixes [PURCHASE-1663](https://artsyproduct.atlassian.net/browse/PURCHASE-1663)

There was an edge-case in the SCA flow that when we tried to confirm the payment intent we'd always error if the intent wasn't in the `requires_confirmation` state. If a user canceled the SCA dialog or came back later to complete their purchase then the confirmation process would happen but with a `requires_action` intent state which would trigger a failure. Essentially it made it where once a user canceled SCA they could never complete their purchase unless they updated their payment information. 

Now during the  confirmation process, if the intent is  in the `requires_action` state  it retriggers the payment intent flow and will reinvoke the SCA process. 