### PR TITLE
Only require phone number for pickup orders

### DIFF
--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -21,7 +21,7 @@ module OrderService
 
   def self.set_shipping!(order, fulfillment_type:, shipping:, phone_number:)
     raise Errors::ValidationError, :invalid_state unless order.state == Order::PENDING
-    raise Errors::ValidationError, :missing_phone_number unless phone_number.present?
+    raise Errors::ValidationError, :missing_phone_number if fulfillment_type == Order::SHIP && phone_number.nil?
 
     order_shipping = OrderShipping.new(order)
     case fulfillment_type

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -146,6 +146,14 @@ describe Api::GraphqlController, type: :request do
           expect(order.reload.shipping_total_cents).to be_nil
           expect(offer.reload.shipping_total_cents).to eq 0
         end
+
+        context 'without passing phone number' do
+          let(:phone_number) { nil }
+          it 'does not raise a validation error' do
+            response = client.execute(mutation, set_shipping_input)
+            expect(@response.data.set_shipping.order_or_error).not_to respond_to(:error)
+          end
+        end
       end
       context 'Ship Order' do
         before do

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -151,7 +151,7 @@ describe Api::GraphqlController, type: :request do
           let(:phone_number) { nil }
           it 'does not raise a validation error' do
             response = client.execute(mutation, set_shipping_input)
-            expect(@response.data.set_shipping.order_or_error).not_to respond_to(:error)
+            expect(response.data.set_shipping.order_or_error).not_to respond_to(:error)
           end
         end
       end


### PR DESCRIPTION
__Problem:__
We were requiring phone number on pickup orders as well as ship orders, so we were getting validation errors when pickup orders were placed without phone number (phone number field has not been added to reaction yet for pickup orders)

__Solution:__
I changed the validation logic so it only requires phone number for pickup orders. I also added a test to confirm this.