### PR TITLE
[PURCHASE-1656] Adds phone number to set_shipping mutation pickup mode

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -24,7 +24,7 @@ module OrderService
 
     order_shipping = OrderShipping.new(order)
     case fulfillment_type
-    when Order::PICKUP then order_shipping.pickup!
+    when Order::PICKUP then order_shipping.pickup!(shipping)
     when Order::SHIP then order_shipping.ship!(shipping)
     end
     order

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -24,7 +24,7 @@ module OrderService
 
     order_shipping = OrderShipping.new(order)
     case fulfillment_type
-    when Order::PICKUP then order_shipping.pickup!(shipping)
+    when Order::PICKUP then order_shipping.pickup!(shipping&.dig(:phone_number))
     when Order::SHIP then order_shipping.ship!(shipping)
     end
     order

--- a/lib/order_shipping.rb
+++ b/lib/order_shipping.rb
@@ -3,11 +3,11 @@ class OrderShipping
     @order = order
   end
 
-  def pickup!
+  def pickup!(shipping_info)
     @order.with_lock do
       @order.update!(
         fulfillment_type: Order::PICKUP,
-        buyer_phone_number: nil,
+        buyer_phone_number: shipping_info[:phone_number],
         shipping_name: nil,
         shipping_address_line1: nil,
         shipping_address_line2: nil,

--- a/lib/order_shipping.rb
+++ b/lib/order_shipping.rb
@@ -3,11 +3,11 @@ class OrderShipping
     @order = order
   end
 
-  def pickup!(shipping_info)
+  def pickup!(buyer_phone_number)
     @order.with_lock do
       @order.update!(
         fulfillment_type: Order::PICKUP,
-        buyer_phone_number: shipping_info[:phone_number],
+        buyer_phone_number: buyer_phone_number,
         shipping_name: nil,
         shipping_address_line1: nil,
         shipping_address_line2: nil,

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -141,6 +141,12 @@ describe Api::GraphqlController, type: :request do
           expect(@response.data.set_shipping.order_or_error.order.shipping_total_cents).to eq 0
           expect(order.reload.shipping_total_cents).to eq 0
         end
+        context 'when phone number is passed' do
+          let(:shipping_address) { { phoneNumber: phone_number } }
+          it 'adds the buyer phone number' do
+            expect(order.reload.buyer_phone_number).to eq '00123456789'
+          end
+        end
       end
       context 'Ship Order' do
         before do

--- a/spec/lib/order_shipping_spec.rb
+++ b/spec/lib/order_shipping_spec.rb
@@ -7,6 +7,12 @@ describe OrderShipping, type: :services do
   let(:artwork_id) { 'artwork-id' }
   let(:order) { Fabricate(:order, buyer_id: buyer_id, buyer_type: Order::USER, seller_id: seller_id, seller_type: 'gallery') }
   let(:line_item) { Fabricate(:line_item, order: order, list_price_cents: 500, quantity: 2, artwork_id: artwork_id) }
+  let(:buyer_phone_number) { '8005882300' }
+  let(:shipping_info) do
+    {
+      phone_number: buyer_phone_number
+    }
+  end
   let(:order_shipping) { OrderShipping.new(order) }
   before do
     line_item
@@ -18,10 +24,13 @@ describe OrderShipping, type: :services do
     context 'Buy Order' do
       before do
         allow_any_instance_of(Tax::CalculatorService).to receive_messages(sales_tax: 100, artsy_should_remit_taxes?: false)
-        order_shipping.pickup!
+        order_shipping.pickup!(shipping_info)
       end
       it 'sets pickup fulfillment type' do
         expect(order.fulfillment_type).to eq Order::PICKUP
+      end
+      it 'sets buyer phone number' do
+        expect(order.buyer_phone_number).to eq buyer_phone_number
       end
       it 'sets shipping to 0' do
         expect(order.shipping_total_cents).to eq 0

--- a/spec/lib/order_shipping_spec.rb
+++ b/spec/lib/order_shipping_spec.rb
@@ -8,11 +8,6 @@ describe OrderShipping, type: :services do
   let(:order) { Fabricate(:order, buyer_id: buyer_id, buyer_type: Order::USER, seller_id: seller_id, seller_type: 'gallery') }
   let(:line_item) { Fabricate(:line_item, order: order, list_price_cents: 500, quantity: 2, artwork_id: artwork_id) }
   let(:buyer_phone_number) { '8005882300' }
-  let(:shipping_info) do
-    {
-      phone_number: buyer_phone_number
-    }
-  end
   let(:order_shipping) { OrderShipping.new(order) }
   before do
     line_item
@@ -24,7 +19,7 @@ describe OrderShipping, type: :services do
     context 'Buy Order' do
       before do
         allow_any_instance_of(Tax::CalculatorService).to receive_messages(sales_tax: 100, artsy_should_remit_taxes?: false)
-        order_shipping.pickup!(shipping_info)
+        order_shipping.pickup!(buyer_phone_number)
       end
       it 'sets pickup fulfillment type' do
         expect(order.fulfillment_type).to eq Order::PICKUP


### PR DESCRIPTION
`setShippng` mutation when `fulfillment_type` is `PICKUP` now processes and saves phone number under order object as `buyer_phone_number`

Fixes [PURCHASE-1656](https://artsyproduct.atlassian.net/browse/PURCHASE-1656)