### PR TITLE
fix: remove unsupported daemonization in Puma 5

### DIFF
--- a/config/puma.config
+++ b/config/puma.config
@@ -2,7 +2,6 @@
 
 directory "/app"
 environment ENV.fetch("RAILS_ENV") { "development" }
-daemonize false
 pidfile  "/shared/pids/puma.pid"
 state_path "/shared/pids/puma.state"
 threads ENV.fetch("PUMA_THREAD_MIN") { 0 }.to_i, ENV.fetch("PUMA_THREAD_MAX") { 16 }.to_i


### PR DESCRIPTION
`daemonize` has been removed in Puma 5. Removing it should behave the same since we want to run it on the foreground.

> tcp mode and daemonization have been removed without replacement. For
daemonization, please use a modern process management solution, such as
systemd or monit.

https://github.com/puma/puma/blob/master/5.0-Upgrade.md#upgrade

The error can be reproduced when running `BUNDLE_GITHUB__COM=... hokusai dev start`:

![Screen Shot 2021-01-15 at 3 27 49 PM](https://user-images.githubusercontent.com/796573/104775384-3e54bc80-5746-11eb-92c7-c6bf2820c682.png)
