### PR TITLE
Fix issue with unhandled Stripe error during accept offer

### DIFF
--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -288,6 +288,18 @@ describe PaymentService, type: :services do
       )
       expect(transaction.payload).not_to be_nil
     end
+
+    it 'returns failed transaction if payment_intent cannot be created (restricted partner account)' do
+      prepare_payment_intent_create_failure(status: 'testmode_charges_only', capture: true, charge_error: { code: 'testmode_charges_only', decline_code: 'testmode_charges_only', message: 'Connected account is not setup.' })
+      transaction = PaymentService.capture_without_hold(params)
+      expect(transaction).to have_attributes(
+        external_id: 'pi_1',
+        external_type: Transaction::PAYMENT_INTENT,
+        transaction_type: Transaction::CAPTURE,
+        status: Transaction::FAILURE,
+        failure_code: 'testmode_charges_only'
+      )
+    end
   end
 
   describe '#confirm_payment_intent' do


### PR DESCRIPTION
# Problem

When partner's connected account wasn't fully setup, aka. restricted mode. Even when user's card was setup for `off-session` use, the actual `payment_intent` creation failed when partner tried to accept the offer. This failed not because of require action issue and because of that it was not fully reverted. So even if order was not processed, it stayed in `approved` state.

Sample order: https://exchange.artsy.net/admin/orders/99655d85-338d-4e11-ac0f-f97ed83a2d7a
Sample missing charge in our data: https://dashboard.stripe.com/payments/pi_1FImTcGK3Gnpfa3O5TiZRBch
# Cause
We were not handling generic Stripe errors for accepting offer, we handled those for BN order submission https://github.com/artsy/exchange/pull/512 but we did not do the same for accept offer.

# Solution
Following the same pattern as https://github.com/artsy/exchange/pull/512, making sure that payment service returns a failed transaction when payment intent creation fails. And then in `offer_service.accept_offer` make sure we handle this case properly and we do `revert!` in all failed cases with a generic rescue block.