### PR TITLE
Fix Stripe capability issue and regression from order cancelation

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -41,17 +41,17 @@ ActiveAdmin.register Order do
   end
 
   member_action :refund, method: :post do
-OrderService.refund!(resource)
+    OrderService.refund!(resource)
     redirect_to resource_path, notice: "Refunded!"
   end
 
   member_action :cancel, method: :post do
-    OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:admin_canceled])
+    OrderService.reject!(resource, current_user[:id], Order::REASONS[Order::CANCELED][:admin_canceled])
     redirect_to resource_path, notice: "Canceled by Artsy admin!"
   end
 
   member_action :buyer_reject, method: :post do
-    OrderCancellationService.new(resource, resource.buyer_id).reject!(Order::REASONS[Order::CANCELED][:buyer_rejected])
+    OrderService.reject!(resource, resource.buyer_id, Order::REASONS[Order::CANCELED][:buyer_rejected])
     redirect_to resource_path, notice: "Canceled on behalf of buyer!"
   end
 

--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -192,13 +192,13 @@ class PaymentService
       status: Transaction::FAILURE,
       external_id: pi[:id],
       external_type: Transaction::PAYMENT_INTENT,
-      source_id: pi[:last_payment_error][:payment_method][:id],
-      destination_id: pi[:transfer_data][:destination],
+      source_id: pi.dig(:last_payment_error, :payment_method, :id),
+      destination_id: pi.dig(:transfer_data, :destination),
       amount_cents: pi[:amount],
       transaction_type: transaction_type,
-      failure_code: pi[:last_payment_error][:code],
-      failure_message: pi[:last_payment_error][:message],
-      decline_code: pi[:last_payment_error][:decline_code],
+      failure_code: pi.dig(:last_payment_error, :code),
+      failure_message: pi.dig(:last_payment_error, :message),
+      decline_code: pi.dig(:last_payment_error, :decline_code),
       payload: exc.json_body
     )
   end


### PR DESCRIPTION
# Problem(s)
We've started seeing failures on staging for our cypress integrity tests where we get following error on Stripe:
```
Your destination account needs to have at least one of the following capabilities enabled: transfers, legacy_payments
```
This is a new set of errors that we haven't seen in the past and looks like for these since there is no charge we can't store transactions. This hasn't happened on prod yet but worth adding support for it:

https://sentry.io/organizations/artsynet/issues/1485964863/?project=1275269&query=is%3Aunresolved

# Regression
As part of #554 we seem to have missed 2 admin calls in admin which lead to 
https://sentry.io/organizations/artsynet/issues/1477952941/?project=1275271&query=is%3Aunresolved
and 
https://sentry.io/organizations/artsynet/issues/1477975587/?project=1275271&query=is%3Aunresolved
