### PR TITLE
Add fraud review to exchange

### DIFF
--- a/app/admin/admin_notes.rb
+++ b/app/admin/admin_notes.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register AdminNote do
 
   form do |f|
     f.inputs do
-      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}
+      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}, wrapper_html: { style: "display:none" }
       f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
       f.input :note_type, :as => :select, :collection => AdminNote::TYPES.collect { |type| [type[1].humanize, type[0]] }
       f.input :description

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -1,13 +1,14 @@
-ActiveAdmin.register AdminNote do
+ActiveAdmin.register FraudReview do
   belongs_to :order
-  permit_params :order_id, :admin_id, :note_type, :description
+  permit_params :order_id, :admin_id, :considered_fraudulent, :reason, :context
 
   form do |f|
     f.inputs do
       f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}
       f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
-      f.input :note_type, :as => :select, :collection => AdminNote::TYPES.collect { |type| [type[1].humanize, type[0]] }
-      f.input :description
+      f.input :context
+      f.input :considered_fraudulent
+      f.input :reason
     end
     f.actions
   end

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -6,7 +6,6 @@ ActiveAdmin.register FraudReview do
     f.inputs do
       f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}
       f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
-      f.input :context
       f.input :considered_fraudulent
       f.input :reason
     end

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register FraudReview do
 
   form do |f|
     f.inputs do
-      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}
+      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}, wrapper_html: { style: "display:none" }
       f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
       f.input :considered_fraudulent
       f.input :reason

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -16,7 +16,6 @@ ActiveAdmin.register FraudReview do
   controller do
     def create
       create! do |format|
-        byebug
         format.html { redirect_to admin_order_path(params[:order_id]) }
       end
     end

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -1,4 +1,5 @@
 ActiveAdmin.register FraudReview do
+  actions :all, except: %i[update destroy edit]
   belongs_to :order
   permit_params :order_id, :admin_id, :considered_fraudulent, :reason, :context
 
@@ -10,5 +11,14 @@ ActiveAdmin.register FraudReview do
       f.input :reason
     end
     f.actions
+  end
+
+  controller do
+    def create
+      create! do |format|
+        byebug
+        format.html { redirect_to admin_order_path(params[:order_id]) }
+      end
+    end
   end
 end

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -407,7 +407,6 @@ OrderService.refund!(resource)
         column "Reviewed by" do |fraud_review|
           Gravity.get_user(fraud_review.admin_id)[:name]
         end
-        column :context
         column :considered_fraudulent
         column :reason
       end

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -390,10 +390,26 @@ OrderService.refund!(resource)
       h5 link_to("Add note", new_admin_order_admin_note_path(order), class: :button)
       table_for(order.admin_notes) do
         column :created_at
+        column "Admin" do |fraud_review|
+          Gravity.get_user(fraud_review.admin_id)[:name]
+        end
         column "Note Type" do |admin_note|
           admin_note.note_type.to_s.humanize
         end
         column :description
+      end
+    end
+
+    panel "Fraud Review" do
+      h5 link_to("Add fraud review",  new_admin_order_fraud_review_path(order), class: :button)
+      table_for(order.fraud_reviews) do
+        column :created_at
+        column "Reviewed by" do |fraud_review|
+          Gravity.get_user(fraud_review.admin_id)[:name]
+        end
+        column :context
+        column :considered_fraudulent
+        column :reason
       end
     end
   end

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -402,7 +402,7 @@ OrderService.refund!(resource)
 
     panel "Fraud Review" do
       h5 link_to("Add fraud review",  new_admin_order_fraud_review_path(order), class: :button)
-      table_for(order.fraud_reviews) do
+      table_for(order.fraud_reviews.order(created_at: :desc) do
         column :created_at
         column "Reviewed by" do |fraud_review|
           Gravity.get_user(fraud_review.admin_id)[:name]

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -402,7 +402,7 @@ OrderService.refund!(resource)
 
     panel "Fraud Review" do
       h5 link_to("Add fraud review",  new_admin_order_fraud_review_path(order), class: :button)
-      table_for(order.fraud_reviews.order(created_at: :desc) do
+      table_for(order.fraud_reviews.order(created_at: :desc)) do
         column :created_at
         column "Reviewed by" do |fraud_review|
           Gravity.get_user(fraud_review.admin_id)[:name]

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -388,7 +388,7 @@ OrderService.refund!(resource)
     panel "Admin Actions and Notes" do
       #TODO: Add "Add note" button
       h5 link_to("Add note", new_admin_order_admin_note_path(order), class: :button)
-      table_for(order.admin_notes) do
+      table_for(order.admin_notes.order(created_at: :desc)) do
         column :created_at
         column "Admin" do |fraud_review|
           Gravity.get_user(fraud_review.admin_id)[:name]

--- a/app/models/fraud_review.rb
+++ b/app/models/fraud_review.rb
@@ -1,0 +1,3 @@
+class FraudReview < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -91,6 +91,7 @@ class Order < ApplicationRecord
   has_many :transactions, dependent: :destroy
   has_many :state_histories, dependent: :destroy
   has_many :admin_notes, dependent: :destroy
+  has_many :fraud_reviews, dependent: :destroy
   has_many :offers, dependent: :destroy
   belongs_to :last_offer, class_name: 'Offer', optional: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
     get '/health', to: 'health#index'
     post '/webhooks/stripe', to: 'webhooks#stripe'
   end
-  resources :admin_notes
-  resources :fraud_reviews
   ActiveAdmin.routes(self)
   mount ArtsyAuth::Engine => '/'
   constraints ->(req) { req.session[:access_token].present? && ArtsyAuthToken.new(req.session[:access_token]).admin? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     post '/webhooks/stripe', to: 'webhooks#stripe'
   end
   resources :admin_notes
+  resources :fraud_reviews
   ActiveAdmin.routes(self)
   mount ArtsyAuth::Engine => '/'
   constraints ->(req) { req.session[:access_token].present? && ArtsyAuthToken.new(req.session[:access_token]).admin? } do

--- a/db/migrate/20200124213353_create_fraud_reviews.rb
+++ b/db/migrate/20200124213353_create_fraud_reviews.rb
@@ -1,0 +1,13 @@
+class CreateFraudReviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :fraud_reviews, id: :uuid do |t|
+      t.references :order, foreign_key: true, type: :uuid
+      t.string :admin_id, null: false
+      t.boolean :considered_fraudulent
+      t.string :context
+      t.text :reason
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200124213353_create_fraud_reviews.rb
+++ b/db/migrate/20200124213353_create_fraud_reviews.rb
@@ -4,7 +4,6 @@ class CreateFraudReviews < ActiveRecord::Migration[6.0]
       t.references :order, foreign_key: true, type: :uuid
       t.string :admin_id, null: false
       t.boolean :considered_fraudulent
-      t.string :context
       t.text :reason
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2020_01_24_213353) do
     t.uuid "resource_id"
     t.string "author_type"
     t.uuid "author_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 2020_01_24_213353) do
     t.uuid "order_id"
     t.string "admin_id", null: false
     t.boolean "considered_fraudulent"
-    t.string "context"
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_16_202202) do
+ActiveRecord::Schema.define(version: 2020_01_24_213353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2020_01_16_202202) do
     t.uuid "resource_id"
     t.string "author_type"
     t.uuid "author_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
@@ -38,6 +38,17 @@ ActiveRecord::Schema.define(version: 2020_01_16_202202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["order_id"], name: "index_admin_notes_on_order_id"
+  end
+
+  create_table "fraud_reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "order_id"
+    t.string "admin_id", null: false
+    t.boolean "considered_fraudulent"
+    t.string "context"
+    t.text "reason"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_fraud_reviews_on_order_id"
   end
 
   create_table "fulfillment_versions", force: :cascade do |t|
@@ -222,6 +233,7 @@ ActiveRecord::Schema.define(version: 2020_01_16_202202) do
   end
 
   add_foreign_key "admin_notes", "orders"
+  add_foreign_key "fraud_reviews", "orders"
   add_foreign_key "line_item_fulfillments", "fulfillments"
   add_foreign_key "line_item_fulfillments", "line_items"
   add_foreign_key "line_items", "orders"


### PR DESCRIPTION
This PR does two things

1. Adds the notion of a fraud review
2. Makes some minor admin notes UI improvements

## Fraud Review

Currently our fraud review process is highly manual. Our friends over in Consumer Marketplace want to be able to track the manual reviews that happen and report stats on them. 

The `fraud_reviews` model is _very_ similar to the `admin_notes` model. @ashkan18 and I have had a lot of conversations on whether we should consolidate the concepts. At this point, I'm explicitly _not_ combining the two models and accepting that this _may_ be technical debt. The explicit reason is because fraud review and what admin notes are used for are two separate workflows utilized by different people. It's been requested that we do a major overhaul to how admin notes currently is set up and functions. 

In the future we may consolidate these models if we can do it in a way that makes sense for our business partners.

## What's Next

This is the first PR in a series that's required. Next will be a PR to fulcrum to add ingestion of this table into redshift. Following that there will be a PR to APRd to have fast access to create a fraud review for our MSO pals. 

Phase II of this work (when we can get to it) is updating the APRd slack app to  have more interactivity. The idea is that we'd like to meet our customers (MSO) where they're at and enable them to leave fraud reviews without ever leaving slack. This will require setting up auth on APRd for reviewers and adding a graphql endpoint to exchange for leaving reviews. Also rebuilding some of the slack messaging setup...

