### PR TITLE
#migration Clean up ELB services and Nginx sidecar

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -57,35 +57,6 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 10"]
-        - name: exchange-nginx
-          image: artsy/docker-nginx:1.14.2
-          ports:
-            - name: nginx-http
-              containerPort: 80
-          readinessProbe:
-            tcpSocket:
-              port: nginx-http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 10
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
-          env:
-            - name: "NGINX_DEFAULT_CONF"
-              valueFrom:
-                configMapKeyRef:
-                  name: nginx-config
-                  key: default
-          volumeMounts:
-            - name: nginx-secrets
-              mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -141,39 +112,6 @@ spec:
                     operator: In
                     values:
                       - background
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: exchange
-    component: web
-    layer: application
-  name: exchange-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-spec:
-  ports:
-  - port: 443
-    protocol: TCP
-    name: https
-    targetPort: nginx-http
-  - port: 80
-    protocol: TCP
-    name: http
-    targetPort: nginx-http
-  selector:
-    app: exchange
-    component: web
-    layer: application
-  type: LoadBalancer
-  
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -57,35 +57,6 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 10"]
-        - name: exchange-nginx
-          image: artsy/docker-nginx:1.14.2
-          ports:
-            - name: nginx-http
-              containerPort: 80
-          readinessProbe:
-            tcpSocket:
-              port: nginx-http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 10
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 5 && /usr/sbin/nginx -s quit"]
-          env:
-            - name: "NGINX_DEFAULT_CONF"
-              valueFrom:
-                configMapKeyRef:
-                  name: nginx-config
-                  key: default
-          volumeMounts:
-            - name: nginx-secrets
-              mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -142,39 +113,6 @@ spec:
                     values:
                       - background
 
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: exchange
-    component: web
-    layer: application
-  name: exchange-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-spec:
-  ports:
-  - port: 443
-    protocol: TCP
-    name: https
-    targetPort: nginx-http
-  - port: 80
-    protocol: TCP
-    name: http
-    targetPort: nginx-http
-  selector:
-    app: exchange
-    component: web
-    layer: application
-  type: LoadBalancer
-  
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Follow-up to #626

- Remove ELB service
- Remove Nginx sidecar

## Migration
1. Merge and deploy
2. Delete the old ELB service with `kubectl delete service exchange-web`