### PR TITLE
Commission exemption: offers [GALL-2589]

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -59,6 +59,9 @@ module OfferService
 
     # this is an off-session if offer is from buyer and seller is accepting it (in case of failed payment buyer could accept their own offer)
     off_session = offer.from_participant == Order::BUYER && user_id != order.buyer_id
+
+    order_processor.debit_commission_exemption
+
     order_processor.charge(off_session)
     order_processor.store_transaction(off_session)
     raise Errors::FailedTransactionError.new(:capture_failed, order_processor.transaction) if order_processor.failed_payment?

--- a/lib/offer_order_totals.rb
+++ b/lib/offer_order_totals.rb
@@ -8,9 +8,10 @@ class OfferOrderTotals
   delegate :tax_total_cents, to: :offer
   delegate :buyer_total_cents, to: :offer
 
-  def initialize(offer)
+  def initialize(offer, commission_exemption_amount_cents: nil)
     @offer = offer
     @order = offer.order
+    @commission_exemption_amount_cents = commission_exemption_amount_cents
   end
 
   def items_total_cents
@@ -22,7 +23,7 @@ class OfferOrderTotals
   end
 
   def commission_fee_cents
-    @commission_fee_cents ||= commission_rate * offer.amount_cents
+    @commission_fee_cents ||= calculate_commission_fee_cents
   end
 
   def transaction_fee_cents
@@ -39,5 +40,13 @@ class OfferOrderTotals
 
   def calculate_remittable_sales_tax
     @offer.should_remit_sales_tax? ? @offer.tax_total_cents : 0
+  end
+
+  def calculate_commission_fee_cents
+    if @commission_exemption_amount_cents.nil? || !@commission_exemption_amount_cents.positive?
+      commission_rate * offer.amount_cents
+    else
+      commission_rate * (offer.amount_cents - @commission_exemption_amount_cents)
+    end
   end
 end

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -126,7 +126,7 @@ class OrderProcessor
                                                                          currency_code: order.currency_code,
                                                                          reference_id: order.id,
                                                                          notes: notes)
-    return if gmv_to_exempt_and_currency_code.nil? || !gmv_to_exempt_and_currency_code.key?(:amount_minor)
+    return if gmv_to_exempt_and_currency_code.nil? || !gmv_to_exempt_and_currency_code.key?(:amount_minor) || gmv_to_exempt_and_currency_code[:amount_minor].zero?
 
     @exempted_commission = true
     apply_commission_exemption(gmv_to_exempt_and_currency_code[:amount_minor])

--- a/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/fix_failed_payment_mutation_request_spec.rb
@@ -96,6 +96,7 @@ describe Api::GraphqlController, type: :request do
       }
     end
     before(:each) do
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       order.transactions << transaction
       order.update!(last_offer: offer, buyer_total_cents: offer.buyer_total_cents, shipping_total_cents: offer.shipping_total_cents)
     end

--- a/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/buyer_accept_offer_mutation_request_spec.rb
@@ -161,6 +161,7 @@ describe Api::GraphqlController, type: :request do
         before do
           undeduct_inventory_request
           prepare_payment_intent_create_failure(status: 'requires_payment_method', charge_error: { code: 'card_declined', decline_code: 'do_not_honor', message: 'The card was declined' })
+          allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
         end
 
         it 'raises processing error' do
@@ -185,6 +186,7 @@ describe Api::GraphqlController, type: :request do
 
       it 'approves the order' do
         prepare_payment_intent_create_success(amount: 20_00)
+        allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
         response = client.execute(mutation, buyer_accept_offer_input)
         expect(deduct_inventory_request).to have_been_requested
 

--- a/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/seller_accept_offer_mutation_request_spec.rb
@@ -80,6 +80,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     before do
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       order.update!(last_offer: offer, buyer_total_cents: offer.buyer_total_cents, shipping_total_cents: offer.shipping_total_cents)
     end
 

--- a/spec/integration/buy_now_commission_exemption_happy_path_spec.rb
+++ b/spec/integration/buy_now_commission_exemption_happy_path_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'include stripe helper'
+  include_context 'GraphQL Client Helpers'
+  describe 'buy now happy path' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'USD', amount_minor: 100_00 } }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
+      )
+      prepare_payment_intent_create_success(amount: 1300_00)
+      prepare_payment_intent_capture_success(amount: 1300_00)
+    end
+
+    it 'succeeds the process of buyer create -> set shipping -> set payment -> submit -> seller accept' do
+      # Buyer creates the order
+      expect do
+        buyer_client.execute(QueryHelper::CREATE_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, items_total_cents: 1000_00, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US'
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits order
+      expect do
+        buyer_client.execute(QueryHelper::SUBMIT_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 1300_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 100_00
+      )
+      expect(order.transactions.last).to have_attributes(
+        transaction_type: Transaction::HOLD,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS,
+        source_id: 'cc_1'
+      )
+
+      # seller accepts order
+      expect do
+        seller_client.execute(QueryHelper::APPROVE_ORDER, input: { id: order.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 1000_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 1300_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 90_00,
+        transaction_fee_cents: 38_00,
+        seller_total_cents: 1172_00,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 1300_00,
+        status: Transaction::SUCCESS
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/buy_now_sca_path.rb
+++ b/spec/integration/buy_now_sca_path.rb
@@ -27,6 +27,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'USD', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -37,7 +38,8 @@ describe Api::GraphqlController, type: :request do
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
         undeduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
     end
 

--- a/spec/integration/gbp/buy_now_happy_path_spec.rb
+++ b/spec/integration/gbp/buy_now_happy_path_spec.rb
@@ -31,6 +31,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'GBP', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -40,7 +41,8 @@ describe Api::GraphqlController, type: :request do
         fetch_partner: gravity_partner,
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
       prepare_payment_intent_create_success(amount: 1200_00)
       prepare_payment_intent_capture_success(amount: 1200_00)
@@ -105,7 +107,6 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts order
-      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(QueryHelper::APPROVE_ORDER, input: { id: order.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -31,6 +31,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'GBP', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -40,7 +41,8 @@ describe Api::GraphqlController, type: :request do
         fetch_partner: gravity_partner,
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
       prepare_setup_intent_create(status: 'succeeded')
       prepare_payment_intent_create_success(amount: 700_00)
@@ -119,7 +121,6 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
-      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/gbp/make_offer_happy_path_spec.rb
+++ b/spec/integration/gbp/make_offer_happy_path_spec.rb
@@ -119,6 +119,7 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
@@ -31,6 +31,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'GBP', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -40,7 +41,8 @@ describe Api::GraphqlController, type: :request do
         fetch_partner: gravity_partner,
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
       prepare_payment_intent_create_success(amount: 900_00)
       prepare_setup_intent_create(status: 'succeeded')
@@ -101,7 +103,6 @@ describe Api::GraphqlController, type: :request do
       expect(seller_counter.submitted_at).to_not be_nil
 
       # Buyer accepts offer
-      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         buyer_client.execute(OfferQueryHelper::BUYER_ACCEPT_OFFER, input: { offerId: seller_counter.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/gbp/single_counteroffer_happy_path_spec.rb
@@ -101,6 +101,7 @@ describe Api::GraphqlController, type: :request do
       expect(seller_counter.submitted_at).to_not be_nil
 
       # Buyer accepts offer
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         buyer_client.execute(OfferQueryHelper::BUYER_ACCEPT_OFFER, input: { offerId: seller_counter.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/make_offer_commission_exemption_happy_path_spec.rb
+++ b/spec/integration/make_offer_commission_exemption_happy_path_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+require 'support/taxjar_helper'
+
+describe Api::GraphqlController, type: :request do
+  include_context 'include stripe helper'
+  include_context 'GraphQL Client Helpers'
+  describe 'make offer happy path with commission exemption' do
+    let(:seller_id) { 'gravity-partner-id' }
+    let(:buyer_id) { 'user-id1' }
+    let(:buyer_shipping_address) do
+      {
+        name: 'Fname Lname',
+        country: 'US',
+        city: 'New York',
+        region: 'NY',
+        postalCode: '10012',
+        phoneNumber: '617-718-7818',
+        addressLine1: '401 Broadway',
+        addressLine2: 'Suite 80'
+      }
+    end
+    let(:buyer_credit_card) { { id: 'cc-1', user: { _id: buyer_id }, external_id: 'cc_1', customer_account: { external_id: 'ca_1' } } }
+    let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+    let(:gravity_partner) { { id: seller_id, artsy_collects_sales_tax: true, billing_location_id: '123abc', effective_commission_rate: 0.1 } }
+    let(:seller_addresses) { [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')] }
+    let(:seller_merchant_account) { { external_id: 'ma-1' } }
+    let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
+    let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'USD', amount_minor: 100_00 } }
+
+    before do
+      stub_tax_for_order(tax_amount: 100)
+      allow(Gravity).to receive_messages(
+        get_artwork: gravity_artwork,
+        fetch_partner_locations: seller_addresses,
+        fetch_partner: gravity_partner,
+        get_credit_card: buyer_credit_card,
+        deduct_inventory: nil,
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
+      )
+      prepare_setup_intent_create(status: 'succeeded')
+      prepare_payment_intent_create_success(amount: 800_00)
+      prepare_setup_intent_create(status: 'succeeded')
+    end
+
+    it 'succeeds the process of buyer create -> add initial offer -> set shipping -> set payment -> submit -> seller accepts' do
+      # Buyer creates the offer order
+      expect do
+        buyer_client.execute(OfferQueryHelper::CREATE_OFFER_ORDER, input: { artworkId: gravity_artwork[:_id], quantity: 1 })
+      end.to change(Order, :count).by(1)
+      order = Order.last
+      expect(order).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+
+      # adds initial offer to order
+      expect do
+        buyer_client.execute(OfferQueryHelper::ADD_OFFER_TO_ORDER, input: { orderId: order.id, amountCents: 500_00 })
+      end.to change(Offer, :count).by(1)
+      offer = Offer.last
+      expect(order.reload).to have_attributes(state: Order::PENDING, mode: Order::OFFER, shipping_total_cents: nil, buyer_total_cents: nil, tax_total_cents: nil)
+      expect(offer.amount_cents).to eq 500_00
+      expect(offer.order_id).to eq order.id
+
+      # Buyer sets shipping info
+      buyer_client.execute(QueryHelper::SET_SHIPPING, input: { id: order.id.to_s, fulfillmentType: 'SHIP', shipping: buyer_shipping_address })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        items_total_cents: nil,
+        shipping_total_cents: nil,
+        tax_total_cents: nil,
+        buyer_total_cents: nil,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        shipping_city: 'New York',
+        shipping_address_line1: '401 Broadway',
+        shipping_address_line2: 'Suite 80',
+        shipping_postal_code: '10012'
+      )
+
+      expect(offer.reload).to have_attributes(
+        amount_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00
+      )
+
+      # Buyer sets credit card
+      buyer_client.execute(QueryHelper::SET_CREDIT_CARD, input: { id: order.id.to_s, creditCardId: buyer_credit_card[:id] })
+      expect(order.reload).to have_attributes(
+        state: Order::PENDING,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1'
+      )
+
+      # Buyer submits offer order
+      expect do
+        buyer_client.execute(OfferQueryHelper::SUBMIT_ORDER_WITH_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, status: Transaction::SUCCESS, transaction_type: Transaction::CONFIRM)
+      expect(order.reload).to have_attributes(
+        state: Order::SUBMITTED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        tax_total_cents: 100_00,
+        buyer_total_cents: 800_00,
+        seller_total_cents: 726_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        commission_fee_cents: 50_00
+      )
+
+      # seller accepts offer
+      expect do
+        seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
+      end.to change(order.transactions, :count).by(1)
+      expect(order.reload).to have_attributes(
+        state: Order::APPROVED,
+        items_total_cents: 500_00,
+        shipping_total_cents: 200_00,
+        buyer_total_cents: 800_00,
+        tax_total_cents: 100_00,
+        commission_fee_cents: 40_00,
+        transaction_fee_cents: 23_50,
+        seller_total_cents: 736_50,
+        fulfillment_type: Order::SHIP,
+        shipping_country: 'US',
+        credit_card_id: 'cc-1',
+        external_charge_id: 'pi_1'
+      )
+      expect(order.transactions.order(created_at: :desc).first).to have_attributes(
+        transaction_type: Transaction::CAPTURE,
+        amount_cents: 800_00,
+        status: Transaction::SUCCESS
+      )
+
+      # seller fulfills order
+      expect do
+        seller_client.execute(QueryHelper::FULFILL_ORDER, input:
+          {
+            id: order.id.to_s,
+            fulfillment: {
+              courier: 'fedex',
+              trackingId: 'fedex-123',
+              estimatedDelivery: '2018-12-15'
+            }
+          })
+      end.to change(order.line_items.first.fulfillments, :count).by(1)
+      expect(order.reload).to have_attributes(state: Order::FULFILLED)
+      expect(order.line_items.first.fulfillments.first).to have_attributes(courier: 'fedex', tracking_id: 'fedex-123', estimated_delivery: Date.strptime('2018-12-15', '%Y-%m-%d'))
+    end
+  end
+end

--- a/spec/integration/make_offer_happy_path_spec.rb
+++ b/spec/integration/make_offer_happy_path_spec.rb
@@ -111,6 +111,7 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/make_offer_happy_path_spec.rb
+++ b/spec/integration/make_offer_happy_path_spec.rb
@@ -27,6 +27,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'USD', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -36,7 +37,8 @@ describe Api::GraphqlController, type: :request do
         fetch_partner: gravity_partner,
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
       prepare_setup_intent_create(status: 'succeeded')
       prepare_payment_intent_create_success(amount: 800_00)
@@ -111,7 +113,6 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
-      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/make_offer_sca_happy_path_spec.rb
+++ b/spec/integration/make_offer_sca_happy_path_spec.rb
@@ -27,6 +27,7 @@ describe Api::GraphqlController, type: :request do
     let(:seller_merchant_account) { { external_id: 'ma-1' } }
     let(:buyer_client) { graphql_client(user_id: buyer_id, partner_ids: [], roles: 'user') }
     let(:seller_client) { graphql_client(user_id: 'partner_admin_id', partner_ids: [seller_id], roles: 'user') }
+    let(:exemption) { { currency_code: 'USD', amount_minor: 0 } }
 
     before do
       stub_tax_for_order(tax_amount: 100)
@@ -36,7 +37,8 @@ describe Api::GraphqlController, type: :request do
         fetch_partner: gravity_partner,
         get_credit_card: buyer_credit_card,
         deduct_inventory: nil,
-        get_merchant_account: seller_merchant_account
+        get_merchant_account: seller_merchant_account,
+        debit_commission_exemption: exemption
       )
       prepare_setup_intent_create(status: 'succeeded')
       prepare_payment_intent_create_success(amount: 800_00)
@@ -128,7 +130,6 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
-      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/make_offer_sca_happy_path_spec.rb
+++ b/spec/integration/make_offer_sca_happy_path_spec.rb
@@ -128,6 +128,7 @@ describe Api::GraphqlController, type: :request do
       )
 
       # seller accepts offer
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         seller_client.execute(OfferQueryHelper::SELLER_ACCEPT_OFFER, input: { offerId: offer.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/integration/single_counteroffer_happy_path_spec.rb
+++ b/spec/integration/single_counteroffer_happy_path_spec.rb
@@ -96,6 +96,7 @@ describe Api::GraphqlController, type: :request do
       expect(seller_counter.submitted_at).to_not be_nil
 
       # Buyer accepts offer
+      allow(Gravity).to receive(:debit_commission_exemption).and_return(currency_code: 'USD', amount_minor: 0)
       expect do
         buyer_client.execute(OfferQueryHelper::BUYER_ACCEPT_OFFER, input: { offerId: seller_counter.id.to_s })
       end.to change(order.transactions, :count).by(1)

--- a/spec/lib/buy_order_totals_spec.rb
+++ b/spec/lib/buy_order_totals_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe BuyOrderTotals do
+  let(:fulfillment_type) { Order::PICKUP }
+  let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+  let(:order) { Fabricate(:order, seller_id: 'partner-1', seller_type: 'gallery', buyer_id: 'buyer1', buyer_type: Order::USER, fulfillment_type: fulfillment_type, commission_rate: 0.8) }
+  let!(:line_item1) { Fabricate(:line_item, order: order, quantity: 1, list_price_cents: 1000_00, artwork_id: 'a-1', artwork_version_id: '1', sales_tax_cents: 0, shipping_total_cents: 0, commission_fee_cents: 800_00) }
+  let(:line_item2) { Fabricate(:line_item, order: order, quantity: 1, list_price_cents: 2000_00, artwork_id: 'a-3', artwork_version_id: '1', sales_tax_cents: 0, shipping_total_cents: 0, commission_fee_cents: 1600_00) }
+
+  before do
+    allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(gravity_artwork)
+    allow(Adapters::GravityV1).to receive(:get).with('/partner/partner-1/all').and_return(gravity_v1_partner)
+  end
+
+  describe 'commission_fee_cents' do
+    context 'with single line item' do
+      context 'no exemption' do
+        it 'returns commission from order' do
+          buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: nil)
+          # Commission rate: 80%, price: 1000, commission: .8 x 1000 = 800
+          expect(buy_order_totals.commission_fee_cents).to eq 800_00
+        end
+      end
+
+      context 'exemption is 0' do
+        it 'returns commission from order' do
+          buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 0)
+          # Commission rate: 80%, price: 1000, commission: .8 x 1000 = 800
+          expect(buy_order_totals.commission_fee_cents).to eq 800_00
+        end
+      end
+
+      context 'exemption is > 0' do
+        context 'exemption is < line item price' do
+          it 'returns commission with partial exemption' do
+            buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 100_00)
+            # Commission rate: 80%, price: 1000, exemption: 100, commission: .8 x (1000 - 100) = 720
+            expect(buy_order_totals.commission_fee_cents).to eq 720_00
+          end
+        end
+
+        context 'exemption is > line item price' do
+          it 'returns 0 commission' do
+            buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 2000_00)
+            # Commission rate: 80%, price: 1000, exemption: 1000, commission: .8 x (1000 - 1000) = 0
+            expect(buy_order_totals.commission_fee_cents).to eq 0
+          end
+        end
+      end
+    end
+
+    context 'with multiple line items' do
+      before do
+        line_item2
+      end
+      context 'no exemption' do
+        it 'returns commission from order' do
+          buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: nil)
+          # Commission rate: 80%, price: 3000, commission: .8 x 3000 = 2400
+          expect(buy_order_totals.commission_fee_cents).to eq 2400_00
+        end
+      end
+
+      context 'exemption is 0' do
+        it 'returns commission from order' do
+          buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 0)
+          # Commission rate: 80%, price: 3000, commission: .8 x 3000 = 2400
+          expect(buy_order_totals.commission_fee_cents).to eq 2400_00
+        end
+      end
+
+      context 'exemption is > 0' do
+        context 'with commission exemption larger than any individual line item' do
+          it 'updates commission on order totals' do
+            buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 1500_00)
+            # Commission rate: 80%, price: 3000, exemption: 1500, commission: .8 x (3000 - 1500) = 1200
+            expect(buy_order_totals.commission_fee_cents).to eq 1200_00
+          end
+        end
+        context 'with commission exmeption smaller than any individual line item' do
+          it 'updates commission on order totals' do
+            buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 100_00)
+            # Commission rate: 80%, price: 3000, exemption: 100, commission: .8 x (3000 - 100) = 2320
+            expect(buy_order_totals.commission_fee_cents).to eq 2320_00
+          end
+        end
+        context 'with commission exemption equal to the total of all line items' do
+          it 'updates commission on order totals' do
+            buy_order_totals = BuyOrderTotals.new(order, commission_exemption_amount_cents: 3000_00)
+            # Commission rate: 80%, price: 3000, exemption: 3000, commission: .8 x (3000 - 3000) = 0
+            expect(buy_order_totals.commission_fee_cents).to eq 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/offer_order_totals_spec.rb
+++ b/spec/lib/offer_order_totals_spec.rb
@@ -2,12 +2,8 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe OfferOrderTotals do
-  let(:partner) { { effective_commission_rate: 0.1 } }
   let(:fulfillment_type) { Order::PICKUP }
   let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
-  let(:shipping_address) { nil }
-  let(:seller_locations) { [] }
-  let(:artsy_collects_sales_tax) { true }
   let(:order) { Fabricate(:order, seller_id: 'partner-1', seller_type: 'gallery', buyer_id: 'buyer1', buyer_type: Order::USER, fulfillment_type: fulfillment_type) }
   let(:offer) { Fabricate(:offer, order: order, from_id: 'partner-1', from_type: 'gallery', amount_cents: 800_00, shipping_total_cents: 0, tax_total_cents: 300_00) }
   let(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'a-1') }

--- a/spec/lib/offer_order_totals_spec.rb
+++ b/spec/lib/offer_order_totals_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe OfferOrderTotals do
+  let(:partner) { { effective_commission_rate: 0.1 } }
+  let(:fulfillment_type) { Order::PICKUP }
+  let(:gravity_artwork) { gravity_v1_artwork(_id: 'a-1', price_listed: 1000.00, edition_sets: [], domestic_shipping_fee_cents: 200_00, international_shipping_fee_cents: 300_00) }
+  let(:shipping_address) { nil }
+  let(:seller_locations) { [] }
+  let(:artsy_collects_sales_tax) { true }
+  let(:order) { Fabricate(:order, seller_id: 'partner-1', seller_type: 'gallery', buyer_id: 'buyer1', buyer_type: Order::USER, fulfillment_type: fulfillment_type) }
+  let(:offer) { Fabricate(:offer, order: order, from_id: 'partner-1', from_type: 'gallery', amount_cents: 800_00, shipping_total_cents: 0, tax_total_cents: 300_00) }
+  let(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'a-1') }
+
+  before do
+    allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(gravity_artwork)
+    allow(Adapters::GravityV1).to receive(:get).with('/partner/partner-1/all').and_return(gravity_v1_partner)
+  end
+
+  describe 'commission_fee_cents' do
+    context 'no exemption' do
+      it 'returns commission based on offer and commission rate' do
+        offer_order_totals = OfferOrderTotals.new(offer, commission_exemption_amount_cents: nil)
+        # Commission rate: 80%, offer: 800, commission: .8 x 800 = 640
+        expect(offer_order_totals.commission_fee_cents).to eq 640_00
+      end
+    end
+
+    context 'exemption is 0' do
+      it 'returns commission based on offer and commission rate' do
+        offer_order_totals = OfferOrderTotals.new(offer, commission_exemption_amount_cents: 0)
+        # Commission rate: 80%, offer: 800, commission: .8 x 800 = 640
+        expect(offer_order_totals.commission_fee_cents).to eq 640_00
+      end
+    end
+
+    context 'exemption is > 0' do
+      it 'returns commission including exemption' do
+        offer_order_totals = OfferOrderTotals.new(offer, commission_exemption_amount_cents: 100_00)
+        # Commission rate: 80%, offer: 800, exemption: 100, commission: .8 x (800 - 100) = 560
+        expect(offer_order_totals.commission_fee_cents).to eq 560_00
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR continues the work started in https://github.com/artsy/exchange/pull/564, adding code that checks for exemptions when an offer is approved. 

With help from @ashkan18, I also moved the logic for calculating exemption to the `[Buy/Offer]OrderTotals` classes. We realized that it made much more sense for the logic determining the final commission after exemption to live with the logic that was responsible for setting commission amounts in general. Plus, this keeps the `order_processor` nice n' streamlined.

This PR also adds simple integration tests for both order and offer - just working on covering our bases here.

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-2589)