### PR TITLE
Fix sending transfer_group in wrong spot

### DIFF
--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -115,9 +115,9 @@ class PaymentService
       on_behalf_of: order.merchant_account[:external_id],
       transfer_data: {
         destination: order.merchant_account[:external_id],
-        amount: order.seller_total_cents,
-        transfer_group: order.id
+        amount: order.seller_total_cents
       },
+      transfer_group: order.id,
       off_session: off_session,
       metadata: metadata,
       capture_method: capture ? 'automatic' : 'manual',

--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -37,9 +37,9 @@ describe PaymentService, type: :services do
       on_behalf_of: 'ma-1',
       transfer_data: {
         destination: 'ma-1',
-        amount: 10_00,
-        transfer_group: order.id
+        amount: 10_00
       },
+      transfer_group: order.id,
       off_session: false,
       metadata: {
         artist_ids: 'artist-id',


### PR DESCRIPTION
# Problem
Integrity tests started failing after #538 with errors like
https://dashboard.stripe.com/test/logs/req_yfs5btC5dBIW5A

# Cause
We added `transfer_group` as part of #538 but it was added in wrong place under `transfer_data` while it should have been added in root level based on 
https://stripe.com/docs/api/payment_intents/create#create_payment_intent-transfer_group 

# Props
To everyone involved in integrity tests