### PR TITLE
Switch from using credit_... to refund_... endpoint

### DIFF
--- a/app/operations/gravity_graphql/refund_commission_exemption.graphql
+++ b/app/operations/gravity_graphql/refund_commission_exemption.graphql
@@ -1,6 +1,6 @@
-mutation($input: CreditCommissionExemptionInput!) {
-  creditCommissionExemption(input: $input) {
-    totalRemainingGmvOrError {
+mutation($input: RefundCommissionExemptionInput!) {
+  refundCommissionExemption(input: $input) {
+    gmvRefundedOrError {
       ... on Money {
         amountMinor
         currencyCode

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -113,17 +113,16 @@ module Gravity
     end
   end
 
-  def self.credit_commission_exemption(partner_id:, amount_minor:, currency_code:, reference_id:, notes:)
+  def self.refund_commission_exemption(partner_id:, reference_id:, notes:)
     mutation_args = {
       input: {
         partnerId: partner_id,
-        exemption: { amountMinor: amount_minor, currencyCode: currency_code },
         referenceId: reference_id,
         notes: notes
       }
     }
     begin
-      GravityGraphql.authenticated.credit_commission_exemption(mutation_args)
+      GravityGraphql.authenticated.refund_commission_exemption(mutation_args).to_h
     rescue GravityGraphql::GraphQLError => e
       Rails.logger.error("Could not credit commission exemption for order #{reference_id}: #{e.message}")
     end

--- a/lib/order_cancelation_processor.rb
+++ b/lib/order_cancelation_processor.rb
@@ -21,7 +21,7 @@ class OrderCancelationProcessor
     raise Errors::ProcessingError.new(:refund_failed, transaction.failure_data) if transaction.failed?
 
     # Only credit commission exemption for refunds, cancelations never deducted from commission exemption total
-    Gravity.credit_commission_exemption(partner_id: @order.seller_id, amount_minor: @order.items_total_cents, currency_code: @order.currency_code, reference_id: @order.id, notes: 'refund')
+    Gravity.refund_commission_exemption(partner_id: @order.seller_id, reference_id: @order.id, notes: 'refund')
   end
 
   def cancel_payment

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -144,7 +144,7 @@ class OrderProcessor
   end
 
   def revert_debit_exemption(reversion_reason)
-    Gravity.credit_commission_exemption(partner_id: order.seller_id, amount_minor: order.items_total_cents, currency_code: order.currency_code, reference_id: order.id, notes: reversion_reason)
+    Gravity.refund_commission_exemption(partner_id: order.seller_id, reference_id: order.id, notes: reversion_reason)
     @exempted_commission = false
   end
 end

--- a/spec/lib/gravity_spec.rb
+++ b/spec/lib/gravity_spec.rb
@@ -228,10 +228,10 @@ describe Gravity, type: :services do
     end
   end
 
-  describe '#credit_commission_exemption' do
+  describe '#refund_commission_exemption' do
     it 'requests the credit commission exemption mutation and returns nil' do
       mutation = stub_request(:post, Rails.application.config_for(:graphql)[:gravity_graphql][:url]).to_return(status: 200, body: { foo: { bar: 'baz' } }.to_json)
-      retval = Gravity.credit_commission_exemption(partner_id: seller_id, amount_minor: 100, currency_code: 'USD', reference_id: 'order123', notes: 'hi')
+      retval = Gravity.refund_commission_exemption(partner_id: seller_id, reference_id: 'order123', notes: 'hi')
       expect(mutation).to have_been_requested
       expect(retval).to be nil
     end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -156,7 +156,7 @@ describe OrderProcessor, type: :services do
       order.approve!
       order_processor.instance_variable_set(:@exempted_commission, true)
 
-      expect(Gravity).to receive(:credit_commission_exemption).with(partner_id: order.seller_id, amount_minor: order.items_total_cents, currency_code: order.currency_code, reference_id: order.id, notes: 'insufficient_inventory')
+      expect(Gravity).to receive(:refund_commission_exemption).with(partner_id: order.seller_id, reference_id: order.id, notes: 'insufficient_inventory')
       order_processor.revert!('insufficient_inventory')
       expect(order_processor.instance_variable_get(:@exempted_commission)).to eq false
     end

--- a/vendor/graphql/schema/gravity.json
+++ b/vendor/graphql/schema/gravity.json
@@ -175,6 +175,33 @@
               "deprecationReason": null
             },
             {
+              "name": "identityVerification",
+              "description": "Find an identity verification by id",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "IdentityVerification",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "matchPartners",
               "description": "Autocomplete resolvers.",
               "args": [
@@ -349,7 +376,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -361,7 +390,9 @@
             {
               "name": "artists",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -434,7 +465,9 @@
             {
               "name": "id",
               "description": "Unique ID for this work",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -450,7 +483,9 @@
             {
               "name": "medium",
               "description": "Description of the work's medium",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -462,7 +497,9 @@
             {
               "name": "slug",
               "description": "Unique, friendly identifier for this work",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -478,7 +515,9 @@
             {
               "name": "title",
               "description": "Artwork title",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -489,7 +528,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -511,7 +552,9 @@
             {
               "name": "id",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -527,7 +570,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -539,7 +584,9 @@
             {
               "name": "slug",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -554,7 +601,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -566,7 +615,9 @@
             {
               "name": "edges",
               "description": "A list of edges.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -582,7 +633,9 @@
             {
               "name": "nodes",
               "description": "A list of nodes.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -598,7 +651,9 @@
             {
               "name": "pageInfo",
               "description": "Information to aid in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -613,7 +668,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -625,7 +682,9 @@
             {
               "name": "endCursor",
               "description": "When paginating forwards, the cursor to continue.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -637,7 +696,9 @@
             {
               "name": "hasNextPage",
               "description": "When paginating forwards, are there more items?",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -653,7 +714,9 @@
             {
               "name": "hasPreviousPage",
               "description": "When paginating backwards, are there more items?",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -669,7 +732,9 @@
             {
               "name": "startCursor",
               "description": "When paginating backwards, the cursor to continue.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -680,7 +745,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -692,7 +759,9 @@
             {
               "name": "cursor",
               "description": "A cursor for use in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -708,7 +777,9 @@
             {
               "name": "node",
               "description": "The item at the end of the edge.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "Artist",
@@ -719,7 +790,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -735,13 +808,106 @@
         },
         {
           "kind": "OBJECT",
+          "name": "IdentityVerification",
+          "description": null,
+          "fields": [
+            {
+              "name": "internalID",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invitationExpiresAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "userID",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ISO8601DateTime",
+          "description": "An ISO 8601-encoded datetime",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Partner",
           "description": null,
           "fields": [
             {
               "name": "artworks",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -814,7 +980,9 @@
             {
               "name": "displayName",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -826,7 +994,9 @@
             {
               "name": "display_name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -838,7 +1008,9 @@
             {
               "name": "givenName",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -850,7 +1022,9 @@
             {
               "name": "given_name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -862,7 +1036,9 @@
             {
               "name": "id",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -878,7 +1054,9 @@
             {
               "name": "relativeSize",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
@@ -890,7 +1068,9 @@
             {
               "name": "relative_size",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
@@ -902,7 +1082,9 @@
             {
               "name": "slug",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -914,7 +1096,9 @@
             {
               "name": "subscriptionState",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -926,7 +1110,9 @@
             {
               "name": "subscription_state",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -937,7 +1123,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -949,7 +1137,9 @@
             {
               "name": "edges",
               "description": "A list of edges.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -965,7 +1155,9 @@
             {
               "name": "nodes",
               "description": "A list of nodes.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -981,7 +1173,9 @@
             {
               "name": "pageInfo",
               "description": "Information to aid in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -996,7 +1190,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1008,7 +1204,9 @@
             {
               "name": "cursor",
               "description": "A cursor for use in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1024,7 +1222,9 @@
             {
               "name": "node",
               "description": "The item at the end of the edge.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "Artwork",
@@ -1035,7 +1235,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1066,33 +1268,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "CaptureHoldPayload",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "creditCommissionExemption",
-              "description": "Add to the partner's exemption balance against which they can make sales and not pay commission",
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CreditCommissionExemptionInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "CreditCommissionExemptionPayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1180,6 +1355,33 @@
               "deprecationReason": null
             },
             {
+              "name": "refundCommissionExemption",
+              "description": "Refund commission exemption for a previous transaction",
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RefundCommissionExemptionInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RefundCommissionExemptionPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "requestConditionReport",
               "description": null,
               "args": [
@@ -1208,7 +1410,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1220,7 +1424,9 @@
             {
               "name": "artworkId",
               "description": "Id of viewed artwork",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1236,7 +1442,9 @@
             {
               "name": "artwork_id",
               "description": "Id of viewed artwork",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1252,7 +1460,9 @@
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1263,7 +1473,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1310,7 +1522,9 @@
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1322,7 +1536,9 @@
             {
               "name": "conditionReportRequest",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1337,7 +1553,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1349,7 +1567,9 @@
             {
               "name": "internalID",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1365,7 +1585,9 @@
             {
               "name": "saleArtworkID",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
@@ -1377,7 +1599,9 @@
             {
               "name": "userID",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
@@ -1388,7 +1612,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1435,7 +1661,9 @@
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1447,7 +1675,9 @@
             {
               "name": "holdOrErrors",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1462,7 +1692,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1495,7 +1727,9 @@
             {
               "name": "capturedAt",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1507,7 +1741,9 @@
             {
               "name": "id",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1576,7 +1812,9 @@
             {
               "name": "referenceId",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1591,7 +1829,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1603,7 +1843,9 @@
             {
               "name": "edges",
               "description": "A list of edges.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1619,7 +1861,9 @@
             {
               "name": "nodes",
               "description": "A list of nodes.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1635,7 +1879,9 @@
             {
               "name": "pageInfo",
               "description": "Information to aid in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1650,7 +1896,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1662,7 +1910,9 @@
             {
               "name": "cursor",
               "description": "A cursor for use in pagination.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1678,7 +1928,9 @@
             {
               "name": "node",
               "description": "The item at the end of the edge.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "InventoryHoldItem",
@@ -1689,7 +1941,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1701,7 +1955,9 @@
             {
               "name": "artworkId",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1717,7 +1973,9 @@
             {
               "name": "editionSetId",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1729,7 +1987,9 @@
             {
               "name": "id",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1745,7 +2005,9 @@
             {
               "name": "quantity",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1760,7 +2022,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1772,7 +2036,9 @@
             {
               "name": "errors",
               "description": "List of Errors.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1795,7 +2061,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1807,7 +2075,9 @@
             {
               "name": "code",
               "description": "Error code",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1823,7 +2093,9 @@
             {
               "name": "data",
               "description": "Extra data about error.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "JSON",
@@ -1835,7 +2107,9 @@
             {
               "name": "message",
               "description": "A description of the error",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1851,7 +2125,9 @@
             {
               "name": "path",
               "description": "Which input value this error came from",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1870,7 +2146,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2008,7 +2286,9 @@
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2020,7 +2300,9 @@
             {
               "name": "holdOrError",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2035,7 +2317,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2111,13 +2395,15 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CreditCommissionExemptionPayload",
-          "description": "Autogenerated return type of CreditCommissionExemption",
+          "name": "RefundCommissionExemptionPayload",
+          "description": "Autogenerated return type of RefundCommissionExemption",
           "fields": [
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2127,9 +2413,11 @@
               "deprecationReason": null
             },
             {
-              "name": "totalRemainingGmvOrError",
+              "name": "gmvRefundedOrError",
               "description": "The total amount of GMV remaining in USD on which a partner won't be charged commission",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2144,7 +2432,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2176,8 +2466,10 @@
           "fields": [
             {
               "name": "amountMinor",
-              "description": null,
-              "args": [],
+              "description": "Amount in the minor unit of currency",
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2192,8 +2484,10 @@
             },
             {
               "name": "currencyCode",
-              "description": null,
-              "args": [],
+              "description": "Three-letter currency code",
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2208,14 +2502,120 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "CreditCommissionExemptionInput",
-          "description": "Autogenerated input type of CreditCommissionExemption",
+          "name": "RefundCommissionExemptionInput",
+          "description": "Autogenerated input type of RefundCommissionExemption",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "partnerId",
+              "description": "Partner ID",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "referenceId",
+              "description": "The transaction ID (e.g. Exchange order ID) associated with this change",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "notes",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DebitCommissionExemptionPayload",
+          "description": "Autogenerated return type of DebitCommissionExemption",
+          "fields": [
+            {
+              "name": "amountOfExemptGmvOrError",
+              "description": "The amount of GMV in sale currency to not charge commission on in this transaction",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "MoneyOrErrorUnion",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DebitCommissionExemptionInput",
+          "description": "Autogenerated input type of DebitCommissionExemption",
           "fields": null,
           "inputFields": [
             {
@@ -2234,7 +2634,7 @@
             },
             {
               "name": "exemption",
-              "description": "GMV on which commission will not be charged and currency code. Amount must be positive",
+              "description": "Gross sale exemption amount and sale currency. Amount must be positive",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2248,7 +2648,7 @@
             },
             {
               "name": "referenceId",
-              "description": "The transaction ID associated with this change",
+              "description": "The transaction ID (e.g. Exchange order ID) associated with this change",
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
@@ -2322,121 +2722,15 @@
         },
         {
           "kind": "OBJECT",
-          "name": "DebitCommissionExemptionPayload",
-          "description": "Autogenerated return type of DebitCommissionExemption",
-          "fields": [
-            {
-              "name": "amountOfExemptGmvOrError",
-              "description": "The amount of GMV in sale currency to not charge commission on in this transaction",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "UNION",
-                  "name": "MoneyOrErrorUnion",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "DebitCommissionExemptionInput",
-          "description": "Autogenerated input type of DebitCommissionExemption",
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "partnerId",
-              "description": "Partner ID",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "exemption",
-              "description": "Gross sale exemption amount and sale currency. Amount must be positive",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "MoneyInput",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "referenceId",
-              "description": "The transaction ID associated with this change",
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "notes",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
           "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
             {
               "name": "directives",
               "description": "A list of all directives supported by this server.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2460,7 +2754,9 @@
             {
               "name": "mutationType",
               "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
@@ -2472,7 +2768,9 @@
             {
               "name": "queryType",
               "description": "The type that query operations will be rooted at.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2488,7 +2786,9 @@
             {
               "name": "subscriptionType",
               "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
@@ -2500,7 +2800,9 @@
             {
               "name": "types",
               "description": "A list of all types supported by this server.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2523,7 +2825,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2535,7 +2839,9 @@
             {
               "name": "description",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2609,7 +2915,9 @@
             {
               "name": "inputFields",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -2629,7 +2937,9 @@
             {
               "name": "interfaces",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -2649,7 +2959,9 @@
             {
               "name": "kind",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2665,7 +2977,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2677,7 +2991,9 @@
             {
               "name": "ofType",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
@@ -2689,7 +3005,9 @@
             {
               "name": "possibleTypes",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -2708,7 +3026,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2720,7 +3040,9 @@
             {
               "name": "args",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2744,7 +3066,9 @@
             {
               "name": "deprecationReason",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2756,7 +3080,9 @@
             {
               "name": "description",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2768,7 +3094,9 @@
             {
               "name": "isDeprecated",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2784,7 +3112,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2800,7 +3130,9 @@
             {
               "name": "type",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2815,7 +3147,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2827,7 +3161,9 @@
             {
               "name": "args",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2851,7 +3187,9 @@
             {
               "name": "description",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2863,7 +3201,9 @@
             {
               "name": "locations",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2887,7 +3227,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2903,7 +3245,9 @@
             {
               "name": "onField",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2919,7 +3263,9 @@
             {
               "name": "onFragment",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2935,7 +3281,9 @@
             {
               "name": "onOperation",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2950,7 +3298,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2962,7 +3312,9 @@
             {
               "name": "deprecationReason",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2974,7 +3326,9 @@
             {
               "name": "description",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -2986,7 +3340,9 @@
             {
               "name": "isDeprecated",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3002,7 +3358,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3017,7 +3375,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -3029,7 +3389,9 @@
             {
               "name": "defaultValue",
               "description": "A GraphQL-formatted string representing the default value for this input value.",
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3041,7 +3403,9 @@
             {
               "name": "description",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -3053,7 +3417,9 @@
             {
               "name": "name",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3069,7 +3435,9 @@
             {
               "name": "type",
               "description": null,
-              "args": [],
+              "args": [
+
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3084,7 +3452,9 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -3271,7 +3641,11 @@
         {
           "name": "include",
           "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -3292,7 +3666,11 @@
         {
           "name": "skip",
           "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
           "args": [
             {
               "name": "if",
@@ -3313,7 +3691,10 @@
         {
           "name": "deprecated",
           "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
           "args": [
             {
               "name": "reason",


### PR DESCRIPTION
Following up on https://github.com/artsy/gravity/pull/12796, this PR switches from consuming the now-nonexistent `credit_commision_exemption` Gravity endpoint to `refund_commission_exemption`. Also grabs the new schema from Gravity using `dotenv bundle exec rake graphql:schema:update`, a handy rake task provided by Artemis