### PR TITLE
Fetch all partner locations from gravity

### DIFF
--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -37,7 +37,8 @@ module Gravity
     url = "/partner/#{partner_id}/locations"
     params = { private: true }
     params = params.merge(address_type: ['Business', 'Sales tax nexus']) if tax_only
-    locations = Adapters::GravityV1.get(url, params: params)
+    locations = Gravity.fetch_all(url, params)
+
     raise Errors::ValidationError.new(:missing_partner_location, partner_id: partner_id) if locations.blank?
 
     locations.map { |loc| Address.new(loc) }
@@ -76,5 +77,20 @@ module Gravity
   rescue Adapters::GravityError, StandardError => e
     Rails.logger.warn("Could not fetch user #{user_id} from gravity: #{e.message}")
     nil
+  end
+
+  def self.fetch_all(url, params)
+    items = []
+    page = 1
+    size = 10
+
+    loop do
+      params = params.merge(page: page, size: size)
+      new_items = Adapters::GravityV1.get(url, params: params)
+      items += new_items if new_items
+      page += 1
+      break if new_items.blank? || new_items.size < size
+    end
+    items
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -82,7 +82,7 @@ module Gravity
   def self.fetch_all(url, params)
     items = []
     page = 1
-    size = 10
+    size = 20
 
     loop do
       params = params.merge(page: page, size: size)

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -163,7 +163,7 @@ describe Api::GraphqlController, type: :request do
         context 'with no partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -175,7 +175,7 @@ describe Api::GraphqlController, type: :request do
         context 'with untaxable partner locations' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -188,7 +188,7 @@ describe Api::GraphqlController, type: :request do
           let(:shipping_country) { 'ASDF' }
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -201,7 +201,7 @@ describe Api::GraphqlController, type: :request do
         context 'with a US-based shipping address' do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -165,7 +165,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([])
           end
           it 'raises an error' do
             response = client.execute(mutation, set_shipping_input)
@@ -178,7 +178,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'FR' }])
           end
           it 'sets sales tax to 0 and should_remit_sales_tax to false on each line item' do
             client.execute(mutation, set_shipping_input)
@@ -195,7 +195,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'FR' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'FR' }])
           end
           it 'returns proper error' do
             response = client.execute(mutation, set_shipping_input)
@@ -209,7 +209,7 @@ describe Api::GraphqlController, type: :request do
           before do
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(artwork2)
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
           end
           let(:shipping_country) { 'US' }
           context 'without a state' do
@@ -237,7 +237,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with artwork with missing location' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
@@ -247,7 +247,7 @@ describe Api::GraphqlController, type: :request do
 
         context 'with failed artwork fetch call' do
           it 'returns an error' do
-            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
+            allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_raise(Adapters::GravityError.new('unknown artwork'))
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -29,7 +29,7 @@ describe Gravity, type: :services do
   describe '#fetch_partner_locations' do
     let(:valid_locations) { [{ country: 'US', state: 'NY', postal_code: '12345' }, { country: 'US', state: 'FL', postal_code: '67890' }] }
     let(:invalid_location) { [{ country: 'US', state: 'Floridada' }] }
-    let(:base_params) { { private: true, page: 1, size: 10 } }
+    let(:base_params) { { private: true, page: 1, size: 20 } }
     let(:tax_only_params) { base_params.merge(address_type: ['Business', 'Sales tax nexus']) }
 
     context 'calls the correct location Gravity endpoint' do
@@ -72,7 +72,7 @@ describe Gravity, type: :services do
     context 'with more than 10 partner locations' do
       it 'correctly returns all locations' do
         first_location_group = []
-        10.times.each { first_location_group << { country: 'US', state: 'FL', postal_code: '67890' } }
+        20.times.each { first_location_group << { country: 'US', state: 'FL', postal_code: '67890' } }
 
         second_location_group = []
         7.times.each { second_location_group << { country: 'US', state: 'MA', postal_code: '67890' } }
@@ -88,7 +88,7 @@ describe Gravity, type: :services do
         ).and_return(second_location_group)
 
         locations = Gravity.fetch_partner_locations(seller_id, tax_only: true)
-        expect(locations.length).to eq(17)
+        expect(locations.length).to eq(27)
       end
     end
   end
@@ -189,23 +189,23 @@ describe Gravity, type: :services do
 
   describe '#fetch_all' do
     it 'paginates until there are no more items' do
-      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 2, size: 10 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 3, size: 10 }).and_return([1, 2, 3])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 20 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 2, size: 20 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 3, size: 20 }).and_return([1, 2, 3])
 
       response = Gravity.fetch_all('/test', {})
-      expect(response.length).to eq 23
+      expect(response.length).to eq 43
     end
 
     it 'only makes one call if there are less than 10 items' do
-      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([1, 2, 3])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 20 }).and_return([1, 2, 3])
 
       response = Gravity.fetch_all('/test', {})
       expect(response.length).to eq 3
     end
 
     it 'returns no items' do
-      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 20 }).and_return([])
 
       response = Gravity.fetch_all('/test', {})
       expect(response.length).to eq 0

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -29,37 +29,66 @@ describe Gravity, type: :services do
   describe '#fetch_partner_locations' do
     let(:valid_locations) { [{ country: 'US', state: 'NY', postal_code: '12345' }, { country: 'US', state: 'FL', postal_code: '67890' }] }
     let(:invalid_location) { [{ country: 'US', state: 'Floridada' }] }
+    let(:base_params) { { private: true, page: 1, size: 10 } }
+    let(:tax_only_params) { base_params.merge(address_type: ['Business', 'Sales tax nexus']) }
+
     context 'calls the correct location Gravity endpoint' do
       context 'without tax_only flag' do
         it 'does not filter by address type' do
-          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true }).and_return(valid_locations)
+          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: base_params).and_return(valid_locations)
           Gravity.fetch_partner_locations(seller_id)
         end
       end
+
       context 'with tax_only flag' do
         it 'filters by address type' do
-          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { address_type: ['Business', 'Sales tax nexus'], private: true }).and_return(valid_locations)
+          expect(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: tax_only_params).and_return(valid_locations)
           Gravity.fetch_partner_locations(seller_id, tax_only: true)
         end
       end
     end
+
     context 'with at least one partner location' do
       context 'with valid partner locations' do
         it 'returns new addresses for each location' do
-          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { address_type: ['Business', 'Sales tax nexus'], private: true }).and_return(valid_locations)
+          allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: tax_only_params).and_return(valid_locations)
           partner_addresses = Gravity.fetch_partner_locations(seller_id, tax_only: true)
           partner_addresses.each { |ad| expect(ad).to be_a Address }
         end
       end
     end
+
     context 'with no partner locations' do
       it 'raises error' do
-        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true }).and_return([])
+        allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: base_params).and_return([])
         expect { Gravity.fetch_partner_locations(seller_id) }.to raise_error do |error|
           expect(error).to be_a Errors::ValidationError
           expect(error.code).to eq :missing_partner_location
           expect(error.data[:partner_id]).to eq seller_id
         end
+      end
+    end
+
+    context 'with more than 10 partner locations' do
+      it 'correctly returns all locations' do
+        first_location_group = []
+        10.times.each { first_location_group << { country: 'US', state: 'FL', postal_code: '67890' } }
+
+        second_location_group = []
+        7.times.each { second_location_group << { country: 'US', state: 'MA', postal_code: '67890' } }
+
+        allow(Adapters::GravityV1).to receive(:get).with(
+          "/partner/#{seller_id}/locations",
+          params: tax_only_params
+        ).and_return(first_location_group)
+
+        allow(Adapters::GravityV1).to receive(:get).with(
+          "/partner/#{seller_id}/locations",
+          params: tax_only_params.merge(page: 2)
+        ).and_return(second_location_group)
+
+        locations = Gravity.fetch_partner_locations(seller_id, tax_only: true)
+        expect(locations.length).to eq(17)
       end
     end
   end
@@ -155,6 +184,31 @@ describe Gravity, type: :services do
         expect(Adapters::GravityV1).to receive(:get).and_raise(Adapters::GravityError, 'timeout')
         expect(Gravity.get_user(user_id)).to be_nil
       end
+    end
+  end
+
+  describe '#fetch_all' do
+    it 'paginates until there are no more items' do
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 2, size: 10 }).and_return([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 3, size: 10 }).and_return([1, 2, 3])
+
+      response = Gravity.fetch_all('/test', {})
+      expect(response.length).to eq 23
+    end
+
+    it 'only makes one call if there are less than 10 items' do
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([1, 2, 3])
+
+      response = Gravity.fetch_all('/test', {})
+      expect(response.length).to eq 3
+    end
+
+    it 'returns no items' do
+      allow(Adapters::GravityV1).to receive(:get).with('/test', params: { page: 1, size: 10 }).and_return([])
+
+      response = Gravity.fetch_all('/test', {})
+      expect(response.length).to eq 0
     end
   end
 end

--- a/spec/lib/order_shipping_spec.rb
+++ b/spec/lib/order_shipping_spec.rb
@@ -12,7 +12,7 @@ describe OrderShipping, type: :services do
   before do
     line_item
     allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/all").and_return(gravity_v1_partner)
-    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'] }).and_return([{ country: 'US', state: 'NY' }])
+    allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], size: 20, page: 1 }).and_return([{ country: 'US', state: 'NY' }])
     allow(Adapters::GravityV1).to receive(:get).with("/artwork/#{artwork_id}").and_return(gravity_v1_artwork(_id: artwork_id))
   end
   describe '#pickup!' do


### PR DESCRIPTION
We found that, because we're only fetching 10 partner locations from gravity, we weren't correctly calculating tax for partners that have > 10 tax nexuses.