### PR TITLE
Fix: persist impulse_conversation_id

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -747,6 +747,7 @@ type OfferOrder implements Order {
   currencyCode: String!
   displayCommissionRate: String
   id: ID!
+  impulseConversationId: String
   internalID: ID!
 
   """

--- a/app/graphql/types/offer_order_type.rb
+++ b/app/graphql/types/offer_order_type.rb
@@ -8,6 +8,7 @@ class Types::OfferOrderType < Types::BaseObject
   field :last_offer, Types::OfferType, null: true, description: 'Last submitted offer'
   field :my_last_offer, Types::OfferType, null: true
   field :awaiting_response_from, Types::OrderParticipantEnum, null: true
+  field :impulse_conversation_id, String, null: true
 
   def offers(**args)
     offers = object.offers.submitted

--- a/lib/order_creator.rb
+++ b/lib/order_creator.rb
@@ -117,7 +117,8 @@ class OrderCreator
         state_expires_at: Order::STATE_EXPIRATIONS[Order::PENDING].from_now,
         original_user_agent: @user_agent,
         original_user_ip: @user_ip,
-        payment_method: Order::CREDIT_CARD # Default to credit card payment method
+        payment_method: Order::CREDIT_CARD, # Default to credit card payment method
+        impulse_conversation_id: @impulse_conversation_id
       )
 
       line_item = order.line_items.create!(

--- a/spec/controllers/api/requests/offers/create_inquiry_offer_order_with_artwork_mutation_request_spec.rb
+++ b/spec/controllers/api/requests/offers/create_inquiry_offer_order_with_artwork_mutation_request_spec.rb
@@ -38,6 +38,9 @@ describe Api::GraphqlController, type: :request do
                       id
                     }
                   }
+                  ... on OfferOrder {
+                    impulseConversationId
+                  }
                 }
               }
               ... on OrderWithMutationFailure {
@@ -271,6 +274,7 @@ describe Api::GraphqlController, type: :request do
                 response = client.execute(mutation, input: { artworkId: artwork_id, impulseConversationId: '24681357' })
               end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
               order_id = response.data.create_inquiry_offer_order_with_artwork.order_or_error.order.id
+              order_conversation_id = response.data.create_inquiry_offer_order_with_artwork.order_or_error.order.impulse_conversation_id
               expect(order_id).not_to be_nil
               order = Order.last
               expect(response.data.create_inquiry_offer_order_with_artwork.order_or_error).not_to respond_to(:error)
@@ -283,6 +287,7 @@ describe Api::GraphqlController, type: :request do
               expect(order.line_items.first.artwork_id).to eq 'artwork-id'
               expect(order.line_items.first.edition_set_id).to be_nil
               expect(order.line_items.first.quantity).to eq 1
+              expect(order_conversation_id).to eq '24681357'
             end
           end
 

--- a/spec/services/order_service_spec.rb
+++ b/spec/services/order_service_spec.rb
@@ -101,6 +101,7 @@ describe OrderService, type: :services do
             expect(order.seller_id).to eq 'gravity-partner-id'
             expect(order.line_items.count).to eq 1
             expect(order.line_items.pick(:artwork_id, :edition_set_id, :quantity)).to eq [artwork_id, edition_set_id, 2]
+            expect(order.impulse_conversation_id).to eq('11223344556677')
           end.to change(Order, :count).by(1).and change(LineItem, :count).by(1)
         end
       end


### PR DESCRIPTION
Addresses [PURCHASE-2418](https://artsyproduct.atlassian.net/browse/PURCHASE-2418)

This PR expands the `OfferOrderType` to include `impulse_conversation_id`. The `impulse_conversation_id` wasn't getting persisted to the database so this also updates creation transaction inside the OrderCreator file.

[Corresponding metaphysics PR](https://github.com/artsy/metaphysics/pull/2977)

cc: @artsy/purchase-devs 