### PR TITLE
Add Danger rule about PaperTrail documentation

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,6 +1,7 @@
 import {danger, warn, fail} from "danger"
 
 const addedOrModified = danger.git.modified_files.concat(danger.git.created_files)
+const added = danger.git.created_files
 const fileInGraphQLFolder = addedOrModified.find(f => f.startsWith("app/graphql"))
 if (fileInGraphQLFolder) {
   warn("If you want these changes to be reflected in Metaphysics, you will need to [update the stored schema](https://github.com/artsy/exchange#did-you-change-graphql-schema).")
@@ -17,4 +18,9 @@ if (danger.git.created_files.includes("exchange.graphql")) {
 const fileInModelsFolder = addedOrModified.find(f => f.startsWith("app/models"))
 if (fileInModelsFolder) {
   warn("You have updated models folder please consider [notifying Analytics Team](https://github.com/artsy/exchange#did-you-change-models).")
+}
+
+const newFileInModelsFolder = added.find(f => f.startsWith("app/models"))
+if (newFileInModelsFolder) {
+  warn("You have added something to the models folder. Please consider [implementing the PaperTrail pattern](https://github.com/artsy/exchange#user-content-papertrail-audit-logging).")
 }


### PR DESCRIPTION
Hi! 👋 This is my first contribution to an Artsy project! I saw this open issue, so I hope it's still relevant and my PR is helpful. I'm totally happy to make changes to my first stab at it here. One other thing I noticed is that the README is substantially lengthened by the section about `Papertrail Audit Logging` so maybe it could be split off into another markdown file and linked to from the README? Also, I think the numbered list is not exactly working since each item is listed as `1.`. I'd be happy to open issues for either or both of these and take them on, too, if that would be helpful! (I presume they should be numbers `1` through `5`) 😄 

EDIT: Sorry, almost forgot, two tests failed for me locally:
```
rspec ./spec/controllers/api/health_controller_spec.rb:6 # Api::HealthController @GET #api/health unauthorized returns healthy: true
rspec ./spec/system/visiting_order_details_spec.rb:13 # visit order details renders order details page
```
Is this expected? Or are they worth looking into further?