### PR TITLE
move postgres auth env

### DIFF
--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -18,7 +18,6 @@ services:
       - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
       - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
       - CI=$CI
-      - POSTGRES_HOST_AUTH_METHOD=trust
 
     command: ./hokusai/ci.sh
     depends_on:
@@ -28,5 +27,7 @@ services:
       - "../.git:/app/.git:ro"
   exchange-db:
     image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   exchange-redis:
     image: redis:3.2-alpine


### PR DESCRIPTION
Following up on https://github.com/artsy/exchange/pull/572, which didn't actually work. Think I had it in the wrong place - was able to run `hokusai test` on this branch so 🤞this works better