### PR TITLE
Change `myOrders` query to accept multiple states

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1158,7 +1158,7 @@ type Query {
     mode: OrderModeEnum
     sellerId: String
     sort: OrderConnectionSortEnum
-    state: OrderStateEnum
+    states: [OrderStateEnum!]
   ): OrderConnectionWithTotalCount
 
   """

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,7 +22,7 @@ class Types::QueryType < Types::BaseObject
   field :my_orders, Types::OrderConnectionWithTotalCountType, null: true, connection: true do
     description 'Return my orders'
     argument :seller_id, String, required: false
-    argument :state, Types::OrderStateEnum, required: false
+    argument :states, [Types::OrderStateEnum], required: false
     argument :sort, Types::OrderConnectionSortEnum, required: false
     argument :mode, Types::OrderModeEnum, required: false
   end
@@ -56,6 +56,8 @@ class Types::QueryType < Types::BaseObject
   def my_orders(params = {})
     raise ActiveRecord::RecordNotFound unless context[:current_user][:id]
 
+    states = params.delete(:states)
+    params = params.merge(state: states) if states.present?
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }
     Order.where(params.merge(buyer_id: context[:current_user][:id])).order(order_clause)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -57,7 +57,7 @@ class Types::QueryType < Types::BaseObject
     raise ActiveRecord::RecordNotFound unless context[:current_user][:id]
 
     states = params.delete(:states)
-    params = params.merge(state: states) if states.present?
+    params = params.merge(state: states) unless states.nil?
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }
     Order.where(params.merge(buyer_id: context[:current_user][:id])).order(order_clause)

--- a/spec/controllers/api/requests/my_orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/my_orders_query_request_spec.rb
@@ -57,6 +57,12 @@ describe Api::GraphqlController, type: :request do
         expect(ids).to match_array([fulfilled_order.id, submitted_order.id])
       end
 
+      it 'returns empty array when an empty state array is passed' do
+        result = client.execute(query, states: [])
+        expect(result.data.my_orders.total_count).to eq 0
+        expect(result.data.my_orders.edges).to eq []
+      end
+
       it 'returns my orders' do
         result = client.execute(query)
         expect(result.data.my_orders.edges.count).to eq 3

--- a/spec/controllers/api/requests/my_orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/my_orders_query_request_spec.rb
@@ -17,8 +17,8 @@ describe Api::GraphqlController, type: :request do
 
     let(:query) do
       <<-GRAPHQL
-        query($sellerId: String, $state: OrderStateEnum, $sort: OrderConnectionSortEnum, $mode: OrderModeEnum, $first: Int) {
-          myOrders(sellerId: $sellerId, state: $state, sort: $sort, mode: $mode, first: $first) {
+        query($sellerId: String, $states: [OrderStateEnum!], $sort: OrderConnectionSortEnum, $mode: OrderModeEnum, $first: Int) {
+          myOrders(sellerId: $sellerId, states: $states, sort: $sort, mode: $mode, first: $first) {
             totalCount
             edges {
               node {
@@ -49,11 +49,12 @@ describe Api::GraphqlController, type: :request do
         expect(ids).to match_array([user1_order2.id, user1_offer_order1.id])
       end
 
-      it 'returns order in specified state' do
+      it 'returns order in specified states' do
         fulfilled_order = Fabricate(:order, buyer_id: my_user_id, state: Order::FULFILLED)
-        result = client.execute(query, state: 'FULFILLED')
+        submitted_order = Fabricate(:order, buyer_id: my_user_id, state: Order::SUBMITTED)
+        result = client.execute(query, states: %w[FULFILLED SUBMITTED])
         ids = ids_from_my_orders_result_data(result)
-        expect(ids).to match_array([fulfilled_order.id])
+        expect(ids).to match_array([fulfilled_order.id, submitted_order.id])
       end
 
       it 'returns my orders' do


### PR DESCRIPTION
#### Problem:

On the purchase history page, we don't want to show the `abandoned` orders but if we do the filtering on the client-side the pagination wouldn't work as expected so we need to do the filtering on the server-side,

#### Solution:

This will change the `state` params to `states` to be able to pass an array of states (everything except 'abandoned') from the client.

#### Breaking change 🚨 

This is a schema breaking change but since we haven't launched purchase history yet it is safe to synchronously deploy it 


 