### PR TITLE
Remove on_behalf_of param when creating PaymentIntent

### DIFF
--- a/lib/payment_service.rb
+++ b/lib/payment_service.rb
@@ -112,7 +112,6 @@ class PaymentService
       payment_method_types: ['card'],
       payment_method: order.credit_card[:external_id],
       customer: order.credit_card[:customer_account][:external_id],
-      on_behalf_of: order.merchant_account[:external_id],
       transfer_data: {
         destination: order.merchant_account[:external_id],
         amount: order.seller_total_cents

--- a/spec/lib/payment_service_spec.rb
+++ b/spec/lib/payment_service_spec.rb
@@ -34,7 +34,6 @@ describe PaymentService, type: :services do
       payment_method_types: ['card'],
       payment_method: 'cc_1',
       customer: 'ca_1',
-      on_behalf_of: 'ma-1',
       transfer_data: {
         destination: 'ma-1',
         amount: 10_00


### PR DESCRIPTION
This change is necessary to ensure that currency does not get converted to one that isn't supported by our bank accounts. By setting `on_behalf_of` to the same value as `transfer_data[destination]`, we retain the behavior of the destination account (aka the partners account) and that causes the destination currency to be  set to the currency of the partners account, in this case, it was CHF.

By setting `on_behalf_of` to `null`, the settling currency is set to the same as the platform's currency (that's us), and it will settle in whatever our account's currency is in (I'm guessing USD). 

Note: This will also cause the statement descriptor to show the platform's instead of the connected account's, but I think we don't set that anyway.

Stripe docs: https://stripe.com/docs/connect/destination-charges#differences