### PR TITLE
Remove order edit button from active admin order page

### DIFF
--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -4,6 +4,8 @@ ActiveAdmin.register Order do
   # TODO: change sort order
   config.sort_order = 'state_updated_at_desc'
 
+  config.action_items.delete_if { |item| item.name == :edit && item.display_on?(:show) }
+
   scope :all
   scope('Submitted', default: true) { |scope| scope.where(state: Order::SUBMITTED) }
   scope('Active', default: true, &:active)


### PR DESCRIPTION

<details><summary>Screenshots</summary>

Before:

<img width="1138" alt="Screen Shot 2020-09-11 at 1 11 39 PM" src="https://user-images.githubusercontent.com/687513/92954404-64352200-f431-11ea-845e-45d47277e52a.png">


After:

<img width="1140" alt="Screen Shot 2020-09-11 at 1 11 49 PM" src="https://user-images.githubusercontent.com/687513/92954412-67c8a900-f431-11ea-9815-cd7fa947265f.png">

</details>

Updating `actions` to `actions :all, except: %i[create destroy new]` in https://github.com/artsy/exchange/pull/636 added the `edit_admin_order_path` path (used for confirm sale button) as well as adding the actual button to page. 
That new `edit` button is not needed and also dangerous. This piece of code removes that. [source](https://stackoverflow.com/questions/44723359/how-do-you-remove-the-edit-button-in-an-active-admin-show)