### PR TITLE
feat: filter orders query field by conversation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1241,6 +1241,7 @@ type Query {
     Returns the first _n_ elements from the list.
     """
     first: Int
+    impulseConversationId: String
 
     """
     Returns the last _n_ elements from the list.

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,6 +11,7 @@ class Types::QueryType < Types::BaseObject
   field :orders, Types::OrderConnectionWithTotalCountType, null: true, connection: true do
     description 'Find list of orders'
     argument :seller_id, String, required: false
+    argument :impulse_conversation_id, String, required: false
     argument :seller_type, String, required: false
     argument :buyer_id, String, required: false
     argument :buyer_type, String, required: false

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -15,7 +15,6 @@ describe Api::GraphqlController, type: :request do
     let!(:user1_order2) { Fabricate(:order, seller_type: 'partner', seller_id: second_seller_id, buyer_type: 'user', buyer_id: user_id, updated_at: 2.days.ago) }
     let!(:user1_offer_order1) { Fabricate(:order, seller_type: 'partner', seller_id: second_seller_id, buyer_type: 'user', buyer_id: user_id, updated_at: 1.day.ago, mode: Order::OFFER) }
     let!(:user2_order1) { Fabricate(:order, seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: second_user) }
-    let!(:user1_conversation_offer_order2) { Fabricate(:order, impulse_conversation_id: 'conv-id', seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: user_id, updated_at: 1.day.ago, mode: Order::OFFER) }
 
     let(:query) do
       <<-GRAPHQL
@@ -163,21 +162,24 @@ describe Api::GraphqlController, type: :request do
     end
 
     context 'query with conversationId' do
+      let!(:user1_conversation_offer_order1) { Fabricate(:order, impulse_conversation_id: 'conversationid1', seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: user_id, updated_at: 1.day.ago, mode: Order::OFFER) }
+      let!(:user1_conversation_offer_order2) { Fabricate(:order, impulse_conversation_id: 'conversationid2', seller_type: 'partner', seller_id: seller_id, buyer_type: 'user', buyer_id: user_id, updated_at: 1.day.ago, mode: Order::OFFER) }
+
       it 'returns orders by conversation and buyer id' do
-        result = client.execute(query, impulseConversationId: 'conv-id', buyerId: user_id)
+        result = client.execute(query, impulseConversationId: 'conversationid1', buyerId: user_id)
         ids = ids_from_result_data(result)
-        expect(ids).to eq([user1_conversation_offer_order2.id])
+        expect(ids).to eq([user1_conversation_offer_order1.id])
       end
 
       it 'returns orders by conversation and buyer id' do
-        result = client.execute(query, impulseConversationId: 'conv-id', sellerId: seller_id)
+        result = client.execute(query, impulseConversationId: 'conversationid1', sellerId: seller_id)
         ids = ids_from_result_data(result)
-        expect(ids).to eq([user1_conversation_offer_order2.id])
+        expect(ids).to eq([user1_conversation_offer_order1.id])
       end
 
       it 'rejects a request without a buyer or seller id' do
         expect do
-          client.execute(query, impulseConversationId: 'conv-id')
+          client.execute(query, impulseConversationId: 'conversationid1')
         end.to raise_error do |error|
           expect(error).to be_a(Graphlient::Errors::ServerError)
           expect(error.message).to eq 'the server responded with status 400'


### PR DESCRIPTION
This PR adds a field `impulseConversationId` to the `orders` query field to allow filtering by conversation ID. `buyerId` or `sellerId` is still required.

🔒 [slack conversation that led to this change](https://artsy.slack.com/archives/C9YNS4X32/p1614119355107900)