### PR TITLE
 fix: prefer tzinfo-data gem over tzdata package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apk --no-cache add \
       git \
       nodejs \
       postgresql-dev \
-      tzdata \
       bash # debugging and datadog events
 
 # Set up deploy user, working directory and shared folders for Puma / Nginx

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'sentry-raven'
 gem 'sidekiq', '<6' # for sending emails in the background (<6 necessary for Redis 3 compatibility)
 gem 'stripe'
 gem 'taxjar-ruby', require: 'taxjar'
+gem 'tzinfo-data' # overrides system TZ database
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,8 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.4)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -486,6 +488,7 @@ DEPENDENCIES
   stripe-ruby-mock
   taxjar-ruby
   timecop
+  tzinfo-data
   webmock
 
 RUBY VERSION

--- a/spec/lib/time_zone_spec.rb
+++ b/spec/lib/time_zone_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'time zone parsing' do
+  it 'handles daylight saving time properly' do
+    utc = '2020-12-01T00:00:00+00:00'
+    est = '2020-11-30T19:00:00-05:00'
+    expect(Time.parse(utc).in_time_zone('America/New_York').iso8601).to eq est
+  end
+end


### PR DESCRIPTION
Fixes a silent failure regarding time zone parsing, resulting from updates to the IANA time zone database.

This follows the pattern in:

- https://github.com/artsy/vortex/pull/279
- https://github.com/artsy/diffusion/pull/347
- https://github.com/artsy/volt/pull/4697

Discussion here:
https://artsy.slack.com/archives/C9ZJYFDNF/p1603137517274800

and here:
https://artsy.slack.com/archives/C02BC3HEJ/p1603289217394000
