### PR TITLE
GALL-2637 Add eu country codes and check for that when calculating shipping

### DIFF
--- a/lib/address.rb
+++ b/lib/address.rb
@@ -1,6 +1,11 @@
 class Address
   attr_reader :country, :region, :city, :street_line1, :street_line2, :postal_code
   UNITED_STATES = Carmen::Country.coded('US')
+  COUNTRY_CODES_EU_SHIPPING = %w[AT BE CH DE DK EE ES FI FR GR IE IT LV LT LU NL PL PT SK SI SE].freeze
+  # Not sure why we need this Carmen gem, but to keep with the pattern,
+  # let's run the list of country codes through that and convert to set
+  COUNTRY_CODES_EU_SHIPPING_SET = COUNTRY_CODES_EU_SHIPPING.map { |country| Carmen::Country.coded(country)&.code }.compact.to_set
+
   def initialize(address)
     @address = parse(address)
     @country = @address[:country]
@@ -29,6 +34,10 @@ class Address
     united_states? &&
       @region != UNITED_STATES.subregions.coded('HI').code &&
       @region != UNITED_STATES.subregions.coded('AK').code
+  end
+
+  def eu_local_shipping?
+    COUNTRY_CODES_EU_SHIPPING_SET.include? @country
   end
 
   private

--- a/lib/address.rb
+++ b/lib/address.rb
@@ -1,10 +1,13 @@
 class Address
   attr_reader :country, :region, :city, :street_line1, :street_line2, :postal_code
   UNITED_STATES = Carmen::Country.coded('US')
-  COUNTRY_CODES_EU_SHIPPING = %w[AT BE CH DE DK EE ES FI FR GR IE IT LV LT LU NL PL PT SK SI SE].freeze
-  # Not sure why we need this Carmen gem, but to keep with the pattern,
-  # let's run the list of country codes through that and convert to set
-  COUNTRY_CODES_EU_SHIPPING_SET = COUNTRY_CODES_EU_SHIPPING.map { |country| Carmen::Country.coded(country)&.code }.compact.to_set
+  COUNTRY_CODES_EU_SHIPPING_SET = %w[
+    AD AM AT AZ BY BE BA BG HR CY
+    CZ DK EE FI FR GE DE HU IT KZ
+    LV LI LT LU MD MC ME NL MK NO
+    PL PT RO RU SM RS SK SI ES SE
+    CH TR UA VA
+  ].map { |country_code| Carmen::Country.coded(country_code).code }.to_set
 
   def initialize(address)
     @address = parse(address)

--- a/lib/shipping_helper.rb
+++ b/lib/shipping_helper.rb
@@ -3,7 +3,7 @@ class ShippingHelper
     return 0 if fulfillment_type == Order::PICKUP
     raise Errors::ValidationError.new(:missing_artwork_location, artwork_id: artwork[:_id]) if artwork[:location].blank?
 
-    if domestic?(artwork, shipping_address)
+    if domestic?(artwork, shipping_address) || eu_local_shipping?(artwork, shipping_address)
       artwork[:domestic_shipping_fee_cents] || raise(Errors::ValidationError, :missing_domestic_shipping_fee)
     else
       artwork[:international_shipping_fee_cents] || raise(Errors::ValidationError.new(:unsupported_shipping_location, failure_code: :domestic_shipping_only))
@@ -12,5 +12,9 @@ class ShippingHelper
 
   def self.domestic?(artwork, shipping_address)
     artwork[:location][:country].casecmp(shipping_address.country).zero? && (shipping_address.country != Carmen::Country.coded('US').code || shipping_address.continental_us?)
+  end
+
+  def self.eu_local_shipping?(artwork, shipping_address)
+    artwork[:eu_shipping_origin] && shipping_address.eu_local_shipping?
   end
 end


### PR DESCRIPTION
I think this is the easiest way to add this check to this app, and it doesn't allow for bad inputs from the mutation (ie. Sending a shipping address with country 'US' and also a flag `is_eu_shipping destination`)

- [x] Add tests