### PR TITLE
#migration Add Ingress resource in hokusai/staging.yml and hokusai/production.yml. Switch DNS to Ingress

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -189,3 +189,42 @@ spec:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: exchange
+    component: web
+    layer: application
+  name: exchange-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: exchange
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: exchange
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: exchange.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: exchange-web-internal
+              servicePort: http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -190,3 +190,42 @@ spec:
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: exchange
+    component: web
+    layer: application
+  name: exchange-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: exchange
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: exchange
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: exchange-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: exchange-web-internal
+              servicePort: http


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2594

See https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 and the section Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service.

## Migration Steps
1. Merge this PR and wait for changes to be deployed to Staging.
2. Test the newly created Ingress in Staging by:
`curl -i -H "host: exchange-staging.artsy.net" -k https://a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
3. Switch Staging DNS to Ingress by updating on Cloudflare as follows:
`exchange-staging.artsy.net` -> `a2b7b9ff4afbf11ea976f123b14b93be-bc5647bbe8f5b617.elb.us-east-1.amazonaws.com`
4. Merge the Deploy PR that will be automatically generated. Wait for changes to be deployed to Production.
5. Test the newly created Ingress in Production by:
`curl -i -H "host: exchange.artsy.net" -k https://a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`
6. Switch Production DNS to Ingress by updating on Cloudflare as follows:
`exchange.artsy.net` -> `a0e5e98faaf2311eaa26a0a55b7aece7-04d12ab5797eaa99.elb.us-east-1.amazonaws.com`