### PR TITLE
[Consignments] If consignment only use artwork location and buyer location for calculating tax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'ddtrace' # datadog instrumentation
 gem 'dogstatsd-ruby', require: 'datadog/statsd' # send metrics to datadog agent
 gem 'faraday'
 gem 'graphql'
+gem 'graphql-rails_logger'
 gem 'jwt'
 gem 'micromachine'
 gem 'money' # Library for dealing with money and currency conversion

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,11 @@ GEM
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
+    graphql-rails_logger (1.2.2)
+      actionpack (> 5.0)
+      activesupport (> 5.0)
+      railties (> 5.0)
+      rouge (~> 3.0)
     guard (2.16.2)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -338,6 +343,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
+    rouge (3.18.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -459,6 +465,7 @@ DEPENDENCIES
   faraday
   graphlient
   graphql
+  graphql-rails_logger
   guard-rspec
   jwt
   listen

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -5,19 +5,12 @@ class RecordSalesTaxJob < ApplicationJob
     line_item = LineItem.find(line_item_id)
     return unless line_item.should_remit_sales_tax?
 
-    artwork = Gravity.get_artwork(line_item.artwork_id)
-    consignment = artwork[:import_source] == 'convection'
+    artwork = line_item.order.artwork
     artwork_address = Address.new(artwork[:location])
+    order = line_item.order
+    nexus_addresses = order.nexus_addresses
 
-    # If the artwork originated from a consignment, the seller location
-    # corresponds to the artwork location for tax purposes.
-    seller_addresses = if consignment
-      [artwork_address]
-    else
-      Gravity.fetch_partner_locations(line_item.order.seller_id, tax_only: true)
-    end
-
-    service = Tax::CollectionService.new(line_item, artwork_address, seller_addresses)
+    service = Tax::CollectionService.new(line_item, artwork_address, nexus_addresses)
     service.record_tax_collected
     line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id) if service.transaction.present?
   end

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -6,8 +6,15 @@ class RecordSalesTaxJob < ApplicationJob
     return unless line_item.should_remit_sales_tax?
 
     artwork = Gravity.get_artwork(line_item.artwork_id)
+    consignment = artwork[:import_source] == 'convection'
+
     artwork_address = Address.new(artwork[:location])
-    seller_addresses = Gravity.fetch_partner_locations(line_item.order.seller_id, tax_only: true)
+    seller_addresses = if consignment
+      artwork_address
+    else
+      Gravity.fetch_partner_locations(line_item.order.seller_id, tax_only: true)
+    end
+
     service = Tax::CollectionService.new(line_item, artwork_address, seller_addresses)
     service.record_tax_collected
     line_item.update!(sales_tax_transaction_id: service.transaction.transaction_id) if service.transaction.present?

--- a/app/jobs/record_sales_tax_job.rb
+++ b/app/jobs/record_sales_tax_job.rb
@@ -7,10 +7,12 @@ class RecordSalesTaxJob < ApplicationJob
 
     artwork = Gravity.get_artwork(line_item.artwork_id)
     consignment = artwork[:import_source] == 'convection'
-
     artwork_address = Address.new(artwork[:location])
+
+    # If the artwork originated from a consignment, the seller location
+    # corresponds to the artwork location for tax purposes.
     seller_addresses = if consignment
-      artwork_address
+      [artwork_address]
     else
       Gravity.fetch_partner_locations(line_item.order.seller_id, tax_only: true)
     end

--- a/config/initializers/graphql_rails_logger.rb
+++ b/config/initializers/graphql_rails_logger.rb
@@ -1,0 +1,3 @@
+GraphQL::RailsLogger.configure do |config|
+  config.white_list = { 'Api::GraphqlController' => %w[execute] }
+end

--- a/lib/line_item_totals.rb
+++ b/lib/line_item_totals.rb
@@ -3,11 +3,11 @@ class LineItemTotals
   delegate :tax_total_cents, to: :tax_data
   delegate :should_remit_sales_tax, to: :tax_data
 
-  def initialize(line_item, fulfillment_type:, shipping_address:, seller_locations:, artsy_collects_sales_tax:)
+  def initialize(line_item, fulfillment_type:, shipping_address:, nexus_addresses:, artsy_collects_sales_tax:)
     @line_item = line_item
     @fulfillment_type = fulfillment_type
     @shipping_address = shipping_address
-    @seller_locations = seller_locations
+    @nexus_addresses = nexus_addresses
     @artsy_collects_sales_tax = artsy_collects_sales_tax
     @order = line_item.order
   end
@@ -35,7 +35,7 @@ class LineItemTotals
         @shipping_address,
         shipping_total_cents,
         @line_item.artwork_location,
-        @seller_locations
+        @nexus_addresses
       )
       sales_tax = @artsy_collects_sales_tax ? service.sales_tax : 0
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)

--- a/lib/offer_totals.rb
+++ b/lib/offer_totals.rb
@@ -38,7 +38,7 @@ class OfferTotals
         @order.shipping_address,
         shipping_total_cents,
         artwork_location,
-        @order.seller_locations
+        @order.nexus_addresses
       )
       sales_tax = @order.partner[:artsy_collects_sales_tax] ? service.sales_tax : 0
       OpenStruct.new(tax_total_cents: sales_tax, should_remit_sales_tax: service.artsy_should_remit_taxes?)

--- a/lib/order_helper.rb
+++ b/lib/order_helper.rb
@@ -39,12 +39,12 @@ module OrderHelper
     @merchant_account ||= Gravity.get_merchant_account(seller_id)
   end
 
-  def seller_locations
+  def nexus_addresses
     consignment = artwork[:import_source] == 'convection'
 
     # If the artwork originated from a consignment, the seller location
     # corresponds to the artwork location for tax purposes.
-    @seller_locations ||= if consignment
+    @nexus_addresses ||= if consignment
       [Address.new(artwork[:location])]
     else
       Gravity.fetch_partner_locations(seller_id, tax_only: true)

--- a/lib/order_helper.rb
+++ b/lib/order_helper.rb
@@ -15,12 +15,10 @@ module OrderHelper
     @artworks ||= line_items.map(&:artwork)
   end
 
+  # This is with assumption of Offer order only having one line_item. Follows
+  # similar pattern as in offer_totals.
   def artwork
-    @artwork ||= begin
-      # This is with assumption of Offer order only having one line_item. Follows
-      # similar pattern as in offer_totals.
-      line_items.first&.artwork
-    end
+    @artwork ||= artworks.first
   end
 
   def artists

--- a/lib/order_helper.rb
+++ b/lib/order_helper.rb
@@ -41,12 +41,11 @@ module OrderHelper
 
   def seller_locations
     consignment = artwork[:import_source] == 'convection'
-    artwork_address = Address.new(artwork[:location])
 
     # If the artwork originated from a consignment, the seller location
     # corresponds to the artwork location for tax purposes.
     @seller_locations ||= if consignment
-      [artwork_address]
+      [Address.new(artwork[:location])]
     else
       Gravity.fetch_partner_locations(seller_id, tax_only: true)
     end

--- a/lib/order_shipping.rb
+++ b/lib/order_shipping.rb
@@ -63,7 +63,7 @@ class OrderShipping
         li,
         fulfillment_type: @order.fulfillment_type,
         shipping_address: @order.shipping_address,
-        seller_locations: @order.seller_locations,
+        nexus_addresses: @order.nexus_addresses,
         artsy_collects_sales_tax: @order.artsy_collects_sales_tax?
       )
       li.update!(

--- a/lib/shipping_helper.rb
+++ b/lib/shipping_helper.rb
@@ -1,6 +1,9 @@
 class ShippingHelper
   def self.calculate(artwork, fulfillment_type, shipping_address = nil)
-    return 0 if fulfillment_type == Order::PICKUP
+    is_consignment = artwork[:import_source] == 'convection'
+    is_pickup = fulfillment_type == Order::PICKUP
+
+    return 0 if is_consignment || is_pickup
 
     if artwork[:location].blank?
       exception = Errors::ValidationError.new(:missing_artwork_location, artwork_id: artwork[:_id])

--- a/lib/shipping_helper.rb
+++ b/lib/shipping_helper.rb
@@ -1,9 +1,9 @@
 class ShippingHelper
   def self.calculate(artwork, fulfillment_type, shipping_address = nil)
-    is_consignment = artwork[:import_source] == 'convection'
-    is_pickup = fulfillment_type == Order::PICKUP
+    consignment = artwork[:import_source] == 'convection'
+    pickup = fulfillment_type == Order::PICKUP
 
-    return 0 if is_consignment || is_pickup
+    return 0 if consignment || pickup
 
     if artwork[:location].blank?
       exception = Errors::ValidationError.new(:missing_artwork_location, artwork_id: artwork[:_id])

--- a/lib/tax/calculator_service.rb
+++ b/lib/tax/calculator_service.rb
@@ -42,15 +42,15 @@ class Tax::CalculatorService
   private
 
   def fetch_sales_tax
+    tax_params = construct_tax_params(
+      line_items: [{
+        unit_price: UnitConverter.convert_cents_to_dollars(@unit_price_cents),
+        quantity: @quantity
+      }]
+    )
+
     UnitConverter.convert_dollars_to_cents(
-      @tax_client.tax_for_order(
-        construct_tax_params(
-          line_items: [{
-            unit_price: UnitConverter.convert_cents_to_dollars(@unit_price_cents),
-            quantity: @quantity
-          }]
-        )
-      ).amount_to_collect
+      @tax_client.tax_for_order(tax_params).amount_to_collect
     )
   end
 

--- a/lib/tax/calculator_service.rb
+++ b/lib/tax/calculator_service.rb
@@ -14,7 +14,6 @@ class Tax::CalculatorService
       api_url: Rails.application.config_for(:taxjar)['taxjar_api_url'].presence
     )
   )
-
     @seller_nexus_addresses = process_nexus_addresses!(nexus_addresses)
     @fulfillment_type = fulfillment_type
     @tax_client = tax_client

--- a/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/offer_set_shipping_mutation_request_spec.rb
@@ -170,8 +170,9 @@ describe Api::GraphqlController, type: :request do
 
         context 'when passing phone number in address' do
           before do
-            expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+            expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
             allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
+            allow(Gravity).to receive(:fetch_partner_locations).and_return(seller_addresses)
           end
           let(:set_shipping_input) do
             {
@@ -321,7 +322,7 @@ describe Api::GraphqlController, type: :request do
           end
           context 'with PICKUP as fulfillment type' do
             before do
-              expect(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork1)
+              expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
             end
             let(:fulfillment_type) { 'PICKUP' }
             it 'sets total shipping cents to 0' do
@@ -333,7 +334,7 @@ describe Api::GraphqlController, type: :request do
           end
           context 'with SHIP as fulfillment type' do
             before do
-              expect(Adapters::GravityV1).to receive(:get).once.with('/artwork/a-1').and_return(artwork1)
+              expect(Adapters::GravityV1).to receive(:get).twice.with('/artwork/a-1').and_return(artwork1)
             end
             context 'with international shipping' do
               let(:shipping_country) { 'IR' }

--- a/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/set_shipping_mutation_request_spec.rb
@@ -240,6 +240,7 @@ describe Api::GraphqlController, type: :request do
           it 'returns an error' do
             allow(Adapters::GravityV1).to receive(:get).with("/partner/#{seller_id}/locations", params: { private: true, address_type: ['Business', 'Sales tax nexus'], page: 1, size: 20 }).and_return([{ country: 'US', state: 'NY' }])
             allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(id: 'missing-location')
+            allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-2').and_return(id: 'missing-location')
             response = client.execute(mutation, set_shipping_input)
             expect(response.data.set_shipping.order_or_error.error.type).to eq 'validation'
             expect(response.data.set_shipping.order_or_error.error.code).to eq 'missing_artwork_location'

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -39,8 +39,7 @@ describe RecordSalesTaxJob, type: :job do
 
       context 'with an order that originated as a consignment' do
         it 'posts a transaction to TaxJar and saves the transaction id' do
-          expect(Gravity).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location))
-          expect(Gravity).to receive(:fetch_partner_locations).with(line_item.order.seller_id, tax_only: true).and_return(seller_addresses)
+          expect(Gravity).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location, import_source: 'convection'))
           expect(Address).to receive(:new).with(artwork_location).and_return(Address.new(artwork_location))
           RecordSalesTaxJob.perform_now(line_item.id)
           expect(line_item.reload.sales_tax_transaction_id).to eq '123'

--- a/spec/jobs/record_sales_tax_job_spec.rb
+++ b/spec/jobs/record_sales_tax_job_spec.rb
@@ -40,7 +40,7 @@ describe RecordSalesTaxJob, type: :job do
       context 'with an order that originated as a consignment' do
         it 'posts a transaction to TaxJar and saves the transaction id' do
           expect(Gravity).to receive(:get_artwork).with(line_item.artwork_id).and_return(gravity_v1_artwork(location: artwork_location, import_source: 'convection'))
-          expect(Address).to receive(:new).with(artwork_location).and_return(Address.new(artwork_location))
+          expect(Address).to receive(:new).twice.with(artwork_location).and_return(Address.new(artwork_location))
           RecordSalesTaxJob.perform_now(line_item.id)
           expect(line_item.reload.sales_tax_transaction_id).to eq '123'
         end

--- a/spec/lib/line_item_totals_spec.rb
+++ b/spec/lib/line_item_totals_spec.rb
@@ -5,11 +5,11 @@ describe LineItemTotals do
   let(:fulfillment_type) { Order::PICKUP }
   let(:artwork) { gravity_v1_artwork }
   let(:shipping_address) { nil }
-  let(:seller_locations) { [] }
+  let(:nexus_addresses) { [] }
   let(:artsy_collects_sales_tax) { true }
   let(:order) { Fabricate(:order, seller_id: 'partner-1', seller_type: 'gallery', buyer_id: 'buyer1', buyer_type: Order::USER, fulfillment_type: fulfillment_type) }
   let(:line_item) { Fabricate(:line_item, order: order, artwork_id: 'a-1') }
-  let(:line_item_totals) { LineItemTotals.new(line_item, fulfillment_type: fulfillment_type, shipping_address: shipping_address, seller_locations: seller_locations, artsy_collects_sales_tax: artsy_collects_sales_tax) }
+  let(:line_item_totals) { LineItemTotals.new(line_item, fulfillment_type: fulfillment_type, shipping_address: shipping_address, nexus_addresses: nexus_addresses, artsy_collects_sales_tax: artsy_collects_sales_tax) }
   let(:mock_tax_calculation) { allow(Tax::CalculatorService).to receive(:new).and_return(double(sales_tax: 100, artsy_should_remit_taxes?: false)) }
   before do
     allow(Adapters::GravityV1).to receive(:get).with('/artwork/a-1').and_return(artwork)

--- a/spec/lib/shipping_helper_spec.rb
+++ b/spec/lib/shipping_helper_spec.rb
@@ -68,9 +68,16 @@ describe ShippingHelper, type: :services do
   let(:continental_us_artwork) { gravity_v1_artwork(continental_us_artwork_config) }
   let(:artwork_in_italy) { gravity_v1_artwork(artwork_in_italy_config) }
   let(:artwork_missing_location) { gravity_v1_artwork(missing_artwork_location_config) }
+
   describe '#calculate' do
     context 'with pickup fulfillment type' do
       it 'returns 0' do
+        expect(ShippingHelper.calculate(artwork, Order::PICKUP)).to eq 0
+      end
+    end
+    context 'when artwork is consigned' do
+      it 'returns 0' do
+        artwork[:import_source] = 'convection'
         expect(ShippingHelper.calculate(artwork, Order::PICKUP)).to eq 0
       end
     end

--- a/spec/lib/shipping_helper_spec.rb
+++ b/spec/lib/shipping_helper_spec.rb
@@ -78,7 +78,7 @@ describe ShippingHelper, type: :services do
     context 'when artwork is consigned' do
       it 'returns 0' do
         artwork[:import_source] = 'convection'
-        expect(ShippingHelper.calculate(artwork, Order::PICKUP)).to eq 0
+        expect(ShippingHelper.calculate(artwork, Order::SHIP)).to eq 0
       end
     end
     context 'with missing artowrk location' do

--- a/spec/lib/tax/calculator_service_sepc.rb
+++ b/spec/lib/tax/calculator_service_sepc.rb
@@ -19,7 +19,7 @@ describe Tax::CalculatorService, type: :services do
     }
   end
   let(:shipping_address) { Address.new(shipping) }
-  let!(:seller_locations) do
+  let!(:nexus_addresses) do
     [
       {
         country: 'US',
@@ -37,7 +37,7 @@ describe Tax::CalculatorService, type: :services do
       }
     ]
   end
-  let!(:seller_addresses) { seller_locations.map { |ad| Address.new(ad) } }
+  let!(:seller_addresses) { nexus_addresses.map { |ad| Address.new(ad) } }
   let(:artwork_location) { Address.new(gravity_v1_artwork[:location]) }
   let(:base_tax_params) do
     {

--- a/spec/lib/tax/collection_service_spec.rb
+++ b/spec/lib/tax/collection_service_spec.rb
@@ -21,7 +21,7 @@ describe Tax::CollectionService, type: :services do
   let(:shipping_total_cents) { 2222 }
   let(:transaction_id) { "#{line_item.order.id}__#{line_item.id}" }
   let(:shipping_address) { Address.new(country: 'US', postal_code: postal_code, region: shipping_region, city: 'New York', address_line1: '123 Fake St') }
-  let!(:seller_locations) do
+  let!(:nexus_addresses) do
     [
       {
         country: 'US',
@@ -39,7 +39,7 @@ describe Tax::CollectionService, type: :services do
       }
     ]
   end
-  let!(:seller_addresses) { seller_locations.map { |ad| Address.new(ad) } }
+  let!(:seller_addresses) { nexus_addresses.map { |ad| Address.new(ad) } }
   let(:artwork_location) { Address.new(gravity_v1_artwork[:location]) }
   let(:base_tax_params) do
     {

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -407,14 +407,14 @@ RSpec.describe Order, type: :model do
     end
   end
 
-  describe '#seller_locations' do
+  describe '#nexus_addresses' do
     context 'when artwork is not consigned' do
       it 'returns partner locations as seller locations' do
         order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-0')])
         seller_addresses = [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')]
         allow(Gravity).to receive(:fetch_partner_locations).and_return(seller_addresses)
         expect(Adapters::GravityV1).to receive(:get).with('/artwork/id-0').and_return(gravity_v1_artwork)
-        expect(order.seller_locations).to eq seller_addresses
+        expect(order.nexus_addresses).to eq seller_addresses
       end
     end
 
@@ -423,7 +423,7 @@ RSpec.describe Order, type: :model do
         artwork = gravity_v1_artwork(import_source: 'convection')
         order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-1')])
         expect(Adapters::GravityV1).to receive(:get).with('/artwork/id-1').and_return(artwork)
-        expect(order.seller_locations).to eq [Address.new(artwork[:location])]
+        expect(order.nexus_addresses).to eq [Address.new(artwork[:location])]
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -406,4 +406,25 @@ RSpec.describe Order, type: :model do
       end
     end
   end
+
+  describe '#seller_locations' do
+    context 'when artwork is not consigned' do
+      it 'returns partner locations as seller locations' do
+        order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-0')])
+        seller_addresses = [Address.new(state: 'NY', country: 'US', postal_code: '10001'), Address.new(state: 'MA', country: 'US', postal_code: '02139')]
+        allow(Gravity).to receive(:fetch_partner_locations).and_return(seller_addresses)
+        expect(Adapters::GravityV1).to receive(:get).with('/artwork/id-0').and_return(gravity_v1_artwork)
+        expect(order.seller_locations).to eq seller_addresses
+      end
+    end
+
+    context 'when artwork is consigned' do
+      it 'returns artwork location as seller location' do
+        artwork = gravity_v1_artwork(import_source: 'convection')
+        order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-1')])
+        expect(Adapters::GravityV1).to receive(:get).with('/artwork/id-1').and_return(artwork)
+        expect(order.seller_locations).to eq [Address.new(artwork[:location])]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Addresses 
- https://artsyproduct.atlassian.net/browse/CSGN-119 
- https://artsyproduct.atlassian.net/browse/CSGN-181

Today our sales tax on BNMO works is calculated by sending taxjar all locations associated with a partner. For direct listings, we will be using one partner account so we only want sales tax to be calculated based on the artwork listing and the buyers address. 

Additionally adds some better logging around our graphql queries via [`graphql-rails_logger`](https://github.com/jetruby/graphql-rails_logger).  

<details><summary>Screenshots</summary>

### Artsy

With Tax: 

<img width="425" alt="Screen Shot 2020-05-01 at 11 46 52 PM" src="https://user-images.githubusercontent.com/236943/80858009-54980800-8c0b-11ea-80ac-112d7229cd18.png">

Without Tax: 

<img width="440" alt="Screen Shot 2020-05-01 at 11 38 43 PM" src="https://user-images.githubusercontent.com/236943/80858014-5cf04300-8c0b-11ea-8e59-8808e42a4518.png">

### Exchange: 

With Tax: 

<img width="406" alt="Screen Shot 2020-05-02 at 12 23 50 AM" src="https://user-images.githubusercontent.com/236943/80858030-74c7c700-8c0b-11ea-8c7e-a554a7f318d6.png">

Without Tax: 

<img width="406" alt="Screen Shot 2020-05-02 at 12 24 04 AM" src="https://user-images.githubusercontent.com/236943/80858033-78f3e480-8c0b-11ea-8fe0-36e651a4e56d.png">

</details> 