### PR TITLE
tweak rollout settings - add sleep to Nginx and Puma and bump maxSurge to 2 #PLATFORM-2230

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:
@@ -51,6 +51,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
         - name: exchange-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -65,7 +69,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 2
       maxUnavailable: 0
     type: RollingUpdate
   template:
@@ -51,6 +51,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
         - name: exchange-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
@@ -65,7 +69,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/usr/sbin/nginx", "-s", "quit"]
+                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
           env:
             - name: "NGINX_DEFAULT_CONF"
               valueFrom:


### PR DESCRIPTION
Attempts to address https://artsyproduct.atlassian.net/browse/PLATFORM-2230

Smooth Rollout via calling sleep before shutting down Nginx and Puma to ensure no 504s on deploy.  Also bump maxSurge to 2 to speed up deployment rollouts.