### PR TITLE
Refactor PaymentService by making it a class and initiate with Order

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 11
 
 Metrics/ClassLength:
-  Max: 130
+  Max: 190
 
 Metrics/AbcSize:
   Max: 61
@@ -33,7 +33,7 @@ Metrics/MethodLength:
     - "db/migrate/*"
 
 Metrics/ModuleLength:
-  Max: 180
+  Max: 130
   Exclude:
     - "spec/**/*"
 

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -75,9 +75,10 @@ module OrderService
   def self.approve!(order, user_id)
     raise Errors::ValidationError.new(:unsupported_payment_method, order.payment_method) unless order.payment_method == Order::CREDIT_CARD
 
+    payment_service = PaymentService.new(order)
     transaction = nil
     order.approve! do
-      transaction = PaymentService.capture_authorized_hold(order.external_charge_id)
+      transaction = payment_service.capture_hold
       raise Errors::ProcessingError.new(:capture_failed, transaction.failure_data) if transaction.failed?
     end
 

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -30,7 +30,7 @@ class PaymentService
     )
     update_transaction_with_payment_intent(new_transaction, payment_intent)
     new_transaction
-  rescue Stripe::CardError => e
+  rescue Stripe::StripeError => e
     transaction_from_payment_intent_failure(e, transaction_type: Transaction::CAPTURE)
   end
 
@@ -61,7 +61,7 @@ class PaymentService
       source_id: payment_intent.payment_method,
       payload: payment_intent.to_h
     )
-  rescue Stripe::CardError, Stripe::StripeError => e
+  rescue Stripe::StripeError => e
     transaction_from_payment_intent_failure(e)
   end
 
@@ -99,7 +99,7 @@ class PaymentService
     )
     update_transaction_with_payment_intent(new_transaction, payment_intent)
     new_transaction
-  rescue Stripe::CardError, Stripe::StripeError => e
+  rescue Stripe::StripeError => e
     transaction_from_payment_intent_failure(e, transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD)
   end
 

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -1,14 +1,21 @@
-module PaymentService
-  def self.hold_payment(payment_params)
-    create_payment_intent(payment_params.merge(capture: false))
+class PaymentService
+  attr_reader :order
+
+  def initialize(order)
+    @order = order
+    @payment_intent_id = order.external_charge_id
   end
 
-  def self.capture_without_hold(payment_params)
-    create_payment_intent(payment_params.merge(capture: true))
+  def hold
+    create_payment_intent(capture: false)
   end
 
-  def self.capture_authorized_hold(payment_intent_id)
-    payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
+  def immediate_capture(off_session:)
+    create_payment_intent(capture: true, off_session: off_session)
+  end
+
+  def capture_hold
+    payment_intent = Stripe::PaymentIntent.retrieve(@payment_intent_id)
     raise Errors::ProcessingError, :cannot_capture unless payment_intent.status == 'requires_capture'
 
     payment_intent.capture
@@ -27,35 +34,21 @@ module PaymentService
     transaction_from_payment_intent_failure(e, transaction_type: Transaction::CAPTURE)
   end
 
-  def self.refund(external_id, external_type)
-    external_type == Transaction::PAYMENT_INTENT ? refund_payment(external_id) : refund_charge(external_id)
+  def refund
+    payment_transaction = @order.transactions.where(external_id: @order.external_charge_id).first
+    payment_transaction.external_type == Transaction::PAYMENT_INTENT ? refund_payment(payment_transaction.external_id) : refund_charge(payment_transaction.external_id)
   end
 
-  def self.cancel_payment_intent(payment_intent_id)
-    payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
+  def cancel_payment_intent
+    payment_intent = Stripe::PaymentIntent.retrieve(@payment_intent_id)
     payment_intent.cancel
-    Transaction.new(external_id: payment_intent_id, external_type: Transaction::PAYMENT_INTENT, transaction_type: Transaction::CANCEL, status: Transaction::SUCCESS, payload: payment_intent.to_h)
+    Transaction.new(external_id: @payment_intent_id, external_type: Transaction::PAYMENT_INTENT, transaction_type: Transaction::CANCEL, status: Transaction::SUCCESS, payload: payment_intent.to_h)
   rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::CANCEL, external_id: payment_intent_id, external_type: Transaction::PAYMENT_INTENT)
+    generate_transaction_from_exception(e, Transaction::CANCEL, external_id: @payment_intent_id, external_type: Transaction::PAYMENT_INTENT)
   end
 
-  def self.refund_charge(charge_id)
-    refund = Stripe::Refund.create(charge: charge_id, reverse_transfer: true)
-    Transaction.new(external_id: refund.id, external_type: Transaction::REFUND, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: refund.charge)
-  rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::REFUND, external_id: charge_id, external_type: Transaction::CHARGE)
-  end
-
-  def self.refund_payment(external_id)
-    payment_intent = Stripe::PaymentIntent.retrieve(external_id)
-    refund = Stripe::Refund.create(charge: payment_intent.charges.first.id, reverse_transfer: true)
-    Transaction.new(external_id: refund.id, external_type: Transaction::REFUND, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: refund.to_h)
-  rescue Stripe::StripeError => e
-    generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id, external_type: Transaction::PAYMENT_INTENT)
-  end
-
-  def self.confirm_payment_intent(payment_intent_id)
-    payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
+  def confirm_payment_intent
+    payment_intent = Stripe::PaymentIntent.retrieve(@payment_intent_id)
     return payment_intent_confirmation_failure(payment_intent) if payment_intent.status != 'requires_confirmation'
 
     payment_intent.confirm
@@ -68,14 +61,29 @@ module PaymentService
       source_id: payment_intent.payment_method,
       payload: payment_intent.to_h
     )
-  rescue Stripe::CardError => e
-    transaction_from_payment_intent_failure(e)
-  rescue Stripe::StripeError => e
+  rescue Stripe::CardError, Stripe::StripeError => e
     transaction_from_payment_intent_failure(e)
   end
 
-  def self.create_payment_intent(credit_card:, buyer_amount:, seller_amount:, merchant_account:, currency_code:, description:, metadata: {}, capture:, shipping_address: nil, shipping_name: nil, off_session: false)
-    payment_intent_params = create_payment_intent_params(credit_card, buyer_amount, seller_amount, merchant_account, currency_code, description, metadata, capture, shipping_address, shipping_name, off_session)
+  private
+
+  def refund_charge(charge_id)
+    refund = Stripe::Refund.create(charge: charge_id, reverse_transfer: true)
+    Transaction.new(external_id: refund.id, external_type: Transaction::REFUND, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: refund.charge)
+  rescue Stripe::StripeError => e
+    generate_transaction_from_exception(e, Transaction::REFUND, external_id: charge_id, external_type: Transaction::CHARGE)
+  end
+
+  def refund_payment(external_id)
+    payment_intent = Stripe::PaymentIntent.retrieve(external_id)
+    refund = Stripe::Refund.create(charge: payment_intent.charges.first.id, reverse_transfer: true)
+    Transaction.new(external_id: refund.id, external_type: Transaction::REFUND, transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: refund.to_h)
+  rescue Stripe::StripeError => e
+    generate_transaction_from_exception(e, Transaction::REFUND, external_id: external_id, external_type: Transaction::PAYMENT_INTENT)
+  end
+
+  def create_payment_intent(capture:, off_session: false)
+    payment_intent_params = create_payment_intent_params(capture: capture, off_session: off_session)
     payment_intent_params.merge!(setup_future_usage: 'off_session') unless off_session
 
     payment_intent = Stripe::PaymentIntent.create(payment_intent_params)
@@ -84,31 +92,30 @@ module PaymentService
       external_id: payment_intent.id,
       external_type: Transaction::PAYMENT_INTENT,
       source_id: payment_intent.payment_method,
-      destination_id: merchant_account[:external_id],
+      destination_id: order.merchant_account[:external_id],
       amount_cents: payment_intent.amount,
       transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD,
       payload: payment_intent.to_h
     )
     update_transaction_with_payment_intent(new_transaction, payment_intent)
     new_transaction
-  rescue Stripe::CardError => e
-    transaction_from_payment_intent_failure(e, transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD)
-  rescue Stripe::StripeError => e
+  rescue Stripe::CardError, Stripe::StripeError => e
     transaction_from_payment_intent_failure(e, transaction_type: capture ? Transaction::CAPTURE : Transaction::HOLD)
   end
 
-  def self.create_payment_intent_params(credit_card, buyer_amount, seller_amount, merchant_account, currency_code, description, metadata, capture, shipping_address, shipping_name, off_session)
+  def create_payment_intent_params(capture:, off_session:)
     {
-      amount: buyer_amount,
-      currency: currency_code,
+      amount: order.buyer_total_cents,
+      currency: order.currency_code,
       description: description,
       payment_method_types: ['card'],
-      payment_method: credit_card[:external_id],
-      customer: credit_card[:customer_account][:external_id],
-      on_behalf_of: merchant_account[:external_id],
+      payment_method: order.credit_card[:external_id],
+      customer: order.credit_card[:customer_account][:external_id],
+      on_behalf_of: order.merchant_account[:external_id],
       transfer_data: {
-        destination: merchant_account[:external_id],
-        amount: seller_amount
+        destination: order.merchant_account[:external_id],
+        amount: order.seller_total_cents,
+        transfer_group: order.id
       },
       off_session: off_session,
       metadata: metadata,
@@ -117,19 +124,38 @@ module PaymentService
       confirmation_method: 'manual', # if requires action, we will confirm manually after
       shipping: {
         address: {
-          line1: shipping_address&.street_line1,
-          line2: shipping_address&.street_line2,
-          city: shipping_address&.city,
-          state: shipping_address&.region,
-          postal_code: shipping_address&.postal_code,
-          country: shipping_address&.country
+          line1: order.shipping_address&.street_line1,
+          line2: order.shipping_address&.street_line2,
+          city: order.shipping_address&.city,
+          state: order.shipping_address&.region,
+          postal_code: order.shipping_address&.postal_code,
+          country: order.shipping_address&.country
         },
-        name: shipping_name
+        name: order.shipping_name
       }
     }
   end
 
-  def self.update_transaction_with_payment_intent(transaction, payment_intent)
+  def metadata
+    {
+      exchange_order_id: @order.id,
+      buyer_id: @order.buyer_id,
+      buyer_type: @order.buyer_type,
+      seller_id: @order.seller_id,
+      seller_type: @order.seller_type,
+      type: @order.auction_seller? ? 'auction-bn' : 'bn-mo',
+      mode: @order.mode,
+      artist_ids: @order.artists.map { |a| a[:_id] }.join(','),
+      artist_names: @order.artists.map { |a| a[:name] }.join(',')
+    }
+  end
+
+  def description
+    partner_name = (@order.partner[:name] || '').parameterize[0...12].upcase
+    "#{partner_name} via Artsy"
+  end
+
+  def update_transaction_with_payment_intent(transaction, payment_intent)
     case payment_intent.status # https://stripe.com/docs/payments/intents#intent-statuses
     when 'requires_capture'
       transaction.status = Transaction::REQUIRES_CAPTURE
@@ -143,7 +169,7 @@ module PaymentService
     end
   end
 
-  def self.generate_transaction_from_exception(exc, type, external_id: nil, external_type:)
+  def generate_transaction_from_exception(exc, type, external_id: nil, external_type:)
     body = exc.json_body[:error]
     Transaction.new(
       external_id: external_id || body[:charge],
@@ -157,7 +183,7 @@ module PaymentService
     )
   end
 
-  def self.transaction_from_payment_intent_failure(exc, transaction_type: nil)
+  def transaction_from_payment_intent_failure(exc, transaction_type: nil)
     body = exc.json_body
     pi = body[:error][:payment_intent]
     # attempting confirm failed
@@ -176,7 +202,7 @@ module PaymentService
     )
   end
 
-  def self.payment_intent_confirmation_failure(payment_intent)
+  def payment_intent_confirmation_failure(payment_intent)
     Transaction.new(
       external_id: payment_intent.id,
       external_type: Transaction::PAYMENT_INTENT,

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -355,32 +355,12 @@ describe OrderProcessor, type: :services do
       end
     end
     it 'sets off_session to false by default' do
-      expect(PaymentService).to receive(:capture_without_hold).with(hash_including(off_session: false))
+      expect_any_instance_of(PaymentService).to receive(:immediate_capture).with(hash_including(off_session: false))
       order_processor.charge
     end
     it 'overrides off_session when passed to method' do
-      expect(PaymentService).to receive(:capture_without_hold).with(hash_including(off_session: true))
+      expect_any_instance_of(PaymentService).to receive(:immediate_capture).with(hash_including(off_session: true))
       order_processor.charge(true)
-    end
-  end
-
-  describe '#charge_metadata' do
-    before do
-      stub_artwork_request
-    end
-    it 'includes all expected metadata' do
-      metadata = order_processor.send(:charge_metadata)
-      expect(metadata).to match(
-        exchange_order_id: order.id,
-        buyer_id: 'buyer1',
-        buyer_type: 'user',
-        seller_id: 'seller1',
-        seller_type: 'gallery',
-        type: 'bn-mo',
-        mode: 'buy',
-        artist_ids: 'artist-id',
-        artist_names: 'BNMOsy'
-      )
     end
   end
 end

--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -3,152 +3,91 @@ require 'support/gravity_helper'
 
 describe PaymentService, type: :services do
   include_context 'include stripe helper'
-
-  let(:currency_code) { 'usd' }
-  let(:buyer_amount) { 20_00 }
-  let(:seller_amount) { 10_00 }
+  let(:order) do
+    Fabricate(
+      :order,
+      buyer_total_cents: 20_00,
+      seller_total_cents: 10_00,
+      currency_code: 'usd',
+      external_charge_id: 'pi_1',
+      shipping_address_line1: '123 nowhere st',
+      shipping_address_line2: 'apt 321',
+      shipping_postal_code: '312',
+      shipping_city: 'ny',
+      shipping_country: 'US',
+      shipping_region: 'NY',
+      shipping_name: 'Homer',
+      fulfillment_type: Order::SHIP
+    )
+  end
+  let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'artwork-1')] }
   let(:credit_card) { { external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
   let(:merchant_account) { { external_id: 'ma-1' } }
-  let(:params) do
+
+  let(:service) { PaymentService.new(order) }
+
+  let(:stripe_call_params) do
     {
-      buyer_amount: buyer_amount,
-      credit_card: credit_card,
-      currency_code: currency_code,
-      description: 'Gallery via Artsy',
-      merchant_account: merchant_account,
-      metadata: { this: 'is', a: 'test' },
-      seller_amount: seller_amount
+      amount: 20_00,
+      currency: 'USD',
+      description: 'INVOICING-DE via Artsy',
+      payment_method_types: ['card'],
+      payment_method: 'cc_1',
+      customer: 'ca_1',
+      on_behalf_of: 'ma-1',
+      transfer_data: {
+        destination: 'ma-1',
+        amount: 10_00,
+        transfer_group: order.id
+      },
+      off_session: false,
+      metadata: {
+        artist_ids: 'artist-id',
+        artist_names: 'BNMOsy',
+        buyer_id: order.buyer_id,
+        buyer_type: 'user',
+        exchange_order_id: order.id,
+        mode: order.mode,
+        seller_id: order.seller_id,
+        seller_type: 'gallery',
+        type: 'bn-mo'
+      },
+      capture_method: 'manual',
+      confirm: true,
+      setup_future_usage: 'off_session',
+      confirmation_method: 'manual',
+      shipping: {
+        address: {
+          line1: '123 nowhere st',
+          line2: 'apt 321',
+          city: 'ny',
+          state: 'NY',
+          postal_code: '312',
+          country: 'US'
+        },
+        name: 'Homer'
+      }
     }
   end
 
-  let(:params_with_shipping) do
-    params.merge(
-      shipping_address: Address.new(address_line1: '123 nowhere st', address_line2: 'apt 321', postal_code: '312', city: 'ny', country: 'US', region: 'NY'),
-      shipping_name: 'Homer'
+  before do
+    allow(Gravity).to receive_messages(
+      fetch_partner: gravity_v1_partner,
+      get_merchant_account: merchant_account,
+      get_credit_card: credit_card,
+      get_artwork: gravity_v1_artwork
     )
   end
 
-  let(:off_session_payment_params) do
-    params_with_shipping.merge(
-      off_session: true,
-      capture: false
-    )
-  end
-
-  let(:on_session_payment_params) do
-    params_with_shipping.merge(
-      off_session: false,
-      capture: false
-    )
-  end
-
-  describe '#create_payment_intent' do
-    it 'creates a payment intent without setup_future_usage for off-session payments' do
-      expect(Stripe::PaymentIntent).to receive(:create).with(
-        amount: buyer_amount,
-        currency: currency_code,
-        description: 'Gallery via Artsy',
-        payment_method_types: ['card'],
-        payment_method: 'cc_1',
-        customer: 'ca_1',
-        on_behalf_of: 'ma-1',
-        transfer_data: {
-          destination: 'ma-1',
-          amount: seller_amount
-        },
-        off_session: true,
-        metadata: { this: 'is', a: 'test' },
-        capture_method: 'manual',
-        confirm: true,
-        confirmation_method: 'manual',
-        shipping: {
-          address: {
-            line1: '123 nowhere st',
-            line2: 'apt 321',
-            city: 'ny',
-            state: 'NY',
-            postal_code: '312',
-            country: 'US'
-          },
-          name: 'Homer'
-        }
-      ).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
-      PaymentService.create_payment_intent(off_session_payment_params)
-    end
-
-    it 'creates a payment intent with setup_future_usage: true for on-session payments' do
-      expect(Stripe::PaymentIntent).to receive(:create).with(
-        amount: buyer_amount,
-        currency: currency_code,
-        description: 'Gallery via Artsy',
-        payment_method_types: ['card'],
-        payment_method: 'cc_1',
-        customer: 'ca_1',
-        on_behalf_of: 'ma-1',
-        transfer_data: {
-          destination: 'ma-1',
-          amount: seller_amount
-        },
-        off_session: false,
-        metadata: { this: 'is', a: 'test' },
-        capture_method: 'manual',
-        confirm: true,
-        setup_future_usage: 'off_session',
-        confirmation_method: 'manual',
-        shipping: {
-          address: {
-            line1: '123 nowhere st',
-            line2: 'apt 321',
-            city: 'ny',
-            state: 'NY',
-            postal_code: '312',
-            country: 'US'
-          },
-          name: 'Homer'
-        }
-      ).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
-      PaymentService.create_payment_intent(on_session_payment_params)
-    end
-  end
-
-  describe '#hold_payment' do
+  describe '#hold' do
     it 'calls stripe with expected values' do
-      expect(Stripe::PaymentIntent).to receive(:create).with(
-        amount: buyer_amount,
-        currency: currency_code,
-        description: 'Gallery via Artsy',
-        payment_method_types: ['card'],
-        payment_method: 'cc_1',
-        customer: 'ca_1',
-        on_behalf_of: 'ma-1',
-        transfer_data: {
-          destination: 'ma-1',
-          amount: seller_amount
-        },
-        off_session: false,
-        metadata: { this: 'is', a: 'test' },
-        capture_method: 'manual',
-        confirm: true,
-        setup_future_usage: 'off_session',
-        confirmation_method: 'manual',
-        shipping: {
-          address: {
-            line1: '123 nowhere st',
-            line2: 'apt 321',
-            city: 'ny',
-            state: 'NY',
-            postal_code: '312',
-            country: 'US'
-          },
-          name: 'Homer'
-        }
-      ).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
-      PaymentService.hold_payment(params_with_shipping)
+      expect(Stripe::PaymentIntent).to receive(:create).with(stripe_call_params).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
+      service.hold
     end
 
     it "authorizes a charge on the user's credit card" do
       prepare_payment_intent_create_success(amount: 20_00)
-      transaction = PaymentService.hold_payment(params)
+      transaction = service.hold
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -165,10 +104,10 @@ describe PaymentService, type: :services do
 
     it 'returns transaction for requires_action' do
       prepare_payment_intent_create_failure(status: 'requires_action')
-      transaction = PaymentService.hold_payment(params)
+      transaction = service.hold
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
-        amount_cents: buyer_amount,
+        amount_cents: 20_00,
         source_id: 'cc_1',
         destination_id: 'ma-1',
         failure_code: nil,
@@ -182,10 +121,10 @@ describe PaymentService, type: :services do
 
     it 'returns failed attempt transaction' do
       prepare_payment_intent_create_failure(status: 'requires_payment_method', capture: false, charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
-      transaction = PaymentService.hold_payment(params)
+      transaction = service.hold
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
-        amount_cents: buyer_amount,
+        amount_cents: 20_00,
         source_id: 'cc_1',
         destination_id: 'ma_1',
         failure_code: 'card_declined',
@@ -198,49 +137,20 @@ describe PaymentService, type: :services do
     end
   end
 
-  describe '#capture_without_hold' do
+  describe '#immediate_capture' do
     it 'calls stripe with expected values' do
-      expect(Stripe::PaymentIntent).to receive(:create).with(
-        amount: buyer_amount,
-        currency: currency_code,
-        description: 'Gallery via Artsy',
-        payment_method_types: ['card'],
-        payment_method: 'cc_1',
-        customer: 'ca_1',
-        on_behalf_of: 'ma-1',
-        transfer_data: {
-          destination: 'ma-1',
-          amount: seller_amount
-        },
-        off_session: false,
-        metadata: { this: 'is', a: 'test' },
-        capture_method: 'automatic',
-        confirm: true,
-        setup_future_usage: 'off_session',
-        confirmation_method: 'manual',
-        shipping: {
-          address: {
-            line1: '123 nowhere st',
-            line2: 'apt 321',
-            city: 'ny',
-            state: 'NY',
-            postal_code: '312',
-            country: 'US'
-          },
-          name: 'Homer'
-        }
-      ).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
-      PaymentService.capture_without_hold(params_with_shipping)
+      expect(Stripe::PaymentIntent).to receive(:create).with(stripe_call_params.merge(capture_method: 'automatic')).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
+      service.immediate_capture(off_session: false)
     end
 
     it 'overrides off_session when passed in' do
       expect(Stripe::PaymentIntent).to receive(:create).with(hash_including(off_session: true)).and_return(double(id: 'pi_1', payment_method: 'cc_1', amount: 123, status: 'requires_capture', to_h: {}))
-      PaymentService.capture_without_hold(params_with_shipping.merge(off_session: true))
+      service.immediate_capture(off_session: true)
     end
 
-    it "authorizes a charge on the user's credit card" do
+    it 'returns correct transaction' do
       prepare_payment_intent_create_success(amount: 20_00)
-      transaction = PaymentService.capture_without_hold(params)
+      transaction = service.immediate_capture(off_session: false)
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -257,10 +167,10 @@ describe PaymentService, type: :services do
 
     it 'returns transaction for requires_action' do
       prepare_payment_intent_create_failure(status: 'requires_action')
-      transaction = PaymentService.capture_without_hold(params)
+      transaction = service.immediate_capture(off_session: false)
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
-        amount_cents: buyer_amount,
+        amount_cents: 20_00,
         source_id: 'cc_1',
         destination_id: 'ma-1',
         failure_code: nil,
@@ -274,10 +184,10 @@ describe PaymentService, type: :services do
 
     it 'returns failed attempt transaction' do
       prepare_payment_intent_create_failure(status: 'requires_payment_method', capture: false, charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
-      transaction = PaymentService.capture_without_hold(params)
+      transaction = service.immediate_capture(off_session: false)
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
-        amount_cents: buyer_amount,
+        amount_cents: 20_00,
         source_id: 'cc_1',
         destination_id: 'ma_1',
         failure_code: 'card_declined',
@@ -291,7 +201,7 @@ describe PaymentService, type: :services do
 
     it 'returns failed transaction if payment_intent cannot be created (restricted partner account)' do
       prepare_payment_intent_create_failure(status: 'testmode_charges_only', capture: true, charge_error: { code: 'testmode_charges_only', decline_code: 'testmode_charges_only', message: 'Connected account is not setup.' })
-      transaction = PaymentService.capture_without_hold(params)
+      transaction = service.immediate_capture(off_session: false)
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -305,7 +215,7 @@ describe PaymentService, type: :services do
   describe '#confirm_payment_intent' do
     it 'returns failed transaction if payment_intent is not in expected state' do
       mock_retrieve_payment_intent(status: 'requires_action')
-      transaction = PaymentService.confirm_payment_intent('pi_1')
+      transaction = service.confirm_payment_intent
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -317,7 +227,7 @@ describe PaymentService, type: :services do
 
     it 'confirms the payment intent and stores transaction' do
       prepare_payment_intent_confirm_success
-      transaction = PaymentService.confirm_payment_intent('pi_1')
+      transaction = service.confirm_payment_intent
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -328,7 +238,7 @@ describe PaymentService, type: :services do
 
     it 'confirms the payment intent and stores failed transaction' do
       prepare_payment_intent_confirm_failure(charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
-      transaction = PaymentService.confirm_payment_intent('pi_1')
+      transaction = service.confirm_payment_intent
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -340,10 +250,10 @@ describe PaymentService, type: :services do
     end
   end
 
-  describe '#capture_authorized_hold' do
+  describe '#capture_hold' do
     it 'captures a payment_intent' do
       prepare_payment_intent_capture_success(amount: 20_00)
-      transaction = PaymentService.capture_authorized_hold('pi_1')
+      transaction = service.capture_hold
       expect(transaction).to have_attributes(
         external_type: Transaction::PAYMENT_INTENT,
         amount_cents: 20_00,
@@ -356,7 +266,7 @@ describe PaymentService, type: :services do
 
     it 'stores failures on transaction' do
       prepare_payment_intent_capture_failure(charge_error: { code: 'capture_charge', decline_code: 'do_not_honor', message: 'The card was declined' })
-      transaction = PaymentService.capture_authorized_hold('pi_1')
+      transaction = service.capture_hold
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -371,14 +281,17 @@ describe PaymentService, type: :services do
   end
 
   describe '#refund_payment' do
+    before do
+      Fabricate(:transaction, order: order, external_id: order.external_charge_id, external_type: Transaction::PAYMENT_INTENT)
+    end
     it 'refunds a charge for the full amount' do
       prepare_payment_intent_refund_success
-      transaction = PaymentService.refund_payment('pi_1')
+      transaction = service.refund
       expect(transaction).to have_attributes(external_id: 're_1', transaction_type: Transaction::REFUND, status: Transaction::SUCCESS, payload: { 'id' => 're_1' })
     end
     it 'catches Stripe errors and returns a failed transaction' do
       prepare_payment_intent_refund_failure(code: 'processing_error', message: 'The card was declined', decline_code: 'failed_refund')
-      transaction = PaymentService.refund_payment('pi_1')
+      transaction = service.refund
       expect(transaction).to have_attributes(
         external_id: 'pi_1',
         external_type: Transaction::PAYMENT_INTENT,
@@ -389,6 +302,23 @@ describe PaymentService, type: :services do
         status: Transaction::FAILURE
       )
       expect(transaction.payload).not_to be_nil
+    end
+  end
+
+  describe '#metadata' do
+    it 'includes all expected metadata' do
+      metadata = service.send(:metadata)
+      expect(metadata).to match(
+        exchange_order_id: order.id,
+        buyer_id: order.buyer_id,
+        buyer_type: 'user',
+        seller_id: order.seller_id,
+        seller_type: 'gallery',
+        type: 'bn-mo',
+        mode: 'buy',
+        artist_ids: 'artist-id',
+        artist_names: 'BNMOsy'
+      )
     end
   end
 end


### PR DESCRIPTION
# Problem
`PaymentService` used to get list of parameters as input to its methods. It provides method to our payment provider (Stripe) so the caller had to generate all those needed parameters based on the action.

This gets confusing since we have to pass those parameters between few methods and list of them was growing.

# Change
Make `PaymentService` a class instead of module and have it initiated using `Order`, this way payment service would be able to generate it's own parameters based on the order. Things like setting metadata and shipping info and etc.

# Extra
Added `transfer_group` to the passed params and set it to the `Order.id`. cc: @mdole 