### PR TITLE
[PURCHASE-2113] Make price/offer editable

### DIFF
--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -35,12 +35,12 @@ module Errors
       missing_required_info
       missing_required_param
       missing_phone_number
+      more_than_one_line_item
       no_taxable_addresses
       not_acquireable
       not_found
       not_last_offer
       not_offerable
-      offer_more_than_one_line_item
       offer_not_from_buyer
       order_not_submitted
       uncommittable_action

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -188,6 +188,12 @@ class Order < ApplicationRecord
     line_items.map(&:total_list_price_cents).sum
   end
 
+  def update_total_list_price_cents(price)
+    raise Errors::ValidationError, :more_than_one_line_item unless line_items.count == 1 && line_items.first.quantity == 1
+
+    line_items.first.update!(list_price_cents: price)
+  end
+
   def can_commit?
     shipping_info? && payment_info?
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -427,4 +427,32 @@ RSpec.describe Order, type: :model do
       end
     end
   end
+
+  describe 'update_total_list_price_cents' do
+    context 'when order has only one line item' do
+      it 'updates price on first line item' do
+        order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-0')])
+        order.update_total_list_price_cents(256)
+        expect(order.total_list_price_cents).to be(256)
+      end
+    end
+    context 'when order has no line item' do
+      it 'raises error' do
+        expect { order.update_total_list_price_cents(256) }.to raise_error(Errors::ValidationError)
+      end
+    end
+    context 'when order has multiple line item' do
+      it 'raises error' do
+        line_items = [Fabricate(:line_item, artwork_id: 'id-0'), Fabricate(:line_item, artwork_id: 'id-1')]
+        order = Fabricate(:order, line_items: line_items)
+        expect { order.update_total_list_price_cents(256) }.to raise_error(Errors::ValidationError)
+      end
+    end
+    context 'when line item has a quantity other than 1' do
+      it 'raises error' do
+        order = Fabricate(:order, line_items: [Fabricate(:line_item, artwork_id: 'id-0', quantity: 2)])
+        expect { order.update_total_list_price_cents(256) }.to raise_error(Errors::ValidationError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/PURCHASE-2113

Follow up to https://github.com/artsy/exchange/pull/636

When creating the offline sale information form forgot to include the artwork price and offer price. This PR adds that. Offer price is straight forward since it is an attribute on `Order` model but artwork price was a bit more tricky because it is derived from sum of `LineItem` prices times their quantity. We currently only have a single `LineItem` on orders and the quantity is always 1 so the new function only handles that case and throws an error if that's not the case. We have a few old orders on production that were manually modified and have multiple line items but no need to worry about that since this 'Offline Sale' is not applicable to them.

![Screen Shot 2020-09-16 at 4 38 13 PM](https://user-images.githubusercontent.com/687513/93390098-283bfb80-f83b-11ea-9217-807ae8f7369a.png)

