### PR TITLE
convert debit return to snake case and add tests

### DIFF
--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -104,7 +104,9 @@ module Gravity
       }
     }
     response = GravityGraphql.authenticated.debit_commission_exemption(mutation_args).to_h
-    response.dig('data', 'debitCommissionExemption', 'amountOfExemptGmvOrError')
+    gmv_or_error = response.dig(:data, :debitCommissionExemption, :amountOfExemptGmvOrError)
+    # Convert hash to snake case
+    gmv_or_error.transform_keys { |key| key.to_s.underscore.to_sym }
   end
 
   def self.credit_commission_exemption(partner_id:, amount_minor:, currency_code:, reference_id:, notes:)

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -104,9 +104,13 @@ module Gravity
       }
     }
     response = GravityGraphql.authenticated.debit_commission_exemption(mutation_args).to_h
-    gmv_or_error = response.dig(:data, :debitCommissionExemption, :amountOfExemptGmvOrError)
-    # Convert hash to snake case
-    gmv_or_error.transform_keys { |key| key.to_s.underscore.to_sym }
+    gmv_or_error = response.dig('data', 'debitCommissionExemption', 'amountOfExemptGmvOrError')
+    if gmv_or_error.nil?
+      nil
+    else
+      # Convert hash to snake case
+      gmv_or_error.transform_keys { |key| key.to_s.underscore.to_sym }
+    end
   end
 
   def self.credit_commission_exemption(partner_id:, amount_minor:, currency_code:, reference_id:, notes:)

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -126,7 +126,8 @@ class OrderProcessor
                                                                          currency_code: order.currency_code,
                                                                          reference_id: order.id,
                                                                          notes: notes)
-    apply_commission_exemption(gmv_to_exempt_and_currency_code[:amount_minor])
+    response_is_valid = !gmv_to_exempt_and_currency_code.nil? && gmv_to_exempt_and_currency_code.key?(:amount_minor)
+    apply_commission_exemption(gmv_to_exempt_and_currency_code[:amount_minor]) if response_is_valid
   rescue GravityGraphql::GraphQLError
     Rails.logger.error("Could not execute Gravity GraphQL query for order #{order.id}")
     nil

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -214,7 +214,11 @@ describe Gravity, type: :services do
 
   describe '#debit_commission_exemption' do
     let(:parameters) { { partner_id: seller_id, amount_minor: 100, currency_code: 'USD', reference_id: 'order123', notes: 'hi' } }
-    # Full response looks like: #<GraphQL::Client::Response:0x00007fbad5a3f650 @original_hash={"data"=>{"debitCommissionExemption"=>{"amountOfExemptGmvOrError"=>{"__typename"=>"Money", "amountMinor"=>490, "currencyCode"=>"USD"}}}}, @data=#< debitCommissionExemption=...>, @errors=#<GraphQL::Client::Errors @messages={} @details={}>, @extensions=nil> }
+    # Full response looks like:
+    # #<GraphQL::Client::Response:0x00007fbad5a3f650
+    # @original_hash={"data"=>{"debitCommissionExemption"=>{"amountOfExemptGmvOrError"=>{"__typename"=>"Money", "amountMinor"=>490, "currencyCode"=>"USD"}}}},
+    # @data=#< debitCommissionExemption=...>,
+    # @errors=#<GraphQL::Client::Errors @messages={} @details={}>, @extensions=nil> }
     let(:response) { { 'data' => { 'debitCommissionExemption' => { 'amountOfExemptGmvOrError' => { 'fooBar' => 'baz' } } } } }
     it 'returns snake-cased amountOfExemptGmvOrError if it is included in the response body' do
       allow(GravityGraphql).to receive_message_chain(:authenticated, :debit_commission_exemption).and_return(response)

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -214,11 +214,6 @@ describe Gravity, type: :services do
 
   describe '#debit_commission_exemption' do
     let(:parameters) { { partner_id: seller_id, amount_minor: 100, currency_code: 'USD', reference_id: 'order123', notes: 'hi' } }
-    # Full response looks like:
-    # #<GraphQL::Client::Response:0x00007fbad5a3f650
-    # @original_hash={"data"=>{"debitCommissionExemption"=>{"amountOfExemptGmvOrError"=>{"__typename"=>"Money", "amountMinor"=>490, "currencyCode"=>"USD"}}}},
-    # @data=#< debitCommissionExemption=...>,
-    # @errors=#<GraphQL::Client::Errors @messages={} @details={}>, @extensions=nil> }
     let(:response) { { 'data' => { 'debitCommissionExemption' => { 'amountOfExemptGmvOrError' => { 'fooBar' => 'baz' } } } } }
     it 'returns snake-cased amountOfExemptGmvOrError if it is included in the response body' do
       allow(GravityGraphql).to receive_message_chain(:authenticated, :debit_commission_exemption).and_return(response)

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -211,4 +211,22 @@ describe Gravity, type: :services do
       expect(response.length).to eq 0
     end
   end
+
+  describe '#debit_commission_exemption' do
+    let(:parameters) { { partner_id: seller_id, amount_minor: 100, currency_code: 'USD', reference_id: 'order123', notes: 'hi' } }
+    let(:debit_response_success) { { data: { debitCommissionExemption: { amountOfExemptGmvOrError: { amountMinor: 10, currencyCode: 'USD' } } } } }
+    let(:debit_response_error) { { data: { debitCommissionExemption: { amountOfExemptGmvOrError: { message: 'Amount must be positive', code: 'negative_amount' } } } } }
+    it 'returns a snake-cased hash on successful execution' do
+      allow(GravityGraphql).to receive_message_chain(:authenticated, :debit_commission_exemption).and_return(debit_response_success)
+      return_value = Gravity.debit_commission_exemption(parameters)
+      expect(return_value).to eq(amount_minor: 10, currency_code: 'USD')
+    end
+
+    it 'returns a snake-cased hash on error' do
+      parameters[:amount_minor] = -100
+      allow(GravityGraphql).to receive_message_chain(:authenticated, :debit_commission_exemption).and_return(debit_response_error)
+      return_value = Gravity.debit_commission_exemption(parameters)
+      expect(return_value).to eq(message: 'Amount must be positive', code: 'negative_amount')
+    end
+  end
 end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -450,33 +450,29 @@ describe OrderProcessor, type: :services do
       order_processor.set_totals!
     end
     context 'on success' do
-      it 'calls apply_commission_exemption' do
+      it 'calls apply_commission_exemption if result has amount_minor' do
         allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 10_00)
         expect(order_processor).to receive(:apply_commission_exemption).with(10_00)
         order_processor.debit_commission_exemption
       end
-    end
 
-    context 'on error' do
-      it 'does not alter commission' do
-        allow(Gravity).to receive(:debit_commission_exemption).and_raise(GravityGraphql::GraphQLError)
-        expect(Rails.logger).to receive(:error).with("Could not execute Gravity GraphQL query for order #{order.id}")
-        order_processor.debit_commission_exemption
-        expect(order_processor.instance_variable_get(:@exempted_commission)).to be false
-        expect(order.commission_fee_cents).to eq 800_00
-      end
-    end
-
-    context 'with successful query but return other than amount_minor from Gravity.debit_commission_exemption' do
-      it 'does not call apply_commission_exemption' do
+      it 'does not call apply_commission_exemption if result is missing amount_minor' do
         allow(Gravity).to receive(:debit_commission_exemption).and_return(foo: 'bar')
         expect(order_processor).not_to receive(:apply_commission_exemption)
         order_processor.debit_commission_exemption
       end
     end
 
-    context 'with nil return from Gravity.debit_commission_exemption' do
-      it 'does not call apply_commission_exemption' do
+    context 'failure' do
+      it 'does not call apply_commission when error is raised' do
+        allow(Gravity).to receive(:debit_commission_exemption).and_raise(GravityGraphql::GraphQLError)
+        expect(Rails.logger).to receive(:error).with("Could not execute Gravity GraphQL query for order #{order.id}")
+        order_processor.debit_commission_exemption
+        expect(order_processor.instance_variable_get(:@exempted_commission)).to be false
+        expect(order.commission_fee_cents).to eq 800_00
+      end
+
+      it 'does not call apply_commission_exemption when response is nil' do
         allow(Gravity).to receive(:debit_commission_exemption).and_return(nil)
         expect(order_processor).not_to receive(:apply_commission_exemption)
         order_processor.debit_commission_exemption


### PR DESCRIPTION
Fixing a couple issues that popped up while QAing commission exemption. First, our `dig` statement was always returning `nil` because we were using strings instead of symbols, and second, the object we were trying to return would have had camelCased keys (in `order_processor.rb` we [expect snake_case](https://github.com/artsy/exchange/blob/a22bddbb521c81cf9b3d2d4af42046acb6a1fd53/lib/order_processor.rb#L129)).