### PR TITLE
Update new graphql schema to be less ambiguous

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1037,8 +1037,8 @@ type OrderRequiresAction {
 
 type OrderStateChangedEvent implements EventInterface {
   createdAt: DateTime!
+  state: OrderStateEnum!
   stateReason: String
-  type: OrderStateEnum!
 }
 
 enum OrderStateEnum {

--- a/app/graphql/types/events/order_state_changed_event.rb
+++ b/app/graphql/types/events/order_state_changed_event.rb
@@ -1,5 +1,5 @@
 class Types::Events::OrderStateChangedEvent < Types::BaseObject
   implements Types::Events::EventInterface
-  field :type, Types::OrderStateEnum, null: false
+  field :state, Types::OrderStateEnum, null: false
   field :state_reason, String, null: true
 end

--- a/app/services/order_history_service.rb
+++ b/app/services/order_history_service.rb
@@ -1,6 +1,6 @@
 class OrderHistoryService
   OfferSubmitted = Struct.new(:created_at, :offer, keyword_init: true)
-  OrderStateChanged = Struct.new(:created_at, :type, :state_reason, keyword_init: true)
+  OrderStateChanged = Struct.new(:created_at, :state, :state_reason, keyword_init: true)
 
   def self.events_for(order_id:)
     order = Order.find(order_id)
@@ -15,7 +15,7 @@ class OrderHistoryService
 
   def self.state_events(order)
     order.state_histories.map do |state_history|
-      OrderStateChanged.new(created_at: state_history.created_at, type: state_history.state, state_reason: state_history.reason)
+      OrderStateChanged.new(created_at: state_history.created_at, state: state_history.state, state_reason: state_history.reason)
     end
   end
 

--- a/spec/controllers/api/requests/order_history_request_spec.rb
+++ b/spec/controllers/api/requests/order_history_request_spec.rb
@@ -47,7 +47,7 @@ describe Api::GraphqlController, type: :request do
               }
               ... on OrderStateChangedEvent {
                 createdAt
-                type
+                state
                 stateReason
               }
             }
@@ -86,10 +86,10 @@ describe Api::GraphqlController, type: :request do
         expect(events.length).to be(2)
 
         expect(events[0].__typename).to eq 'OrderStateChangedEvent'
-        expect(events[0].type).to eq 'PENDING'
+        expect(events[0].state).to eq 'PENDING'
 
         expect(events[1].__typename).to eq 'OrderStateChangedEvent'
-        expect(events[1].type).to eq 'SUBMITTED'
+        expect(events[1].state).to eq 'SUBMITTED'
       end
     end
 
@@ -114,10 +114,10 @@ describe Api::GraphqlController, type: :request do
           expect(events.length).to be(5)
 
           expect(events[0].__typename).to eq 'OrderStateChangedEvent'
-          expect(events[0].type).to eq 'PENDING'
+          expect(events[0].state).to eq 'PENDING'
 
           expect(events[1].__typename).to eq 'OrderStateChangedEvent'
-          expect(events[1].type).to eq 'SUBMITTED'
+          expect(events[1].state).to eq 'SUBMITTED'
 
           expect(events[2].__typename).to eq 'OfferSubmittedEvent'
           expect(events[2].offer.amount_cents).to eq 200

--- a/spec/services/order_history_service_spec.rb
+++ b/spec/services/order_history_service_spec.rb
@@ -38,7 +38,7 @@ describe OrderHistoryService, type: :services do
           events = OrderHistoryService.events_for(order_id: order.id)
           expect(events.length).to be 4
           expect(events.map { |event| event.class.name.demodulize }).to eq %w[OrderStateChanged OrderStateChanged OrderStateChanged OrderStateChanged]
-          expect(events.map(&:type)).to eq %w[pending submitted approved fulfilled]
+          expect(events.map(&:state)).to eq %w[pending submitted approved fulfilled]
         end
       end
       describe 'seller lapsed order' do
@@ -50,7 +50,7 @@ describe OrderHistoryService, type: :services do
           events = OrderHistoryService.events_for(order_id: order.id)
           expect(events.length).to be 3
           expect(events.map { |event| event.class.name.demodulize }).to eq %w[OrderStateChanged OrderStateChanged OrderStateChanged]
-          expect(events.map(&:type)).to eq %w[pending submitted canceled]
+          expect(events.map(&:state)).to eq %w[pending submitted canceled]
         end
       end
     end
@@ -60,8 +60,8 @@ describe OrderHistoryService, type: :services do
           events = OrderHistoryService.events_for(order_id: order.id)
           expect(events.length).to be 3
           expect(events.map { |event| event.class.name.demodulize }).to eq %w[OrderStateChanged OfferSubmitted OrderStateChanged]
-          expect(events[0].type).to eq 'pending'
-          expect(events[2].type).to eq 'submitted'
+          expect(events[0].state).to eq 'pending'
+          expect(events[2].state).to eq 'submitted'
           expect(events[1].offer.amount_cents).to eq  100000
           expect(events[1].offer.from_participant).to eq 'buyer'
         end
@@ -104,9 +104,9 @@ describe OrderHistoryService, type: :services do
           events = OrderHistoryService.events_for(order_id: order.id)
           expect(events.length).to be 5
           expect(events.map { |event| event.class.name.demodulize }).to eq %w[OrderStateChanged OfferSubmitted OrderStateChanged OfferSubmitted OrderStateChanged]
-          expect(events[0].type).to eq 'pending'
-          expect(events[2].type).to eq 'submitted'
-          expect(events[4].type).to eq 'approved'
+          expect(events[0].state).to eq 'pending'
+          expect(events[2].state).to eq 'submitted'
+          expect(events[4].state).to eq 'approved'
           expect(events[1].offer.from_participant).to eq 'buyer'
           expect(events[3].offer.from_participant).to eq 'seller'
         end


### PR DESCRIPTION
This pr builds on https://github.com/artsy/exchange/pull/683 with a minor naming change: `OrderStateChangedEvent#type` -> `#state`. Up for debate whether we want to do it but the change would be easier now than later.