### PR TITLE
Add fulfilled_by_admin_id to orders

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -75,7 +75,7 @@ ActiveAdmin.register Order do
 
   member_action :confirm_fulfillment, method: :post do
     if resource.fulfillment_type == Order::SHIP
-      OrderService.confirm_fulfillment!(resource, current_user[:id])
+      OrderService.confirm_fulfillment!(resource, current_user[:id], true)
     end
     redirect_to resource_path, notice: "Fulfillment confirmed!"
   end

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -75,7 +75,7 @@ ActiveAdmin.register Order do
 
   member_action :confirm_fulfillment, method: :post do
     if resource.fulfillment_type == Order::SHIP
-      OrderService.confirm_fulfillment!(resource, current_user[:id], true)
+      OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true)
     end
     redirect_to resource_path, notice: "Fulfillment confirmed!"
   end

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -2,17 +2,19 @@ class OrderEvent < Events::BaseEvent
   TOPIC = 'commerce'.freeze
   PROPERTIES_ATTRS = %i[
     id
-    mode
     buyer_id
-    buyer_type
     buyer_phone_number
     buyer_total_cents
+    buyer_type
     code
     commission_fee_cents
     created_at
     currency_code
+    external_charge_id
+    fulfilled_by_admin_id
     fulfillment_type
     items_total_cents
+    mode
     seller_id
     seller_total_cents
     seller_type
@@ -24,13 +26,12 @@ class OrderEvent < Events::BaseEvent
     shipping_postal_code
     shipping_region
     shipping_total_cents state
-    state_reason
     state_expires_at
+    state_reason
     tax_total_cents
+    total_list_price_cents
     transaction_fee_cents
     updated_at
-    total_list_price_cents
-    external_charge_id
   ].freeze
 
   def self.post(order, action, user_id)

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -113,7 +113,7 @@ module OrderService
     order
   end
 
-  def self.confirm_fulfillment!(order, user_id, fulfilled_by_admin = false)
+  def self.confirm_fulfillment!(order, user_id, fulfilled_by_admin: false)
     raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::SHIP
 
     order.fulfill! do

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -113,10 +113,12 @@ module OrderService
     order
   end
 
-  def self.confirm_fulfillment!(order, user_id)
+  def self.confirm_fulfillment!(order, user_id, fulfilled_by_admin = false)
     raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::SHIP
 
-    order.fulfill!
+    order.fulfill! do
+      order.update!(fulfilled_by_admin_id: user_id) if fulfilled_by_admin
+    end
     OrderEvent.delay_post(order, user_id)
     order
   end

--- a/db/migrate/20200116202202_add_fulfilled_by_admin_id_to_orders.rb
+++ b/db/migrate/20200116202202_add_fulfilled_by_admin_id_to_orders.rb
@@ -1,4 +1,4 @@
-class AddFulfilledByAdminToFulfillments < ActiveRecord::Migration[6.0]
+class AddFulfilledByAdminIdToOrders < ActiveRecord::Migration[6.0]
   def change
     add_column :orders, :fulfilled_by_admin_id, :string
   end

--- a/db/migrate/20200116202202_add_fulfilled_by_admin_to_fulfillments.rb
+++ b/db/migrate/20200116202202_add_fulfilled_by_admin_to_fulfillments.rb
@@ -1,0 +1,5 @@
+class AddFulfilledByAdminToFulfillments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :orders, :fulfilled_by_admin_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_204947) do
+ActiveRecord::Schema.define(version: 2020_01_16_202202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 2019_07_23_204947) do
     t.string "original_user_ip"
     t.string "payment_method", null: false
     t.boolean "assisted"
+    t.string "fulfilled_by_admin_id"
     t.index ["buyer_id"], name: "index_orders_on_buyer_id"
     t.index ["code"], name: "index_orders_on_code"
     t.index ["last_offer_id"], name: "index_orders_on_last_offer_id"

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -33,6 +33,7 @@ describe OrderEvent, type: :events do
       buyer_total_cents: 380,
       state: 'submitted',
       external_charge_id: 'pi_1',
+      fulfilled_by_admin_id: 'admin1',
       **shipping_info
     )
   end
@@ -113,6 +114,7 @@ describe OrderEvent, type: :events do
         expect(event.properties[:total_list_price_cents]).to eq(400)
         expect(event.properties[:last_offer]).to be_nil
         expect(event.properties[:external_charge_id]).to eq 'pi_1'
+        expect(event.properties[:fulfilled_by_admin_id]).to eq 'admin1'
       end
     end
     context 'with last_offer' do

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -6,7 +6,8 @@ describe OrderService, type: :services do
   include_context 'include stripe helper'
   let(:state) { Order::PENDING }
   let(:state_reason) { state == Order::CANCELED ? 'seller_lapsed' : nil }
-  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: state, state_reason: state_reason, buyer_id: 'b123') }
+  let(:fulfillment_type) { Order::SHIP }
+  let(:order) { Fabricate(:order, external_charge_id: captured_charge.id, state: state, state_reason: state_reason, buyer_id: 'b123', fulfillment_type: fulfillment_type) }
   let!(:line_items) { [Fabricate(:line_item, order: order, artwork_id: 'a-1', list_price_cents: 123_00), Fabricate(:line_item, order: order, artwork_id: 'a-2', edition_set_id: 'es-1', quantity: 2, list_price_cents: 124_00)] }
   let(:user_id) { 'user-id' }
 
@@ -199,6 +200,56 @@ describe OrderService, type: :services do
           expect do
             OrderService.fulfill_at_once!(order, fulfillment_params, user_id)
           end.to raise_error(Errors::ValidationError).and change(Fulfillment, :count).by(0)
+        end
+      end
+    end
+  end
+
+  describe 'confirm_fulfillment!' do
+    context 'with order in approved state' do
+      let(:state) { Order::APPROVED }
+
+      it 'raises error for pickup orders' do
+        order.update!(fulfillment_type: Order::PICKUP)
+        expect { OrderService.confirm_fulfillment!(order, user_id) }.to raise_error do |e|
+          expect(e).to be_a Errors::ValidationError
+          expect(e.code).to eq :wrong_fulfillment_type
+        end
+      end
+
+      it 'changes order state to fulfilled' do
+        OrderService.confirm_fulfillment!(order, user_id)
+        expect(order.reload.state).to eq Order::FULFILLED
+        expect(order.reload.fulfilled_by_admin_id).to be_nil
+      end
+
+      it 'queues job to post fulfillment event' do
+        OrderService.confirm_fulfillment!(order, user_id)
+        expect(PostEventJob).to have_been_enqueued.with('commerce', kind_of(String), 'order.fulfilled')
+      end
+
+      it 'does not add fulfillments' do
+        expect do
+          OrderService.confirm_fulfillment!(order, user_id)
+        end.to change(Fulfillment, :count).by(0)
+      end
+
+      it 'sets fulfilled_by_admin_id when it was fulfilled by admin' do
+        OrderService.confirm_fulfillment!(order, user_id, true)
+        expect(order.reload.fulfilled_by_admin_id).to eq user_id
+      end
+    end
+
+    Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|
+      context "order in #{state}" do
+        let(:state) { state }
+        it 'raises error' do
+          expect do
+            OrderService.confirm_fulfillment!(order, user_id)
+          end.to raise_error do |error|
+            expect(error).to be_a Errors::ValidationError
+            expect(error.code).to eq :invalid_state
+          end
         end
       end
     end

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -235,7 +235,7 @@ describe OrderService, type: :services do
       end
 
       it 'sets fulfilled_by_admin_id when it was fulfilled by admin' do
-        OrderService.confirm_fulfillment!(order, user_id, true)
+        OrderService.confirm_fulfillment!(order, user_id, fulfilled_by_admin: true)
         expect(order.reload.fulfilled_by_admin_id).to eq user_id
       end
     end


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1695
Artsy admins currently can mark orders as fulfilled to clean up the _un-completed_ orders. While that works and tracked in our papertrail logic. We want to capture the fact that this was handled by admins in a more first class way. This way we can make sure emails are not sent in this case and etc.

# Solution
Add `fulfilled_by_admin_id` to `Order` and when we mark things as fulfilled in admin, we call `confirm_order` and pass newly added `confirmed_by_admin` flag that makes sure `fulfilled_by_admin_id` is set on the `Order`.

Also added `fulfilled_by_admin_id` to `OrderEvent` so consumers can decide what to do based on this being approved by admin or actual user.

