### PR TITLE
Enable Rubocop for active admin files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Layout/EndAlignment:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+    - "app/admin/**/*"
 
 Metrics/MethodLength:
   Max: 43

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - "vendor/**/*"
     - "spec/support/gravity_helper.rb"
     - "spec/support/taxjar_helper.rb"
-    - "app/admin/**"
     - "db/migrate/**"
 
 Metrics/ParameterLists:

--- a/app/admin/admin_notes.rb
+++ b/app/admin/admin_notes.rb
@@ -4,9 +4,9 @@ ActiveAdmin.register AdminNote do
 
   form do |f|
     f.inputs do
-      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}, wrapper_html: { style: "display:none" }
-      f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
-      f.input :note_type, :as => :select, :collection => AdminNote::TYPES.collect { |type| [type[1].humanize, type[0]] }
+      f.input :order_id, as: :string, input_html: { readonly: true, value: order.id }, wrapper_html: { style: 'display:none' }
+      f.input :admin_id, input_html: { readonly: true, value: current_user[:id] }, wrapper_html: { style: 'display:none' }
+      f.input :note_type, as: :select, collection: AdminNote::TYPES.collect { |type| [type[1].humanize, type[0]] }
       f.input :description
     end
     f.actions

--- a/app/admin/fraud_reviews.rb
+++ b/app/admin/fraud_reviews.rb
@@ -5,9 +5,9 @@ ActiveAdmin.register FraudReview do
 
   form do |f|
     f.inputs do
-      f.input :order_id, as: :string, input_html: {readonly: true, value: order.id}, wrapper_html: { style: "display:none" }
-      f.input :admin_id, input_html: {readonly: true, value: current_user[:id]}, wrapper_html: { style: "display:none" }
-      f.input :flagged_as_fraud, label: "Flag as fraud"
+      f.input :order_id, as: :string, input_html: { readonly: true, value: order.id }, wrapper_html: { style: 'display:none' }
+      f.input :admin_id, input_html: { readonly: true, value: current_user[:id] }, wrapper_html: { style: 'display:none' }
+      f.input :flagged_as_fraud, label: 'Flag as fraud'
       f.input :reason
     end
     f.actions

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -79,7 +79,7 @@ ActiveAdmin.register Order do
   end
 
   member_action :toggle_assisted, method: :post do
-    resource.toggle!(:assisted)
+    resource.update!(assisted: !resource.assisted)
     redirect_to resource_path, notice: 'toggled assisted flag!'
   end
 
@@ -210,8 +210,8 @@ ActiveAdmin.register Order do
         partner_info[:partner_location] = partner_location
         attributes_table_for partner_info do
           row :name
-          row :partner_location do |partner_info|
-            partner_location = partner_info[:partner_location]
+          row :partner_location do |partner|
+            partner_location = partner[:partner_location]
             div partner_location.street_line1
             div partner_location.street_line2
             div "#{partner_location.city}, #{partner_location.region} #{partner_location.postal_code}"
@@ -398,7 +398,7 @@ ActiveAdmin.register Order do
 
   form do |f|
     f.inputs do
-      f.input :offline_sale_date, as: :date_picker, input_html: { value: Date.today }, label: 'Offline sale date'
+      f.input :offline_sale_date, as: :date_picker, input_html: { value: Time.zone.today }, label: 'Offline sale date'
       f.input :admin_note_description, as: :string, input_html: { value: '' }, label: 'Admin note'
       f.input :shipping_total_cents, as: :number, label: "Shipping (#{order.currency_code} cents)"
       f.input :tax_total_cents, as: :number, label: "Sales Tax (#{order.currency_code} cents)"

--- a/app/admin/orders.rb
+++ b/app/admin/orders.rb
@@ -398,8 +398,8 @@ ActiveAdmin.register Order do
 
   form do |f|
     f.inputs do
-      f.input :offline_sale_date, as: :date_picker, input_html: { value: Date.today }, label: 'Offline sale date' 
-      f.input :admin_note_description, as: :string, input_html: { value: '' }, label: 'Admin note' 
+      f.input :offline_sale_date, as: :date_picker, input_html: { value: Date.today }, label: 'Offline sale date'
+      f.input :admin_note_description, as: :string, input_html: { value: '' }, label: 'Admin note'
       f.input :shipping_total_cents, as: :number, label: "Shipping (#{order.currency_code} cents)"
       f.input :tax_total_cents, as: :number, label: "Sales Tax (#{order.currency_code} cents)"
       f.input :buyer_total_cents, as: :number, label: "Buyer Paid (#{order.currency_code} cents)"
@@ -419,7 +419,7 @@ ActiveAdmin.register Order do
 
       # update fulfilled state change timestamp to the `offline_sale_date` provided in the form
       fulfillment_state = resource.state_histories.where(state: Order::FULFILLED).order(created_at: :asc).last
-      fulfillment_state.update!(created_at: offline_sale_date) if fulfillment_state
+      fulfillment_state&.update!(created_at: offline_sale_date)
 
       resource.admin_notes.create!(note_type: AdminNote::TYPES[:offline_sale], admin_id: current_user[:id], description: admin_note_description)
 
@@ -427,5 +427,5 @@ ActiveAdmin.register Order do
         format.html { redirect_to admin_order_path(params[:id]) }
       end
     end
-  end  
+  end
 end


### PR DESCRIPTION
Noticed in https://github.com/artsy/exchange/pull/637#discussion_r487205381 Rubocop wasn't running for Active Admin files. Instead of disabling Rubocop entirely for Active Admin files, let's only disable `Metrics/BlockLength` rule for them (given the Active Admin files tend to be long).

I ran `bundle exec rubocop -a` and manually fixed a few (commented inline).