### PR TITLE
[Toolchain] Add Guard for watching tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'taxjar-ruby', require: 'taxjar'
 group :development, :test do
   gem 'byebug'
   gem 'graphlient'
+  gem 'guard-rspec', require: false
   gem 'rspec-rails'
   gem 'rubocop-rails', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       cork
       nap
       open4 (~> 1.3)
+    coderay (1.1.2)
     colored2 (3.1.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
@@ -146,6 +147,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -161,6 +163,20 @@ GEM
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
+    guard (2.16.2)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -210,6 +226,7 @@ GEM
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lumberjack (1.2.4)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -230,10 +247,14 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nap (1.1.0)
+    nenv (0.3.0)
     nio4r (2.5.2)
     no_proxy_fix (0.1.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
@@ -261,6 +282,9 @@ GEM
     pg (1.2.3)
     polyamorous (2.3.2)
       activerecord (>= 5.2.1)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -314,6 +338,10 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -362,6 +390,7 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
+    shellany (0.0.1)
     sidekiq (5.2.8)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (< 2.1.0)
@@ -430,6 +459,7 @@ DEPENDENCIES
   faraday
   graphlient
   graphql
+  guard-rspec
   jwt
   listen
   micromachine

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+group :rspec do
+  guard :rspec, cmd: 'bundle exec rspec' do
+    watch('spec/spec_helper.rb')                        { 'spec' }
+    watch('app/controllers/application_controller.rb')  { 'spec/controllers' }
+    watch(%r{^spec/.+_spec\.rb$})
+    watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+    watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+    watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
+    watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,9 @@ SimpleCov.start do
 end
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
Follows [Convection PR](https://github.com/artsy/convection/pull/505) in adding `Guard`, which will watch tests for changes and re-execute, without having to restart command. Additionally adds the ability to focus on specific tests via the `focus: true` param.  

![guard](https://user-images.githubusercontent.com/236943/81007727-9f31a400-8e06-11ea-8b11-817125960fc2.gif)
