### PR TITLE
Return phoneNumber in graphQL response for CommercePickup order

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1078,6 +1078,7 @@ type Partner {
 
 type Pickup {
   fulfillmentType: String!
+  phoneNumber: String
 }
 
 type Query {
@@ -1319,6 +1320,7 @@ input SetShippingInput {
   clientMutationId: String
   fulfillmentType: OrderFulfillmentTypeEnum!
   id: ID!
+  phoneNumber: String
   shipping: ShippingAttributes
 }
 
@@ -1357,7 +1359,7 @@ input ShippingAttributes {
   city: String
   country: String
   name: String
-  phoneNumber: String!
+  phoneNumber: String
   postalCode: String
   region: String
 }

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -34,6 +34,7 @@ module Errors
       missing_region
       missing_required_info
       missing_required_param
+      missing_phone_number
       no_taxable_addresses
       not_acquireable
       not_found

--- a/app/graphql/inputs/shipping_attributes.rb
+++ b/app/graphql/inputs/shipping_attributes.rb
@@ -9,5 +9,5 @@ class Inputs::ShippingAttributes < Types::BaseInputObject
   argument :region, String, required: false
   argument :country, String, required: false
   argument :postal_code, String, required: false
-  argument :phone_number, String, required: true
+  argument :phone_number, String, required: false
 end

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -11,7 +11,8 @@ class Mutations::SetShipping < Mutations::BaseMutation
   def resolve(id:, fulfillment_type:, shipping: {}, phone_number: nil)
     order = Order.find(id)
     authorize_buyer_request!(order)
-    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || shipping&.to_h[:phone_number])
+    # byebug
+    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || (shipping ? (shipping&.to_h[:phone_number]) : nil))
     {
       order_or_error: { order: order }
     }

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -8,11 +8,11 @@ class Mutations::SetShipping < Mutations::BaseMutation
 
   field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
-  def resolve(id:, fulfillment_type:, shipping: {}, phone_number: nil)
+  def resolve(id:, fulfillment_type:, shipping: nil, phone_number: nil)
     order = Order.find(id)
     authorize_buyer_request!(order)
-    # byebug
-    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || (shipping ? (shipping&.to_h[:phone_number]) : nil))
+
+    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || shipping&.phone_number)
     {
       order_or_error: { order: order }
     }

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -4,13 +4,14 @@ class Mutations::SetShipping < Mutations::BaseMutation
   argument :id, ID, required: true
   argument :fulfillment_type, Types::OrderFulfillmentTypeEnum, required: true
   argument :shipping, Inputs::ShippingAttributes, required: false
+  argument :phone_number, String, required: false
 
   field :order_or_error, Mutations::OrderOrFailureUnionType, 'A union of success/failure', null: false
 
-  def resolve(id:, fulfillment_type:, shipping: {})
+  def resolve(id:, fulfillment_type:, shipping: {}, phone_number: nil)
     order = Order.find(id)
     authorize_buyer_request!(order)
-    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping)
+    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || shipping&.to_h.fetch(:phone_number))
     {
       order_or_error: { order: order }
     }

--- a/app/graphql/mutations/set_shipping.rb
+++ b/app/graphql/mutations/set_shipping.rb
@@ -11,7 +11,7 @@ class Mutations::SetShipping < Mutations::BaseMutation
   def resolve(id:, fulfillment_type:, shipping: {}, phone_number: nil)
     order = Order.find(id)
     authorize_buyer_request!(order)
-    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || shipping&.to_h.fetch(:phone_number))
+    OrderService.set_shipping!(order, fulfillment_type: fulfillment_type, shipping: shipping, phone_number: phone_number || shipping&.to_h[:phone_number])
     {
       order_or_error: { order: order }
     }

--- a/app/graphql/types/order_interface.rb
+++ b/app/graphql/types/order_interface.rb
@@ -7,11 +7,10 @@ module Types::OrderInterface
 
   field :id, ID, null: false
   field :internalID, ID, null: false, method: :id, camelize: false
-  field :mode, Types::OrderModeEnum, null: true
-  field :code, String, null: false
   field :buyer_phone_number, String, null: true
   field :buyer_total_cents, Integer, null: true
   field :buyer, Types::OrderPartyUnionType, null: false
+  field :code, String, null: false
   field :commission_fee_cents, Integer, null: true, seller_only: true
   field :commission_rate, Float, null: true
   field :created_at, Types::DateTimeType, null: false
@@ -23,6 +22,7 @@ module Types::OrderInterface
   field :last_submitted_at, Types::DateTimeType, null: true
   field :last_transaction_failed, Boolean, null: true, method: :last_transaction_failed?
   field :line_items, Types::LineItemType.connection_type, null: true
+  field :mode, Types::OrderModeEnum, null: true
   field :requested_fulfillment, Types::RequestedFulfillmentUnionType, null: true
   field :seller_total_cents, Integer, null: true, seller_only: true
   field :seller, Types::OrderPartyUnionType, null: false
@@ -31,8 +31,8 @@ module Types::OrderInterface
   field :state_reason, String, null: true
   field :state_updated_at, Types::DateTimeType, null: true
   field :state, Types::OrderStateEnum, null: false
-  field :total_list_price_cents, Integer, null: false
   field :tax_total_cents, Integer, null: true
+  field :total_list_price_cents, Integer, null: false
   field :transaction_fee_cents, Integer, null: true, seller_only: true
   field :updated_at, Types::DateTimeType, null: false
 

--- a/app/graphql/types/requested_fulfillment_union_type.rb
+++ b/app/graphql/types/requested_fulfillment_union_type.rb
@@ -14,6 +14,11 @@ end
 
 class Types::Pickup < Types::BaseObject
   field :fulfillment_type, String, null: false
+  field :phone_number, String, null: true
+
+  def phone_number
+    object.buyer_phone_number
+  end
 
   def fulfillment_type
     Order::PICKUP

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -21,6 +21,7 @@ module OrderService
 
   def self.set_shipping!(order, fulfillment_type:, shipping:, phone_number:)
     raise Errors::ValidationError, :invalid_state unless order.state == Order::PENDING
+    raise Errors::ValidationError, :missing_phone_number unless phone_number.present?
 
     order_shipping = OrderShipping.new(order)
     case fulfillment_type

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -19,13 +19,13 @@ module OrderService
     end
   end
 
-  def self.set_shipping!(order, fulfillment_type:, shipping:)
+  def self.set_shipping!(order, fulfillment_type:, shipping:, phone_number:)
     raise Errors::ValidationError, :invalid_state unless order.state == Order::PENDING
 
     order_shipping = OrderShipping.new(order)
     case fulfillment_type
-    when Order::PICKUP then order_shipping.pickup!(shipping&.dig(:phone_number))
-    when Order::SHIP then order_shipping.ship!(shipping)
+    when Order::PICKUP then order_shipping.pickup!(phone_number)
+    when Order::SHIP then order_shipping.ship!(shipping, phone_number)
     end
     order
   end

--- a/lib/order_shipping.rb
+++ b/lib/order_shipping.rb
@@ -20,14 +20,14 @@ class OrderShipping
     end
   end
 
-  def ship!(shipping_info)
+  def ship!(shipping_info, buyer_phone_number)
     @shipping_address = Address.new(shipping_info)
     raise Errors::ValidationError, :missing_country if @shipping_address&.country.blank?
 
     @order.with_lock do
       @order.update!(
         fulfillment_type: Order::SHIP,
-        buyer_phone_number: shipping_info[:phone_number],
+        buyer_phone_number: buyer_phone_number,
         shipping_name: shipping_info[:name],
         shipping_address_line1: @shipping_address&.street_line1,
         shipping_address_line2: @shipping_address&.street_line2,

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -76,7 +76,6 @@ describe Api::GraphqlController, type: :request do
         city: 'New York',
         region: shipping_region,
         postalCode: shipping_postal_code,
-        phoneNumber: phone_number,
         addressLine1: '401 Broadway',
         addressLine2: 'Suite 80'
       }
@@ -86,7 +85,8 @@ describe Api::GraphqlController, type: :request do
         input: {
           id: order.id.to_s,
           fulfillmentType: fulfillment_type,
-          shipping: shipping_address
+          shipping: shipping_address,
+          phoneNumber: phone_number
         }.compact
       }
     end

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -154,9 +154,9 @@ describe Api::GraphqlController, type: :request do
         context 'without passing phone number' do
           let(:phone_number) { nil }
           it 'fails' do
-            expect do
-              client.execute(mutation, set_shipping_input)
-            end.to raise_error(/was provided invalid value for shipping.phoneNumber/)
+            response = client.execute(mutation, set_shipping_input)
+            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_phone_number'
           end
         end
 

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -179,12 +179,12 @@ describe Api::GraphqlController, type: :request do
                   postalCode: shipping_postal_code,
                   addressLine1: '401 Broadway',
                   addressLine2: 'Suite 80'
-                },
+                }
               }.compact
             }
           end
           it 'does not fail' do
-            response = client.execute(mutation, set_shipping_input)
+            client.execute(mutation, set_shipping_input)
             expect(order.reload.buyer_phone_number).to eq '2813308004'
           end
         end

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -155,9 +155,9 @@ describe Api::GraphqlController, type: :request do
         context 'without passing phone number' do
           let(:phone_number) { nil }
           it 'fails' do
-            expect do
-              client.execute(mutation, set_shipping_input)
-            end.to raise_error(/was provided invalid value for shipping.phoneNumber/)
+            response = client.execute(mutation, set_shipping_input)
+            expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
+            expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_phone_number'
           end
         end
 

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -81,7 +81,8 @@ describe Api::GraphqlController, type: :request do
         input: {
           id: order.id.to_s,
           fulfillmentType: fulfillment_type,
-          shipping: shipping_address
+          shipping: shipping_address,
+          phoneNumber: phone_number
         }.compact
       }
     end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -179,7 +179,7 @@ describe Api::GraphqlController, type: :request do
         buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
         offer = Offer.last
 
-        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil })
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil})
         expect(offer.reload).to have_attributes(tax_total_cents: nil)
       end
     end

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -179,7 +179,7 @@ describe Api::GraphqlController, type: :request do
         buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
         offer = Offer.last
 
-        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil})
+        buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', shipping: nil })
         expect(offer.reload).to have_attributes(tax_total_cents: nil)
       end
     end

--- a/spec/integration/gbp/reset_shipping_request_spec.rb
+++ b/spec/integration/gbp/reset_shipping_request_spec.rb
@@ -113,7 +113,7 @@ describe Api::GraphqlController, type: :request do
           buyer_total_cents: 1200_00,
           currency_code: 'GBP'
         )
-        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP' })
+        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', phoneNumber: '9876765432' })
       end
       it 'changes shipping info' do
         expect(order.reload).to have_attributes(
@@ -122,7 +122,7 @@ describe Api::GraphqlController, type: :request do
           shipping_city: nil,
           shipping_region: nil,
           shipping_postal_code: nil,
-          buyer_phone_number: nil,
+          buyer_phone_number: '9876765432',
           shipping_name: nil,
           shipping_address_line1: nil,
           shipping_address_line2: nil

--- a/spec/integration/reset_shipping_request_spec.rb
+++ b/spec/integration/reset_shipping_request_spec.rb
@@ -107,7 +107,7 @@ describe Api::GraphqlController, type: :request do
           shipping_total_cents: 200_00,
           buyer_total_cents: 1201_16
         )
-        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP' })
+        @response = client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'PICKUP', phoneNumber: '8766543221' })
       end
       it 'changes shipping info' do
         expect(order.reload).to have_attributes(
@@ -116,7 +116,7 @@ describe Api::GraphqlController, type: :request do
           shipping_city: nil,
           shipping_region: nil,
           shipping_postal_code: nil,
-          buyer_phone_number: nil,
+          buyer_phone_number: '8766543221',
           shipping_name: nil,
           shipping_address_line1: nil,
           shipping_address_line2: nil


### PR DESCRIPTION
# [PURCHASE-1707] 

__Problem:__

- We want to be able to pre-fill the phone number field on the shipping page if a user has selected pickup, but currently we're not able to fetch for the phone number for pickup orders so this isn't possible.

__Solution:__

- we now return `phone_number` for pickup orders as part of `requested_fulfillment`

- we also updated `setShipping` mutation to now get a root level optional `phone_number`. We kept the `phone_number` passed in shipping as well. so if its not set in the root argument we try to fetch it from shipping input

[PURCHASE-1707]: https://artsyproduct.atlassian.net/browse/PURCHASE-1707