### PR TITLE
Credit a Partner's Commission Exemption When an Order Is Refunded (GALL-2588)

### DIFF
--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -122,7 +122,7 @@ module Gravity
         notes: notes
       }
     }
-    response = GravityGraphql.authenticated.credit_commission_exemption(mutation_args).to_h
-    response.dig('data', 'creditCommissionExemption')
+    GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
+    nil
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -123,6 +123,9 @@ module Gravity
       }
     }
     GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
+  rescue
+    Rails.logger.error("Could not credit commission exemption for order #{reference_id}")
+  ensure
     nil
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -122,10 +122,11 @@ module Gravity
         notes: notes
       }
     }
-    GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
-  rescue GravityGraphql::GraphQLError
-    Rails.logger.error("Could not credit commission exemption for order #{reference_id}")
-  ensure
+    begin
+      GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
+    rescue GravityGraphql::GraphQLError => e
+      Rails.logger.error("Could not credit commission exemption for order #{reference_id}: #{e.message}")
+    end
     nil
   end
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -123,7 +123,7 @@ module Gravity
       }
     }
     GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
-  rescue
+  rescue GravityGraphql::GraphQLError
     Rails.logger.error("Could not credit commission exemption for order #{reference_id}")
   ensure
     nil

--- a/lib/order_cancelation_processor.rb
+++ b/lib/order_cancelation_processor.rb
@@ -19,6 +19,9 @@ class OrderCancelationProcessor
     transaction = @payment_service.refund
     @order.transactions << transaction
     raise Errors::ProcessingError.new(:refund_failed, transaction.failure_data) if transaction.failed?
+
+    # Only credit commission exemption for refunds, cancelations never deducted from commission exemption total
+    Gravity.credit_commission_exemption(partner_id: @order.seller_id, amount_minor: @order.items_total_cents, currency_code: @order.currency_code, reference_id: @order.id, notes: 'refund')
   end
 
   def cancel_payment

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -144,6 +144,7 @@ class OrderProcessor
   end
 
   def revert_debit_exemption(reversion_reason)
-    Gravity.credit_commission_exemption(partner_id: order.seller_id, amount_minor: order.items_total_cents, currency_code: order.currency_code, reference_id: order.id, notes: reversion_reason) if @exempted_commission
+    Gravity.credit_commission_exemption(partner_id: order.seller_id, amount_minor: order.items_total_cents, currency_code: order.currency_code, reference_id: order.id, notes: reversion_reason)
+    @exempted_commission = false
   end
 end

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -227,4 +227,13 @@ describe Gravity, type: :services do
       expect(return_value).to be nil
     end
   end
+
+  describe '#credit_commission_exemption' do
+    it 'requests the credit commission exemption mutation and returns nil' do
+      mutation = stub_request(:post, Rails.application.config_for(:graphql)[:gravity_graphql][:url]).to_return(status: 200, body: { foo: { bar: 'baz' } }.to_json)
+      retval = Gravity.credit_commission_exemption(partner_id: seller_id, amount_minor: 100, currency_code: 'USD', reference_id: 'order123', notes: 'hi')
+      expect(mutation).to have_been_requested
+      expect(retval).to be nil
+    end
+  end
 end

--- a/spec/lib/order_cancellation_processor_spec.rb
+++ b/spec/lib/order_cancellation_processor_spec.rb
@@ -28,6 +28,7 @@ describe OrderCancelationProcessor, type: :services do
     end
 
     it 'refunds the payment and stores transaction' do
+      stub_request(:post, Rails.application.config_for(:graphql)[:gravity_graphql][:url]).to_return(status: 200, body: '{}', headers: {})
       prepare_payment_intent_refund_success
       expect { processor.refund_payment }.to change(order.transactions, :count).by(1)
       transaction = order.transactions.order(created_at: :desc).first

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -158,6 +158,7 @@ describe OrderProcessor, type: :services do
 
       expect(Gravity).to receive(:credit_commission_exemption).with(partner_id: order.seller_id, amount_minor: order.items_total_cents, currency_code: order.currency_code, reference_id: order.id, notes: 'insufficient_inventory')
       order_processor.revert!('insufficient_inventory')
+      expect(order_processor.instance_variable_get(:@exempted_commission)).to eq false
     end
   end
 

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -499,6 +499,7 @@ describe OrderService, type: :services do
     [Order::APPROVED, Order::FULFILLED].each do |state|
       before do
         Fabricate(:transaction, order: order, external_id: 'pi_1', external_type: Transaction::PAYMENT_INTENT)
+        stub_request(:post, Rails.application.config_for(:graphql)[:gravity_graphql][:url]).to_return(status: 200, body: '{}', headers: {})
       end
       context "#{state} order" do
         let(:state) { state }

--- a/spec/system/visiting_order_details_spec.rb
+++ b/spec/system/visiting_order_details_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'visit order details', type: :system do
   let!(:order) { Fabricate(:order) }
   before do
-    stub_request(:get, "http://exchange-test-gravity.biz/user/#{order.buyer_id}")
+    stub_request(:get, "#{Rails.application.config_for(:gravity)[:api_v1_root]}/user/#{order.buyer_id}")
       .to_return(status: 200, body: {}.to_json, headers: {})
 
-    stub_request(:get, "http://exchange-test-gravity.biz/partner/#{order.seller_id}/all")
+    stub_request(:get, "#{Rails.application.config_for(:gravity)[:api_v1_root]}/partner/#{order.seller_id}/all")
       .to_return(status: 200, body: {}.to_json, headers: {})
   end
 


### PR DESCRIPTION
This PR updates Exchange to request a credit to a partner's commission exemption balance in Gravity when an order is refunded in the admin UI.

This work was started in #571. Instead of rebasing that feature branch on master after #564 was merged, I decided to open a new feature branch and manually port over the relevant changes to the refund flow, since there were too many merge conflicts.