### PR TITLE
Upgrade rubocop and switch gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
+require: rubocop-rails
+
 AllCops:
   Exclude:
     - "db/schema.rb"
@@ -58,3 +60,18 @@ Style/NumericLiterals:
 Lint/UselessComparison:
   Exclude:
     - "spec/lib/address_spec.rb"
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,5 +48,5 @@ Style/MixinUsage:
 # Offense count: 1399
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 276

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'byebug'
   gem 'graphlient'
   gem 'rspec-rails'
-  gem 'rubocop'
+  gem 'rubocop-rails', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       activerecord (>= 4.2)
       request_store (~> 1.1)
     parallel (1.19.1)
-    parser (2.6.5.0)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
     pg (1.1.4)
     polyamorous (2.3.0)
@@ -311,6 +311,7 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.4)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -328,13 +329,18 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.78.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
@@ -433,7 +439,7 @@ DEPENDENCIES
   puma (~> 3.12.2)
   rails (= 6.0)
   rspec-rails
-  rubocop
+  rubocop-rails
   selenium-webdriver
   sentry-raven
   sidekiq (< 6)

--- a/app/events/offer_event.rb
+++ b/app/events/offer_event.rb
@@ -43,7 +43,7 @@ class OfferEvent < Events::BaseEvent
 
   def order
     order = @object.order
-    OrderEvent::PROPERTIES_ATTRS.map { |att| [att, order.send(att)] }.to_h.merge(line_items: line_items_details)
+    OrderEvent::PROPERTIES_ATTRS.index_with { |att| order.send(att) }.merge(line_items: line_items_details)
   end
 
   def line_items_details

--- a/app/events/order_event.rb
+++ b/app/events/order_event.rb
@@ -51,7 +51,7 @@ class OrderEvent < Events::BaseEvent
   end
 
   def properties
-    PROPERTIES_ATTRS.map { |att| [att, @object.send(att)] }.to_h.merge(line_items: line_items_details, last_offer: last_offer)
+    PROPERTIES_ATTRS.index_with { |att| @object.send(att) }.merge(line_items: line_items_details, last_offer: last_offer)
   end
 
   private

--- a/app/jobs/offer_respond_reminder_job.rb
+++ b/app/jobs/offer_respond_reminder_job.rb
@@ -5,7 +5,7 @@ class OfferRespondReminderJob < ApplicationJob
     order = Order.find(order_id)
     offer = Offer.find(offer_id)
     return unless order.state == Order::SUBMITTED &&
-                  Time.now <= order.state_expires_at &&
+                  Time.zone.now <= order.state_expires_at &&
                   order.last_offer.id == offer_id
 
     OfferEvent.post(offer, OfferEvent::PENDING_RESPONSE, nil)

--- a/app/jobs/order_follow_up_job.rb
+++ b/app/jobs/order_follow_up_job.rb
@@ -3,7 +3,7 @@ class OrderFollowUpJob < ApplicationJob
 
   def perform(order_id, state)
     order = Order.find(order_id)
-    return unless order.state == state && Time.now >= order.state_expires_at
+    return unless order.state == state && Time.zone.now >= order.state_expires_at
 
     case order.state
     when Order::PENDING

--- a/app/jobs/reminder_follow_up_job.rb
+++ b/app/jobs/reminder_follow_up_job.rb
@@ -6,7 +6,7 @@ class ReminderFollowUpJob < ApplicationJob
 
   def perform(order_id, state)
     order = Order.find(order_id)
-    return unless order.state == state && Time.now <= order.state_expires_at
+    return unless order.state == state && Time.zone.now <= order.state_expires_at
 
     case state
     when Order::SUBMITTED

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -203,7 +203,7 @@ class Order < ApplicationRecord
   end
 
   def last_transaction_failed?
-    return false unless transactions.present?
+    return false if transactions.blank?
 
     last_transaction = transactions.order(created_at: :desc).first
     last_transaction.failed? || last_transaction.requires_action?

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,5 +1,5 @@
 module PaperTrail
-  class Version < ActiveRecord::Base
+  class Version < ApplicationRecord
     include PaperTrail::VersionConcern
 
     self.abstract_class = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/config/initializers/datadog_statsd.rb
+++ b/config/initializers/datadog_statsd.rb
@@ -3,7 +3,7 @@ module Datadog
     attr_accessor :disabled
 
     def send_to_socket(message)
-      print message
+      print message # rubocop:disable Rails/Output
       super unless disabled
     end
   end

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -4,7 +4,7 @@ namespace 'graphql' do
     ORIG_SCHEMA_PATH = '_schema.graphql.orig'.freeze
 
     desc 'fail if there is ungenerated diff in _schema.graphql'
-    task :diff_check do
+    task diff_check: :environment do
       puts 'Checking for GraphQL schema diffs...'
 
       cp SCHEMA_FILE_PATH, ORIG_SCHEMA_PATH, verbose: false

--- a/spec/controllers/api/requests/my_orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/my_orders_query_request_spec.rb
@@ -84,14 +84,14 @@ describe Api::GraphqlController, type: :request do
         end
 
         it 'sorts by state_updated_at in ascending order' do
-          user1_order1.update!(state_updated_at: Time.now)
+          user1_order1.update!(state_updated_at: Time.zone.now)
           result = client.execute(query, sort: 'STATE_UPDATED_AT_ASC')
           ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
         end
 
         it 'sorts by state_updated_at in descending order' do
-          user1_order1.update!(state_updated_at: Time.now)
+          user1_order1.update!(state_updated_at: Time.zone.now)
           result = client.execute(query, sort: 'STATE_UPDATED_AT_DESC')
           ids = ids_from_my_orders_result_data(result)
           expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -131,14 +131,14 @@ describe Api::GraphqlController, type: :request do
       end
 
       it 'sorts by state_updated_at in ascending order' do
-        user1_order1.update!(state_updated_at: Time.now)
+        user1_order1.update!(state_updated_at: Time.zone.now)
         result = client.execute(query, buyerId: user_id, sort: 'STATE_UPDATED_AT_ASC')
         ids = ids_from_result_data(result)
         expect(ids).to eq([user1_order2.id, user1_offer_order1.id, user1_order1.id])
       end
 
       it 'sorts by state_updated_at in descending order' do
-        user1_order1.update!(state_updated_at: Time.now)
+        user1_order1.update!(state_updated_at: Time.zone.now)
         result = client.execute(query, buyerId: user_id, sort: 'STATE_UPDATED_AT_DESC')
         ids = ids_from_result_data(result)
         expect(ids).to eq([user1_order1.id, user1_offer_order1.id, user1_order2.id])

--- a/spec/events/offer_event_spec.rb
+++ b/spec/events/offer_event_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe OfferEvent, type: :events do
-  before { Timecop.freeze(Time.parse('2018-08-16 15:48:00 -0400')) }
+  before { Timecop.freeze(Time.zone.parse('2018-08-16 15:48:00 -0400')) }
   after { Timecop.return }
 
   let(:seller_id) { 'partner-1' }
@@ -133,7 +133,7 @@ describe OfferEvent, type: :events do
           expect(order_prop[:shipping_postal_code]).to eq '60618'
           expect(order_prop[:buyer_phone_number]).to eq '00123459876'
           expect(order_prop[:shipping_region]).to eq 'IL'
-          expect(order_prop[:state_expires_at]).to eq Time.parse('2018-08-19 15:48:00 -0400')
+          expect(order_prop[:state_expires_at]).to eq Time.zone.parse('2018-08-19 15:48:00 -0400')
           expect(order_prop[:total_list_price_cents]).to eq(200)
         end
       end

--- a/spec/events/order_event_spec.rb
+++ b/spec/events/order_event_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe OrderEvent, type: :events do
-  before { Timecop.freeze(Time.parse('2018-08-16 15:48:00 -0400')) }
+  before { Timecop.freeze(Time.zone.parse('2018-08-16 15:48:00 -0400')) }
   after { Timecop.return }
 
   let(:seller_id) { 'partner-1' }
@@ -110,7 +110,7 @@ describe OrderEvent, type: :events do
         expect(event.properties[:shipping_postal_code]).to eq '60618'
         expect(event.properties[:buyer_phone_number]).to eq '00123459876'
         expect(event.properties[:shipping_region]).to eq 'IL'
-        expect(event.properties[:state_expires_at]).to eq Time.parse('2018-08-19 15:48:00 -0400')
+        expect(event.properties[:state_expires_at]).to eq Time.zone.parse('2018-08-19 15:48:00 -0400')
         expect(event.properties[:total_list_price_cents]).to eq(400)
         expect(event.properties[:last_offer]).to be_nil
         expect(event.properties[:external_charge_id]).to eq 'pi_1'

--- a/spec/lib/tax/collection_service_spec.rb
+++ b/spec/lib/tax/collection_service_spec.rb
@@ -210,20 +210,20 @@ describe Tax::CollectionService, type: :services do
       it 'refunds the transaction' do
         expect(taxjar_client).to receive(:show_order).with(transaction_id).and_return(double)
         expect(@service).to receive(:post_refund)
-        @service.refund_transaction(Time.new(2018, 1, 1))
+        @service.refund_transaction(Time.zone.local(2018, 1, 1))
       end
     end
     context 'without an existing transaction in Taxjar' do
       it 'does nothing' do
         expect(taxjar_client).to receive(:show_order).with(transaction_id).and_return(nil)
         expect(@service).to_not receive(:post_refund)
-        @service.refund_transaction(Time.new(2018, 1, 1))
+        @service.refund_transaction(Time.zone.local(2018, 1, 1))
       end
     end
     context 'with an error from TaxJar' do
       it 'raises a ProcessingError with a code of tax_refund_failure' do
         expect(taxjar_client).to receive(:show_order).and_raise(Taxjar::Error)
-        expect { @service.refund_transaction(Time.new(2018, 1, 1)) }.to raise_error do |error|
+        expect { @service.refund_transaction(Time.zone.local(2018, 1, 1)) }.to raise_error do |error|
           expect(error).to be_a Errors::ProcessingError
           expect(error.type).to eq :processing
           expect(error.code).to eq :tax_refund_failure
@@ -240,7 +240,7 @@ describe Tax::CollectionService, type: :services do
   end
 
   describe '#post_refund' do
-    let(:transaction_date) { Time.new(2018, 1, 1) }
+    let(:transaction_date) { Time.zone.local(2018, 1, 1) }
     let(:params) do
       base_tax_params.merge(
         transaction_id: "refund_#{transaction_id}",

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Offer, type: :model do
 
   describe '#scopes' do
     describe 'submitted' do
-      let!(:offer1) { Fabricate(:offer, submitted_at: Time.now) }
+      let!(:offer1) { Fabricate(:offer, submitted_at: Time.zone.now) }
       let!(:offer2) { Fabricate(:offer, submitted_at: nil) }
       let!(:offer3) { Fabricate(:offer, submitted_at: nil) }
       it 'returns submitted offers' do


### PR DESCRIPTION
Exchange had fallen behind on RuboCop so this PR updates it to latest and complies with the new rules. I also switched to the `rubocop-rails` gem which is the current best-practice.

So mostly this is just churn, but I did have to refactor the `ShippingHelper.calculate` method so that I could comply but also so I could better understand what that method did - hopefully people find this easier to change in the future!