### PR TITLE
chore: Log revert reason

### DIFF
--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -17,6 +17,7 @@ class OrderProcessor
   end
 
   def revert!(reversion_reason = nil)
+    Rails.logger.warn("Order #{order.id}/#{order.code} reverted. Reason: #{reversion_reason}")
     undeduct_inventory! if @deducted_inventory.any?
     reset_totals! if @totals_set
     revert_debit_exemption(reversion_reason) if @exempted_commission

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -107,6 +107,11 @@ describe OrderProcessor, type: :services do
   end
 
   describe 'revert!' do
+    let(:revert_reason) { 'revert reason' }
+    it 'logs a warning' do
+      expect(Rails.logger).to receive(:warn).with("Order #{order.id}/#{order.code} reverted. Reason: #{revert_reason}")
+      order_processor.revert! revert_reason
+    end
     it 'undeducts inventory if there are deducted inventories' do
       order_processor.instance_variable_set(:@deducted_inventory, [line_item1, line_item2])
       stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)


### PR DESCRIPTION
Fixes [PURCHASE-2242](https://artsyproduct.atlassian.net/browse/PURCHASE-2242)

Problem:
When a submitted order gets reverted we don't leave enough paper trail to troubleshoot the problem

Solution:
Log revert reason to Rails logger for better troubleshooting