### PR TITLE
fix: allow postgres connection without password in hokusai dev

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -19,6 +19,8 @@ services:
       - exchange-db
   exchange-db:
     image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   exchange-redis:
     image: redis:3.2-alpine
   worker:

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -10,13 +10,11 @@ services:
       - DATABASE_HOST=exchange-db
       - DATABASE_USER=postgres
       - REDIS_URL=redis://exchange-redis
-
       - CI_PULL_REQUEST=$CI_PULL_REQUEST
       - CIRCLE_PULL_REQUEST=$CIRCLE_PULL_REQUEST
       - CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM
       - DANGER_GITHUB_API_TOKEN=$DANGER_GITHUB_API_TOKEN
       - CI=$CI
-
     command: ./hokusai/ci.sh
     depends_on:
       - exchange-db


### PR DESCRIPTION
When running `hokusai dev start`, postgres gives an error of

```
Database is uninitialized and superuser password is not specified.`
```

This follows the prompt and existing pattern in [Gravity](https://github.com/artsy/gravity/blob/6d5ea778793cf9ce095494a3cc55a0485b207efd/hokusai/development.yml#L113) to set

```
POSTGRES_HOST_AUTH_METHOD=trust
```

and allow connection without password in hokusai dev.

![Screen Shot 2021-01-15 at 4 26 19 PM](https://user-images.githubusercontent.com/796573/104780829-6563bc00-574f-11eb-896e-dc302017cd36.png)
