### PR TITLE
Attempt to adapt Volt's chromedriver config for Exchange

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'stripe-ruby-mock', '~> 2.5.8', require: 'stripe_mock'
   gem 'timecop'
+  gem 'webdrivers', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,10 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -442,6 +446,7 @@ DEPENDENCIES
   stripe-ruby-mock (~> 2.5.8)
   taxjar-ruby
   timecop
+  webdrivers
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
While working on https://github.com/artsy/exchange/pull/580, we ran into an error that we couldn't reproduce locally due to issues with the `rails_helper.rb` file and webdrivers - basically, it was running off my local chromedriver instead of a specific version for this project. We stole Volt's chromedriver config and that worked great for running it locally and seeing results...but failed on CI. To unblock that PR, decided to remove these changes, put in a separate PR, and close for now - we can repoen if we're interested in exploring/solving in the future.