### PR TITLE
#Hackthon2020 Add myOrders Query

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1133,6 +1133,35 @@ type Query {
   ): LineItemConnection
 
   """
+  Return my orders
+  """
+  myOrders(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    mode: OrderModeEnum
+    sellerId: String
+    sort: OrderConnectionSortEnum
+    state: OrderStateEnum
+  ): OrderConnectionWithTotalCount
+
+  """
   Find an order by ID
   """
   order(code: String, id: ID): Order

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -55,6 +55,7 @@ class Types::QueryType < Types::BaseObject
 
   def my_orders(params = {})
     raise ActiveRecord::RecordNotFound unless context[:current_user][:id]
+
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }
     Order.where(params.merge(buyer_id: context[:current_user][:id])).order(order_clause)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -19,6 +19,14 @@ class Types::QueryType < Types::BaseObject
     argument :mode, Types::OrderModeEnum, required: false
   end
 
+  field :my_orders, Types::OrderConnectionWithTotalCountType, null: true, connection: true do
+    description 'Return my orders'
+    argument :seller_id, String, required: false
+    argument :state, Types::OrderStateEnum, required: false
+    argument :sort, Types::OrderConnectionSortEnum, required: false
+    argument :mode, Types::OrderModeEnum, required: false
+  end
+
   field :line_items, Types::LineItemType.connection_type, null: true, connection: true do
     argument :artwork_id, String, required: false
     argument :edition_set_id, String, required: false
@@ -43,6 +51,13 @@ class Types::QueryType < Types::BaseObject
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }
     Order.where(params).order(order_clause)
+  end
+
+  def my_orders(params = {})
+    raise ActiveRecord::RecordNotFound unless context[:current_user][:id]
+    sort = params.delete(:sort)
+    order_clause = sort_to_order[sort] || { state_updated_at: :desc }
+    Order.where(params.merge(buyer_id: context[:current_user][:id])).order(order_clause)
   end
 
   def line_items(args = {})

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2019_07_23_204947) do
     t.uuid "resource_id"
     t.string "author_type"
     t.uuid "author_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"

--- a/spec/controllers/api/requests/my_orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/my_orders_query_request_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+def ids_from_result_data(result)
+  result.data.my_orders.edges.map(&:node).map(&:id)
+end
+
+describe Api::GraphqlController, type: :request do
+  describe 'my_orders query' do
+    include_context 'GraphQL Client'
+    let(:seller_id) { jwt_partner_ids.first }
+    let(:second_seller_id) { 'partner-2' }
+    let(:my_user_id) { jwt_user_id }
+    let(:another_user) { 'user2' }
+    let!(:user1_order1) { Fabricate(:order, seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: my_user_id, updated_at: 3.days.ago) }
+    let!(:user1_order2) { Fabricate(:order, seller_type: 'partner', seller_id: second_seller_id, buyer_type: 'user', buyer_id: my_user_id, updated_at: 2.days.ago) }
+    let!(:user1_offer_order1) { Fabricate(:order, seller_type: 'partner', seller_id: second_seller_id, buyer_type: 'user', buyer_id: my_user_id, updated_at: 1.day.ago, mode: Order::OFFER) }
+    let!(:user2_order1) { Fabricate(:order, seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: another_user) }
+
+    let(:query) do
+      <<-GRAPHQL
+        query($sellerId: String, $state: OrderStateEnum, $sort: OrderConnectionSortEnum, $mode: OrderModeEnum, $first: Int) {
+          myOrders(sellerId: $sellerId, state: $state, sort: $sort, mode: $mode, first: $first) {
+            totalCount
+            edges {
+              node {
+                id
+                buyer {
+                  ... on Partner {
+                    id
+                  }
+                }
+                seller {
+                  ... on User {
+                    id
+                  }
+                }
+                state
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'as user' do
+      it 'returns orders by a seller' do
+        result = client.execute(query, sellerId: second_seller_id)
+        expect(result.data.my_orders.edges.count).to eq 2
+        ids = ids_from_result_data(result)
+        expect(ids).to match_array([user1_order2.id, user1_offer_order1.id])
+      end
+      it 'returns orders in specified order' do
+        result = client.execute(query, sellerId: seller_id)
+      end
+      it 'returns order in specified state' do
+        result = client.execute(query, sellerId: seller_id)
+      end
+      it 'returns my orders' do
+        result = client.execute(query)
+        expect(result.data.my_orders.edges.count).to eq 3
+        ids = ids_from_result_data(result)
+        expect(ids).to match_array([user1_order1.id, user1_order2.id, user1_offer_order1.id])
+      end
+      it 'returns proper total count' do
+        Fabricate.times(10, :order, buyer_id: my_user_id, seller_type: 'partner', seller_id: seller_id)
+        results = client.execute(query, sellerId: seller_id, first: 2)
+        expect(results.data.my_orders.total_count).to eq 11
+        expect(results.data.my_orders.edges.count).to eq 2
+      end
+      describe 'sort' do
+        it 'sorts by updated_at in ascending order' do
+          result = client.execute(query, sort: 'UPDATED_AT_ASC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_order1.id, user1_order2.id, user1_offer_order1.id])
+        end
+        it 'sorts by updated_at in descending order' do
+          result = client.execute(query, sort: 'UPDATED_AT_DESC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_offer_order1.id, user1_order2.id, user1_order1.id])
+        end
+        it 'sorts by state_updated_at in ascending order' do
+          user1_order1.update!(state_updated_at: Time.now)
+          result = client.execute(query, sort: 'STATE_UPDATED_AT_ASC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
+        end
+        it 'sorts by state_updated_at in descending order' do
+          user1_order1.update!(state_updated_at: Time.now)
+          result = client.execute(query, sort: 'STATE_UPDATED_AT_DESC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])
+        end
+        it 'sorts by state_expires_at in ascending order' do
+          user1_order1.update!(state_expires_at: 1.day.from_now)
+          user1_order2.update!(state_expires_at: 2.days.from_now)
+          result = client.execute(query, sort: 'STATE_EXPIRES_AT_ASC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])
+        end
+        it 'sorts by state_expires_at in descending order' do
+          user1_order1.update!(state_expires_at: 1.day.from_now)
+          user1_order2.update!(state_expires_at: 2.days.from_now)
+          result = client.execute(query, sort: 'STATE_EXPIRES_AT_DESC')
+          ids = ids_from_result_data(result)
+          expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
+        end
+      end
+    end
+
+    context 'as an app' do
+      let(:jwt_user_id) { nil }
+      it 'raises error' do
+        expect do
+          client.execute(query)
+        end.to raise_error do |error|
+          expect(error).to be_a(Graphlient::Errors::ServerError)
+          expect(error.status_code).to eq 404
+          expect(error.message).to eq 'the server responded with status 404'
+          expect(error.response['errors'].first['extensions']['code']).to eq 'not_found'
+          expect(error.response['errors'].first['extensions']['type']).to eq 'validation'
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/requests/my_orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/my_orders_query_request_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
 
-def ids_from_result_data(result)
-  result.data.my_orders.edges.map(&:node).map(&:id)
-end
-
 describe Api::GraphqlController, type: :request do
+  def ids_from_my_orders_result_data(result)
+    result.data.my_orders.edges.map(&:node).map(&:id)
+  end
   describe 'my_orders query' do
     include_context 'GraphQL Client'
     let(:seller_id) { jwt_partner_ids.first }
@@ -46,21 +45,21 @@ describe Api::GraphqlController, type: :request do
       it 'returns orders by a seller' do
         result = client.execute(query, sellerId: second_seller_id)
         expect(result.data.my_orders.edges.count).to eq 2
-        ids = ids_from_result_data(result)
+        ids = ids_from_my_orders_result_data(result)
         expect(ids).to match_array([user1_order2.id, user1_offer_order1.id])
       end
 
       it 'returns order in specified state' do
         fulfilled_order = Fabricate(:order, buyer_id: my_user_id, state: Order::FULFILLED)
         result = client.execute(query, state: 'FULFILLED')
-        ids = ids_from_result_data(result)
+        ids = ids_from_my_orders_result_data(result)
         expect(ids).to match_array([fulfilled_order.id])
       end
 
       it 'returns my orders' do
         result = client.execute(query)
         expect(result.data.my_orders.edges.count).to eq 3
-        ids = ids_from_result_data(result)
+        ids = ids_from_my_orders_result_data(result)
         expect(ids).to match_array([user1_order1.id, user1_order2.id, user1_offer_order1.id])
       end
 
@@ -74,27 +73,27 @@ describe Api::GraphqlController, type: :request do
       describe 'sort' do
         it 'sorts by updated_at in ascending order' do
           result = client.execute(query, sort: 'UPDATED_AT_ASC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order1.id, user1_order2.id, user1_offer_order1.id])
         end
 
         it 'sorts by updated_at in descending order' do
           result = client.execute(query, sort: 'UPDATED_AT_DESC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_offer_order1.id, user1_order2.id, user1_order1.id])
         end
 
         it 'sorts by state_updated_at in ascending order' do
           user1_order1.update!(state_updated_at: Time.now)
           result = client.execute(query, sort: 'STATE_UPDATED_AT_ASC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
         end
 
         it 'sorts by state_updated_at in descending order' do
           user1_order1.update!(state_updated_at: Time.now)
           result = client.execute(query, sort: 'STATE_UPDATED_AT_DESC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])
         end
 
@@ -102,7 +101,7 @@ describe Api::GraphqlController, type: :request do
           user1_order1.update!(state_expires_at: 1.day.from_now)
           user1_order2.update!(state_expires_at: 2.days.from_now)
           result = client.execute(query, sort: 'STATE_EXPIRES_AT_ASC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])
         end
 
@@ -110,7 +109,7 @@ describe Api::GraphqlController, type: :request do
           user1_order1.update!(state_expires_at: 1.day.from_now)
           user1_order2.update!(state_expires_at: 2.days.from_now)
           result = client.execute(query, sort: 'STATE_EXPIRES_AT_DESC')
-          ids = ids_from_result_data(result)
+          ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
         end
       end

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-def ids_from_result_data(result)
-  result.data.orders.edges.map(&:node).map(&:id)
-end
-
 describe Api::GraphqlController, type: :request do
+  def ids_from_result_data(result)
+    result.data.orders.edges.map(&:node).map(&:id)
+  end
+
   describe 'orders query' do
     include_context 'GraphQL Client'
     let(:seller_id) { jwt_partner_ids.first }


### PR DESCRIPTION
# Problem
We want to be able to show specific user's order in their dashboard.

# Solution
Add a new `myOrders` query which can be filtered down by:
- `state`
- `sellerId`
and can be sorted same way we currently can sort orders.

It will return a `OrderConnection` for the current user's orders.

A trusted app request will fail. 