### PR TITLE
Repeat of incident 73 but now on exchange

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'money' # Library for dealing with money and currency conversion
 gem 'omniauth-artsy', '~> 0.2.3'
 gem 'paper_trail'
 gem 'sentry-raven'
-gem 'sidekiq'
+gem 'sidekiq', '<6' # for sending emails in the background (<6 necessary for Redis 3 compatibility)
 gem 'stripe'
 gem 'taxjar-ruby', require: 'taxjar'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,11 +303,11 @@ GEM
       i18n
       polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.6.0)
-    request_store (1.4.1)
+    request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -355,11 +355,11 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
-    sidekiq (6.0.3)
-      connection_pool (>= 2.2.2)
-      rack (>= 2.0.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -440,7 +440,7 @@ DEPENDENCIES
   rubocop
   selenium-webdriver
   sentry-raven
-  sidekiq
+  sidekiq (< 6)
   stripe
   stripe-ruby-mock (~> 2.5.8)
   taxjar-ruby


### PR DESCRIPTION
# Problem
we got reports about collectors not receiving emails when orders are approved.

Sidekiq pods were not working of the queue:
```shell
You are connecting to Redis v3.2.4, Sidekiq requires Redis v4.0.0 or greater
```

# Cause
Exact same thing as https://github.com/artsy/convection/pull/369

# Solution
Downgrade Sidekiq
