### PR TITLE
[PURCHASE-1715] Add 'Confirm offline sale' button

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -417,7 +417,10 @@ ActiveAdmin.register Order do
 
       OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true)
 
-      resource.state_histories.last.update_attributes(:created_at=> offline_sale_date, :updated_at=> offline_sale_date)
+      # update fulfilled state change timestamp to the `offline_sale_date` provided in the form
+      fulfillment_state = resource.state_histories.where(state: Order::FULFILLED).order(created_at: :asc).last
+      fulfillment_state.update!(created_at: offline_sale_date) if fulfillment_state
+
       resource.admin_notes.create!(note_type: AdminNote::TYPES[:offline_sale], admin_id: current_user[:id], description: admin_note_description)
 
       update! do |format|

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -69,7 +69,7 @@ ActiveAdmin.register Order do
   end
 
   member_action :confirm_pickup, method: :post do
-    OrderService.confirm_pickup!(resource, current_user[:id]) if resource.fulfillment_type == Order::PICKUP
+    OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true) if resource.fulfillment_type == Order::PICKUP
     redirect_to resource_path, notice: 'Fulfillment confirmed!'
   end
 
@@ -415,13 +415,7 @@ ActiveAdmin.register Order do
       offline_sale_date = params[:order].delete(:offline_sale_date)
       admin_note_description = params[:order].delete(:admin_note_description)
 
-      if resource.fulfillment_type == Order::PICKUP
-        OrderService.confirm_pickup!(resource, current_user[:id])
-      elsif  resource.fulfillment_type == Order::SHIP
-        OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true)
-      else
-        raise Errors::ValidationError, :wrong_fulfillment_type
-      end
+      OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true)
 
       resource.state_histories.last.update_attributes(:created_at=> offline_sale_date, :updated_at=> offline_sale_date)
       resource.admin_notes.create!(note_type: AdminNote::TYPES[:offline_sale], admin_id: current_user[:id], description: admin_note_description)

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register Order do
-  actions :all, except: %i[create update destroy new edit]
+  permit_params :shipping_total_cents, :tax_total_cents, :buyer_total_cents, :transaction_fee_cents, :commission_fee_cents, :seller_total_cents
+  actions :all, except: %i[create destroy new]
   # TODO: change sort order
   config.sort_order = 'state_updated_at_desc'
 
@@ -82,6 +83,18 @@ ActiveAdmin.register Order do
     redirect_to resource_path, notice: 'toggled assisted flag!'
   end
 
+  member_action :confirm_offline_sale, method: :post do
+    if resource.fulfillment_type == Order::PICKUP
+      OrderService.confirm_pickup!(resource, current_user[:id])
+    elsif  resource.fulfillment_type == Order::SHIP
+      OrderService.confirm_fulfillment!(resource, current_user[:id], fulfilled_by_admin: true)
+    else
+      raise Errors::ValidationError, :wrong_fulfillment_type
+    end
+    redirect_to edit_admin_order_path(resource[:id]), notice: 'Offline sale created. you can now edit the price'
+  end
+
+
   action_item :refund, only: :show do
     link_to 'Refund', refund_admin_order_path(order), method: :post, data: { confirm: 'Are you sure you want to refund this order?' } if [Order::APPROVED, Order::FULFILLED].include? order.state
   end
@@ -112,6 +125,10 @@ ActiveAdmin.register Order do
 
   action_item :toggle_assisted_flag, only: :show do
     link_to 'Toggle Assisted', toggle_assisted_admin_order_path(order), method: :post if order.state != Order::PENDING
+  end
+
+  action_item :confirm_offline_sale, only: :show do
+    link_to 'Confirm Offline Sale', confirm_offline_sale_admin_order_path(order), method: :post if [Order::ABANDONED, Order::CANCELED].include?(order.state)
   end
 
   sidebar :artwork_info, only: :show do
@@ -365,7 +382,6 @@ ActiveAdmin.register Order do
     end
 
     panel 'Admin Actions and Notes' do
-      # TODO: Add "Add note" button
       h5 link_to('Add note', new_admin_order_admin_note_path(order), class: :button)
       table_for(order.admin_notes.order(created_at: :desc)) do
         column :created_at
@@ -391,4 +407,31 @@ ActiveAdmin.register Order do
       end
     end
   end
+
+  form do |f|
+    f.inputs do
+      f.input :offline_sale_date, as: :date_picker, input_html: { value: Date.today }, label: 'Offline sale date' 
+      f.input :admin_note_description, as: :string, input_html: { value: '' }, label: 'Admin note' 
+      f.input :shipping_total_cents, as: :number, label: "Shipping (#{order.currency_code} cents)"
+      f.input :tax_total_cents, as: :number, label: "Sales Tax (#{order.currency_code} cents)"
+      f.input :buyer_total_cents, as: :number, label: "Buyer Paid (#{order.currency_code} cents)"
+      f.input :transaction_fee_cents, as: :number, label: "Processing Fee (#{order.currency_code} cents)"
+      f.input :commission_fee_cents, as: :number, label: "Artsy Fee (#{order.currency_code} cents)"
+      f.input :seller_total_cents, as: :number, label: "Seller Payout (#{order.currency_code} cents)"
+    end
+    f.actions
+  end
+
+  controller do
+    def update
+      offline_sale_date = params[:order].delete(:offline_sale_date)
+      admin_note_description = params[:order].delete(:admin_note_description)
+      resource.state_histories.last.update_attributes(:created_at=> offline_sale_date, :updated_at=> offline_sale_date)
+      resource.admin_notes.create!(note_type: AdminNote::TYPES[:offline_sale], admin_id: current_user[:id], description: admin_note_description)
+
+      update! do |format|
+        format.html { redirect_to admin_order_path(params[:id]) }
+      end
+    end
+  end  
 end

--- a/app/graphql/mutations/confirm_fulfillment.rb
+++ b/app/graphql/mutations/confirm_fulfillment.rb
@@ -8,6 +8,9 @@ class Mutations::ConfirmFulfillment < Mutations::BaseMutation
   def resolve(id:)
     order = Order.find(id)
     authorize_seller_request!(order)
+
+    raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::SHIP
+
     OrderService.confirm_fulfillment!(order, context[:current_user][:id])
     {
       order_or_error: { order: order }

--- a/app/graphql/mutations/confirm_pickup.rb
+++ b/app/graphql/mutations/confirm_pickup.rb
@@ -8,7 +8,10 @@ class Mutations::ConfirmPickup < Mutations::BaseMutation
   def resolve(id:)
     order = Order.find(id)
     authorize_seller_request!(order)
-    OrderService.confirm_pickup!(order, context[:current_user][:id])
+
+    raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::PICKUP
+
+    OrderService.confirm_fulfillment!(order, context[:current_user][:id])
     {
       order_or_error: { order: order }
     }

--- a/app/models/admin_note.rb
+++ b/app/models/admin_note.rb
@@ -9,6 +9,7 @@ class AdminNote < ApplicationRecord
     execution_contacted_buyer: 'execution_contacted_buyer'.freeze,
     execution_contacted_seller: 'execution_contacted_seller'.freeze,
     execution_initiated_refund: 'execution_initiated_refund'.freeze,
-    case_closed: 'case_closed'.freeze
+    case_closed: 'case_closed'.freeze,
+    offline_sale: 'offline_sale'.freeze
   }.freeze
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -259,7 +259,7 @@ class Order < ApplicationRecord
     machine.when(:seller_lapse, SUBMITTED => CANCELED)
     machine.when(:buyer_lapse, SUBMITTED => CANCELED)
     machine.when(:cancel, SUBMITTED => CANCELED)
-    machine.when(:fulfill, APPROVED => FULFILLED)
+    machine.when(:fulfill, APPROVED => FULFILLED, CANCELED => FULFILLED, ABANDONED => FULFILLED)
     machine.when(:refund, APPROVED => REFUNDED, FULFILLED => REFUNDED)
     machine.on(:any) do
       self.state = machine.state

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -107,16 +107,8 @@ module OrderService
     order
   end
 
-  def self.confirm_pickup!(order, user_id)
-    raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::PICKUP
-
-    order.fulfill!
-    OrderEvent.delay_post(order, user_id)
-    order
-  end
-
   def self.confirm_fulfillment!(order, user_id, fulfilled_by_admin: false)
-    raise Errors::ValidationError, :wrong_fulfillment_type unless order.fulfillment_type == Order::SHIP
+    raise Errors::ValidationError, :wrong_fulfillment_type unless [Order::SHIP, Order::PICKUP].include? order.fulfillment_type
 
     order.fulfill! do
       order.update!(fulfilled_by_admin_id: user_id) if fulfilled_by_admin

--- a/spec/controllers/api/requests/confirm_fulfillment_request_spec.rb
+++ b/spec/controllers/api/requests/confirm_fulfillment_request_spec.rb
@@ -61,7 +61,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      Order::STATES.reject { |s| [Order::APPROVED, Order::CANCELED].include? s }.each do |state|
+      Order::STATES.reject { |s| [Order::APPROVED, Order::CANCELED, Order::ABANDONED].include? s }.each do |state|
         context "with order not in #{state} state" do
           before do
             order.update! state: state

--- a/spec/controllers/api/requests/confirm_pickup_request_spec.rb
+++ b/spec/controllers/api/requests/confirm_pickup_request_spec.rb
@@ -61,7 +61,7 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'with proper permission' do
-      Order::STATES.reject { |s| [Order::APPROVED, Order::CANCELED].include? s }.each do |state|
+      Order::STATES.reject { |s| [Order::APPROVED, Order::CANCELED, Order::ABANDONED].include? s }.each do |state|
         context "with order not in #{state} state" do
           before do
             order.update! state: state

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -209,17 +209,7 @@ describe OrderService, type: :services do
   end
 
   describe 'confirm_fulfillment!' do
-    context 'with order in approved state' do
-      let(:state) { Order::APPROVED }
-
-      it 'raises error for pickup orders' do
-        order.update!(fulfillment_type: Order::PICKUP)
-        expect { OrderService.confirm_fulfillment!(order, user_id) }.to raise_error do |e|
-          expect(e).to be_a Errors::ValidationError
-          expect(e.code).to eq :wrong_fulfillment_type
-        end
-      end
-
+    shared_examples 'order to be fulfilled' do
       it 'changes order state to fulfilled' do
         OrderService.confirm_fulfillment!(order, user_id)
         expect(order.reload.state).to eq Order::FULFILLED
@@ -240,6 +230,21 @@ describe OrderService, type: :services do
       it 'sets fulfilled_by_admin_id when it was fulfilled by admin' do
         OrderService.confirm_fulfillment!(order, user_id, fulfilled_by_admin: true)
         expect(order.reload.fulfilled_by_admin_id).to eq user_id
+      end
+    end
+
+    context 'with order in approved state' do
+      let(:state) { Order::APPROVED }
+
+      context 'for PICKUP fullfillment type' do
+        before do
+          order.update!(fulfillment_type: Order::PICKUP)
+        end
+        it_behaves_like 'order to be fulfilled'
+      end
+
+      context 'for SHIP fullfilment type' do
+        it_behaves_like 'order to be fulfilled'
       end
     end
 

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -187,7 +187,7 @@ describe OrderService, type: :services do
       end
     end
 
-    Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|
+    Order::STATES.reject { |s| [Order::APPROVED, Order::ABANDONED, Order::CANCELED].include?(s) }.each do |state|
       context "order in #{state}" do
         let(:state) { state }
         it 'raises error' do
@@ -243,7 +243,7 @@ describe OrderService, type: :services do
       end
     end
 
-    Order::STATES.reject { |s| s == Order::APPROVED }.each do |state|
+    Order::STATES.reject { |s| [Order::APPROVED, Order::ABANDONED, Order::CANCELED].include?(s) }.each do |state|
       context "order in #{state}" do
         let(:state) { state }
         it 'raises error' do


### PR DESCRIPTION
Fixes [PURCHASE-1715](https://artsyproduct.atlassian.net/browse/PURCHASE-1715)

Problem:
MSO team is not able to report offline sales in exchange. This involves changing the state from `canceled` or `abandoned` (why? [discussion here](https://artsyproduct.atlassian.net/browse/PURCHASE-1715?focusedCommentId=31124)) to `fulfilled` as well as editing prices and the fulfillment date. There is no need to capture credit card or send emails since the sale has happened off-platform.

Solution:
Admins now have the ability to confirm offline sale on canceled and abandoned orders and edit prices/date. This also automatically adds an 'Admin note'.

<details><summary>Screenshots</summary>

The button (only appears on abandoned/canceled orders):

<img width="1129" alt="Screen Shot 2020-08-31 at 4 52 41 PM" src="https://user-images.githubusercontent.com/687513/91769489-7bf8e480-ebad-11ea-8bfb-dfc2610eb5cf.png">

This form shows up after pressing the button:

<img width="1141" alt="Screen Shot 2020-08-31 at 4 53 16 PM" src="https://user-images.githubusercontent.com/687513/91769493-7ef3d500-ebad-11ea-98d0-e467ea274900.png">

Changes to order state:

<img width="1122" alt="Screen Shot 2020-08-31 at 4 54 01 PM" src="https://user-images.githubusercontent.com/687513/91769499-81562f00-ebad-11ea-8b4a-6840b10566fe.png">

</details>

~To verify:
I checked mailtrap and the `Confirm fulfillment` button doesn't send emails to the collector so this shouldn't send it either but need to verify that on staging. If you think that is not the case let me know.~  see https://github.com/artsy/exchange/pull/636#issuecomment-685780756