### PR TITLE
Use Simplecov and Codecov for coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  codecov: codecov/codecov@1.0.5
   hokusai: artsy/hokusai@0.7.2
 
 not_staging_or_release: &not_staging_or_release
@@ -29,6 +30,13 @@ workflows:
       - hokusai/test:
           name: test
           <<: *not_staging_or_release
+          post-steps:
+            - run:
+                name: Copy coverage artifacts
+                command: mkdir -p ./coverage && docker cp hokusai_exchange_1:/app/coverage ./
+                when: always
+            - codecov/upload:
+                file: ./coverage/.resultset.json
 
       # staging
       - hokusai/push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,10 @@ workflows:
             - run:
                 name: Copy coverage artifacts
                 command: mkdir -p ./coverage && docker cp hokusai_exchange_1:/app/coverage ./
-                when: always
+                when: on_success
             - codecov/upload:
                 file: ./coverage/.resultset.json
+                when: on_success
 
       # staging
       - hokusai/push:

--- a/Gemfile
+++ b/Gemfile
@@ -40,10 +40,10 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'simplecov', require: false
   gem 'danger'
   gem 'fabrication'
   gem 'selenium-webdriver'
+  gem 'simplecov', require: false
   gem 'stripe-ruby-mock', '~> 2.5.8', require: 'stripe_mock'
   gem 'timecop'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'coveralls', require: false
+  gem 'simplecov', require: false
   gem 'danger'
   gem 'fabrication'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,12 +104,6 @@ GEM
     connection_pool (2.2.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -382,15 +376,12 @@ GEM
       http (>= 1.0, < 5.0)
       memoizable (~> 0.4.0)
       model_attribute (~> 3.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
-    tins (1.22.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -418,7 +409,6 @@ DEPENDENCIES
   byebug
   capybara
   carmen
-  coveralls
   dalli
   danger
   ddtrace (>= 0.15.0)
@@ -441,6 +431,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   sidekiq (< 6)
+  simplecov
   stripe
   stripe-ruby-mock (~> 2.5.8)
   taxjar-ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,7 @@
 require_relative 'config/application'
 require 'graphql/rake_task'
-require 'coveralls/rake/task'
 
 Rails.application.load_tasks
-Coveralls::RakeTask.new
 
 GraphQL::RakeTask.new(schema_name: 'ExchangeSchema', idl_outfile: '_schema.graphql')
 
@@ -13,5 +11,5 @@ if %w[development test].include? Rails.env
   RuboCop::RakeTask.new(:rubocop)
 
   Rake::Task[:default].clear
-  task default: %i[graphql:schema:diff_check rubocop spec coveralls:push]
+  task default: %i[graphql:schema:diff_check rubocop spec]
 end

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -1,24 +1,23 @@
 ---
-version: '2'
+version: "2"
 services:
   exchange:
     extends:
       file: build.yml
       service: exchange
     ports:
-    - 8080:8080
+      - 8080:8080
     environment:
-    - RAILS_ENV=test
-    - DATABASE_HOST=exchange-db
-    - DATABASE_USER=postgres
-    - REDIS_URL=redis://exchange-redis
+      - RAILS_ENV=test
+      - DATABASE_HOST=exchange-db
+      - DATABASE_USER=postgres
+      - REDIS_URL=redis://exchange-redis
 
-    - CI_PULL_REQUEST=$CI_PULL_REQUEST
-    - CIRCLE_PULL_REQUEST=$CIRCLE_PULL_REQUEST
-    - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
-    - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
-    - COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
-    - CI=$CI
+      - CI_PULL_REQUEST=$CI_PULL_REQUEST
+      - CIRCLE_PULL_REQUEST=$CIRCLE_PULL_REQUEST
+      - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
+      - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
+      - CI=$CI
 
     command: ./hokusai/ci.sh
     depends_on:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
-if ENV.fetch('CI', false)
-  require 'coveralls'
-  Coveralls.wear!('rails')
-end
+require 'simplecov'
+SimpleCov.start
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require 'simplecov'
-SimpleCov.start
+
+SimpleCov.start do
+  add_filter '/spec/'
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
- Replaces `coveralls` with `simplecov` gem, and updates reporting configuration
- Uploads reports after CI test runs via `codecov` orb

Coverage reports for this app available here: https://codecov.io/gh/artsy/exchange

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2072