### PR TITLE
feat: do not require inventory for inquiry orders (PURCHASE-2471)

### DIFF
--- a/app/controllers/errors/application_error.rb
+++ b/app/controllers/errors/application_error.rb
@@ -9,7 +9,7 @@ module Errors
       @code = code
       @data = data
       post_error_event if post_event
-      super(type)
+      super(code)
     end
 
     private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -155,6 +155,14 @@ class Order < ApplicationRecord
     seller_type == AUCTION_SELLER_TYPE
   end
 
+  def inquiry_order?
+    impulse_conversation_id.present?
+  end
+
+  def require_inventory?
+    !inquiry_order?
+  end
+
   def to_s
     "Order #{id}"
   end

--- a/app/services/inventory_service.rb
+++ b/app/services/inventory_service.rb
@@ -1,0 +1,24 @@
+class InventoryService
+  def initialize(order)
+    @order = order
+    @deducted_items = []
+  end
+
+  def check_inventory!
+    raise Errors::InsufficientInventoryError unless @order.inventory?
+  end
+
+  def deduct_inventory!
+    @order.line_items.each do |item|
+      Gravity.deduct_inventory(item)
+      @deducted_items << item
+    end
+  end
+
+  def undeduct_inventory!
+    until @deducted_items.empty?
+      Gravity.undeduct_inventory(@deducted_items.first)
+      @deducted_items.shift
+    end
+  end
+end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -55,7 +55,7 @@ module OfferService
     raise Errors::ValidationError, order_processor.validation_error unless order_processor.valid?
 
     order_processor.advance_state(:approve!)
-    raise Errors::InsufficientInventoryError unless order_processor.deduct_inventory
+    order_processor.deduct_inventory!
 
     # this is an off-session if offer is from buyer and seller is accepting it (in case of failed payment buyer could accept their own offer)
     off_session = offer.from_participant == Order::BUYER && user_id != order.buyer_id
@@ -72,7 +72,7 @@ module OfferService
     order
   rescue StandardError => e
     # catch all
-    order_processor&.revert!
+    order_processor&.revert!(e.message)
     raise e
   end
 end

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -51,10 +51,7 @@ module OrderService
     raise Errors::ValidationError, order_processor.validation_error unless order_processor.valid?
 
     order_processor.advance_state(:submit!)
-    unless order_processor.deduct_inventory
-      order_processor.revert!('insufficient_inventory')
-      raise Errors::InsufficientInventoryError
-    end
+    order_processor.deduct_inventory!
 
     order_processor.set_totals!
     order_processor.hold

--- a/app/services/order_service.rb
+++ b/app/services/order_service.rb
@@ -124,7 +124,7 @@ module OrderService
     order.seller_lapse!
     order_cancelation_processor = OrderCancelationProcessor.new(order)
     order_cancelation_processor.cancel_payment if order.mode == Order::BUY
-    order_cancelation_processor.queue_undeduct_inventory_jobs if order.mode == Order::BUY
+    order_cancelation_processor.queue_undeduct_inventory_jobs if order.mode == Order::BUY && order.require_inventory?
     order_cancelation_processor.notify
     Exchange.dogstatsd.increment 'order.seller_lapsed'
   end
@@ -141,7 +141,7 @@ module OrderService
     order.reject!(reason)
     order_cancelation_processor = OrderCancelationProcessor.new(order, user_id)
     order_cancelation_processor.cancel_payment if order.mode == Order::BUY
-    order_cancelation_processor.queue_undeduct_inventory_jobs if order.mode == Order::BUY
+    order_cancelation_processor.queue_undeduct_inventory_jobs if order.mode == Order::BUY && order.require_inventory?
     order_cancelation_processor.notify
     Exchange.dogstatsd.increment 'order.reject'
   end
@@ -150,7 +150,7 @@ module OrderService
     order.refund!
     order_cancelation_processor = OrderCancelationProcessor.new(order)
     order_cancelation_processor.refund_payment
-    order_cancelation_processor.queue_undeduct_inventory_jobs
+    order_cancelation_processor.queue_undeduct_inventory_jobs if order.require_inventory?
     order_cancelation_processor.notify
     Exchange.dogstatsd.increment 'order.refund'
     Exchange.dogstatsd.count("order.money_refunded_#{order.currency_code}", order.buyer_total_cents)

--- a/lib/offer_processor.rb
+++ b/lib/offer_processor.rb
@@ -6,6 +6,7 @@ class OfferProcessor
     @order = offer.order
     @user_id = user_id
     @state_changed = false
+    @inventory_service = InventoryService.new(@order)
   end
 
   def validate_offer!
@@ -13,7 +14,7 @@ class OfferProcessor
   end
 
   def check_inventory!
-    raise Errors::InsufficientInventoryError unless order.inventory?
+    @inventory_service.check_inventory!
   end
 
   def validate_order!

--- a/lib/offer_processor.rb
+++ b/lib/offer_processor.rb
@@ -14,7 +14,7 @@ class OfferProcessor
   end
 
   def check_inventory!
-    @inventory_service.check_inventory!
+    @inventory_service.check_inventory! if @order.require_inventory?
   end
 
   def validate_order!

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -91,20 +91,16 @@ class OrderProcessor
     @validation_error.nil?
   end
 
+  def deduct_inventory!
+    @order.line_items.each do |item|
+      Gravity.deduct_inventory(item)
+      @deducted_inventory << item
+    end
+  end
+
   def undeduct_inventory!
     @deducted_inventory.each { |li| Gravity.undeduct_inventory(li) }
     @deducted_inventory = []
-  end
-
-  def deduct_inventory
-    # Try holding artwork and deduct inventory
-    @order.line_items.each do |li|
-      Gravity.deduct_inventory(li)
-      @deducted_inventory << li
-    end
-    true
-  rescue Errors::InsufficientInventoryError
-    false
   end
 
   def store_transaction(off_session = false)

--- a/lib/order_processor.rb
+++ b/lib/order_processor.rb
@@ -92,11 +92,11 @@ class OrderProcessor
   end
 
   def deduct_inventory!
-    @inventory_service.deduct_inventory!
+    @inventory_service.deduct_inventory! if @order.require_inventory?
   end
 
   def undeduct_inventory!
-    @inventory_service.undeduct_inventory!
+    @inventory_service.undeduct_inventory! if @order.require_inventory?
   end
 
   def store_transaction(off_session = false)

--- a/spec/controllers/errors/application_error_spec.rb
+++ b/spec/controllers/errors/application_error_spec.rb
@@ -15,4 +15,13 @@ describe Errors::ApplicationError do
       expect(PostEventJob).not_to have_been_enqueued
     end
   end
+
+  describe 'error message' do
+    it 'uses the code as the error message' do
+      error = Errors::InsufficientInventoryError.new
+
+      expect(error.type).to eq :processing
+      expect(error.message).to eq 'insufficient_inventory'
+    end
+  end
 end

--- a/spec/integration/inquiry_checkout_happy_path_spec.rb
+++ b/spec/integration/inquiry_checkout_happy_path_spec.rb
@@ -240,7 +240,7 @@ describe 'Inquiry Checkout happy path with missing artwork metadata', type: :req
 
     # TODO: feat: capture payment and update transactions
     allow_any_instance_of(OrderProcessor).to receive_messages(
-      deduct_inventory: true,
+      deduct_inventory!: nil,
       debit_commission_exemption: nil,
       charge: nil,
       store_transaction: nil

--- a/spec/lib/offer_processor_spec.rb
+++ b/spec/lib/offer_processor_spec.rb
@@ -13,19 +13,31 @@ describe OfferProcessor, type: :services do
       offer.update!(submitted_at: Time.now.utc)
       expect { op.validate_offer! }.to raise_error(Errors::ValidationError)
     end
+
     it 'does not raise error when order is not submitted' do
       expect { op.validate_offer! }.not_to raise_error
     end
   end
 
   describe '#check_inventory!' do
-    it 'raises error when there are no inventory' do
-      allow(order).to receive(:inventory?).and_return(false)
-      expect { op.check_inventory! }.to raise_error(Errors::InsufficientInventoryError)
+    context 'with inventory' do
+      it 'does not raise error' do
+        allow(order).to receive(:inventory?).and_return(true)
+        expect { op.check_inventory! }.not_to raise_error
+      end
     end
-    it 'does not raise error' do
-      allow(order).to receive(:inventory?).and_return(true)
-      expect { op.check_inventory! }.not_to raise_error
+
+    context 'without inventory' do
+      it 'raises error' do
+        allow(order).to receive(:inventory?).and_return(false)
+        expect { op.check_inventory! }.to raise_error(Errors::InsufficientInventoryError)
+      end
+
+      it 'does not raise error for inquiry orders' do
+        order.impulse_conversation_id = '401'
+        allow(order).to receive(:inventory?).and_return(false)
+        expect { op.check_inventory! }.not_to raise_error
+      end
     end
   end
 
@@ -34,18 +46,22 @@ describe OfferProcessor, type: :services do
       order.update!(mode: Order::BUY)
       expect { op.validate_order! }.to raise_error(Errors::ValidationError)
     end
+
     it 'raises error when order not committable' do
       allow(order).to receive(:can_commit?).and_return(false)
       expect { op.validate_order! }.to raise_error(Errors::ValidationError)
     end
+
     it 'raises error when invalid artwork version' do
       allow(order).to receive(:valid_artwork_version?).and_return(false)
       expect { op.validate_order! }.to raise_error(Errors::ValidationError)
     end
+
     it 'raises error when invalid credit card' do
       allow(order).to receive(:assert_credit_card).and_return(:credit_card_missing_external_id)
       expect { op.validate_order! }.to raise_error(Errors::ValidationError)
     end
+
     it 'does not raise error Oif all good and sunny' do
       allow(order).to receive_messages(
         can_commit?: true,
@@ -71,6 +87,7 @@ describe OfferProcessor, type: :services do
         expect { op.confirm_payment_method! }.to change(order.transactions, :count).by(1)
         expect(order.transactions.first.id).to eq transaction.id
       end
+
       it 'adds transaction to the order and raises error in case of require action' do
         transaction = Fabricate(:transaction, status: Transaction::REQUIRES_ACTION, payload: { client_secret: 'si_test1' })
         expect(PaymentMethodService).to receive(:confirm_payment_method!).with(order).and_return(transaction)
@@ -78,18 +95,21 @@ describe OfferProcessor, type: :services do
         expect(order.transactions.first.id).to eq transaction.id
       end
     end
+
     context 'verifying existing setup intent' do
       it 'adds transaction to the order in case of success' do
         prepare_setup_intent_retrieve
         expect { op.confirm_payment_method!('si_1') }.to change(order.transactions, :count).by(1)
         expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::SUCCESS)
       end
+
       it 'adds transaction to the order and raises error in case of require action' do
         prepare_setup_intent_retrieve(status: 'requires_action')
         expect { op.confirm_payment_method!('si_1') }.to raise_error(Errors::PaymentRequiresActionError).and change(order.transactions, :count).by(1)
         expect(order.transactions.first).to have_attributes(external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM, status: Transaction::REQUIRES_ACTION)
       end
     end
+
     context 'setup intent fails with card_decline' do
       it 'adds transaction to the order and raises error in case of require action' do
         transaction = Fabricate(:transaction, status: Transaction::FAILURE, external_id: 'si_1', external_type: Transaction::SETUP_INTENT, transaction_type: Transaction::CONFIRM)
@@ -115,9 +135,11 @@ describe OfferProcessor, type: :services do
     it 'queues OrderFollowUpJob' do
       expect(OrderFollowUpJob).to have_been_enqueued.with(order.id, Order::SUBMITTED)
     end
+
     it 'queues OfferRespondReminderJob' do
       expect(OfferRespondReminderJob).to have_been_enqueued.with(order.id, offer.id)
     end
+
     it 'posts offer event' do
       expect(PostEventJob).to have_been_enqueued
     end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -229,21 +229,25 @@ describe OrderProcessor, type: :services do
     end
   end
 
-  describe 'deduct_inventory' do
+  describe 'deduct_inventory!' do
     before do
       line_item2
     end
-    it 'returns true when fully deducted inventory' do
+    it 'does not raise an exception when fully deducted inventory' do
       stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
       stub_line_item_2_gravity_deduct.to_return(status: 200, body: {}.to_json)
-      expect(order_processor.deduct_inventory).to be true
+      expect do
+        order_processor.deduct_inventory!
+      end.to_not raise_error
       expect(stub_line_item_1_gravity_deduct).to have_been_requested
       expect(stub_line_item_2_gravity_deduct).to have_been_requested
     end
-    it 'returns false on insufficient inventory' do
+    it 'raises an exception on insufficient inventory' do
       stub_line_item_1_gravity_deduct.to_return(status: 200, body: {}.to_json)
       stub_line_item_2_gravity_deduct.to_return(status: 400, body: {}.to_json)
-      expect(order_processor.deduct_inventory).to be false
+      expect do
+        order_processor.deduct_inventory!
+      end.to raise_error(Errors::InsufficientInventoryError)
       expect(stub_line_item_1_gravity_deduct).to have_been_requested
       expect(stub_line_item_2_gravity_deduct).to have_been_requested
     end

--- a/spec/lib/order_processor_spec.rb
+++ b/spec/lib/order_processor_spec.rb
@@ -113,7 +113,9 @@ describe OrderProcessor, type: :services do
       order_processor.revert! revert_reason
     end
     it 'undeducts inventory if there are deducted inventories' do
-      order_processor.instance_variable_set(:@deducted_inventory, [line_item1, line_item2])
+      inventory_service = InventoryService.new(order)
+      inventory_service.instance_variable_set(:@deducted_items, [line_item1, line_item2])
+      order_processor.instance_variable_set(:@inventory_service, inventory_service)
       stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)
       stub_line_item_2_gravity_undeduct.to_return(status: 200, body: {}.to_json)
       order_processor.revert!
@@ -137,7 +139,6 @@ describe OrderProcessor, type: :services do
       )
     end
     it 'it reverts submitted order to pending' do
-      order_processor.instance_variable_set(:@deducted_inventory, [])
       order.submit!
       original_state_expires_at = order.reload.state_expires_at
       order_processor.instance_variable_set(:@state_changed, true)
@@ -255,7 +256,9 @@ describe OrderProcessor, type: :services do
 
   describe 'undedudct_inventory!' do
     before do
-      order_processor.instance_variable_set(:@deducted_inventory, [line_item1, line_item2])
+      inventory_service = InventoryService.new(order)
+      inventory_service.instance_variable_set(:@deducted_items, [line_item1, line_item2])
+      order_processor.instance_variable_set(:@inventory_service, inventory_service)
     end
     it 'calls undeduct for line items' do
       stub_line_item_1_gravity_undeduct.to_return(status: 200, body: {}.to_json)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -308,6 +308,30 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe '#inquiry_order?' do
+    it 'is true with impulse conversation id' do
+      order = Fabricate(:order, impulse_conversation_id: '401')
+      expect(order.inquiry_order?).to eq true
+    end
+
+    it 'is false with no impulse conversation id' do
+      order = Fabricate(:order, impulse_conversation_id: nil)
+      expect(order.inquiry_order?).to eq false
+    end
+  end
+
+  describe '#require_inventory?' do
+    it 'is true for non-inquiry order' do
+      order = Fabricate(:order, impulse_conversation_id: nil)
+      expect(order.require_inventory?).to eq true
+    end
+
+    it 'is false for inquiry order' do
+      order = Fabricate(:order, impulse_conversation_id: '401')
+      expect(order.require_inventory?).to eq false
+    end
+  end
+
   describe '#last_transaction_failed?' do
     context 'with an offer order' do
       let(:order) { Fabricate(:order, mode: Order::OFFER, offers: [Fabricate(:offer)]) }

--- a/spec/services/inventory_service_spec.rb
+++ b/spec/services/inventory_service_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+describe InventoryService do
+  let(:artwork1_inventory) { { count: 1, unlimited: false } }
+  let(:artwork1) { gravity_v1_artwork(_id: 'artwork-1', current_version_id: 'artwork-version-1', inventory: artwork1_inventory) }
+  let(:artwork2) { gravity_v1_artwork(_id: 'artwork-1', current_version_id: 'artwork-version-1', inventory: { count: 2, unlimited: false }) }
+
+  let(:order) do
+    Fabricate(
+      :order,
+      mode: Order::BUY,
+      buyer_id: 'buyer-1',
+      fulfillment_type: Order::SHIP,
+      credit_card_id: 'cc-1',
+      seller_id: 'seller-1',
+      shipping_name: 'Fname Lname',
+      shipping_address_line1: '12 Vanak St',
+      shipping_address_line2: 'P 80',
+      shipping_city: 'Tehran',
+      shipping_postal_code: '02198',
+      buyer_phone_number: '00123456',
+      shipping_country: 'IR',
+      items_total_cents: 3000_00
+    )
+  end
+  let(:line_item1) { Fabricate(:line_item, order: order, quantity: 1, list_price_cents: 1000_00, artwork_id: artwork1[:_id], artwork_version_id: artwork1[:current_version_id], sales_tax_cents: 0, shipping_total_cents: 0) }
+  let(:line_item2) { Fabricate(:line_item, order: order, quantity: 2, list_price_cents: 1000_00, artwork_id: artwork2[:_id], artwork_version_id: artwork2[:current_version_id], sales_tax_cents: 0, shipping_total_cents: 0) }
+
+  let(:get_artwork1_request) { stub_request(:get, "#{gravity_v1_api_root}/artwork/#{artwork1[:_id]}").to_return(status: 200, body: artwork1.to_json) }
+  let(:get_artwork2_request) { stub_request(:get, "#{gravity_v1_api_root}/artwork/#{artwork2[:_id]}").to_return(status: 200, body: artwork2.to_json) }
+
+  let(:deduct_artwork1_inventory_request) { stub_request(:put, "#{gravity_v1_api_root}/artwork/#{artwork1[:_id]}/inventory").with(body: { deduct: 1 }) }
+  let(:deduct_artwork2_inventory_request) { stub_request(:put, "#{gravity_v1_api_root}/artwork/#{artwork2[:_id]}/inventory").with(body: { deduct: 2 }) }
+  let(:undeduct_artwork1_inventory_request) { stub_request(:put, "#{gravity_v1_api_root}/artwork/#{artwork1[:_id]}/inventory").with(body: { undeduct: 1 }) }
+  let(:undeduct_artwork2_inventory_request) { stub_request(:put, "#{gravity_v1_api_root}/artwork/#{artwork1[:_id]}/inventory").with(body: { undeduct: 2 }) }
+
+  let(:service) { InventoryService.new(order) }
+
+  before do
+    line_item1
+    line_item2
+    get_artwork1_request
+  end
+
+  describe '#check_inventory' do
+    xcontext 'with null inventory' do
+      let(:artwork1_inventory) { nil }
+
+      it 'raises an exception' do
+        expect do
+          service.check_inventory!
+        end.to raise_error(Errors::InsufficientInventoryError)
+      end
+    end
+
+    context 'with insufficient inventory' do
+      let(:artwork1_inventory) { { count: 0, unlimited: false } }
+
+      it 'raises an exception' do
+        expect do
+          service.check_inventory!
+        end.to raise_error(Errors::InsufficientInventoryError)
+      end
+    end
+
+    context 'with sufficient inventory' do
+      it 'does not raise an exception with sufficient inventory' do
+        expect do
+          service.check_inventory!
+        end.to_not raise_error
+      end
+    end
+  end
+
+  describe '#deduct_inventory!' do
+    context 'on success' do
+      before do
+        deduct_artwork1_inventory_request.to_return(status: 200, body: {}.to_json)
+        deduct_artwork2_inventory_request.to_return(status: 200, body: {}.to_json)
+
+        service.deduct_inventory!
+      end
+
+      it 'deducts inventory for all line items of the order' do
+        expect(deduct_artwork1_inventory_request).to have_been_made
+        expect(deduct_artwork2_inventory_request).to have_been_made
+      end
+
+      it 'pushes deducted items in a queue' do
+        expect(service.instance_variable_get(:@deducted_items)).to eq [line_item1, line_item2]
+      end
+    end
+
+    context 'on failure' do
+      before do
+        deduct_artwork1_inventory_request.to_return(status: 200, body: {}.to_json)
+        deduct_artwork2_inventory_request.to_return(status: 400, body: {}.to_json)
+      end
+
+      it 'raises an exception' do
+        expect do
+          service.deduct_inventory!
+        end.to raise_error(Errors::InsufficientInventoryError)
+
+        expect(deduct_artwork1_inventory_request).to have_been_made
+        expect(deduct_artwork2_inventory_request).to have_been_made
+      end
+
+      it 'pushes deducted items in a queue' do
+        expect do
+          service.deduct_inventory!
+        end.to raise_error(Errors::InsufficientInventoryError)
+
+        expect(service.instance_variable_get(:@deducted_items)).to eq [line_item1]
+      end
+    end
+  end
+
+  describe '#undeduct_inventory!' do
+    before do
+      service.instance_variable_set(:@deducted_items, [line_item1, line_item2])
+    end
+
+    context 'on success' do
+      before do
+        undeduct_artwork1_inventory_request.to_return(status: 200, body: {}.to_json)
+        undeduct_artwork2_inventory_request.to_return(status: 200, body: {}.to_json)
+
+        service.undeduct_inventory!
+      end
+
+      it 'undeducts inventory for all line items deducted' do
+        expect(undeduct_artwork1_inventory_request).to have_been_made
+        expect(undeduct_artwork2_inventory_request).to have_been_made
+      end
+
+      it 'removes undeducted items from the queue' do
+        expect(service.instance_variable_get(:@deducted_items)).to be_empty
+      end
+    end
+
+    context 'on failure' do
+      before do
+        undeduct_artwork1_inventory_request.to_return(status: 200, body: {}.to_json)
+        undeduct_artwork2_inventory_request.to_return(status: 400, body: {}.to_json)
+      end
+
+      it 'raises an exception' do
+        expect do
+          service.undeduct_inventory!
+        end.to raise_error(Errors::ProcessingError, 'undeduct_inventory_failure')
+
+        expect(undeduct_artwork1_inventory_request).to have_been_made
+        expect(undeduct_artwork2_inventory_request).to have_been_made
+      end
+
+      it 'keeps line items not yet undeducted in the queue' do
+        expect do
+          service.undeduct_inventory!
+        end.to raise_error(Errors::ProcessingError, 'undeduct_inventory_failure')
+
+        expect(service.instance_variable_get(:@deducted_items)).to eq [line_item2]
+      end
+    end
+  end
+end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -512,7 +512,7 @@ describe OfferService, type: :services do
       allow_any_instance_of(OrderProcessor).to receive_messages(
         valid?: true,
         advance_state: nil,
-        deduct_inventory: true,
+        deduct_inventory!: nil,
         set_totals!: nil,
         failed_payment?: false,
         store_transaction: nil,
@@ -529,7 +529,7 @@ describe OfferService, type: :services do
       allow_any_instance_of(OrderProcessor).to receive_messages(
         valid?: true,
         advance_state: nil,
-        deduct_inventory: true,
+        deduct_inventory!: nil,
         set_totals!: nil,
         failed_payment?: false,
         store_transaction: nil,
@@ -544,7 +544,7 @@ describe OfferService, type: :services do
       allow_any_instance_of(OrderProcessor).to receive_messages(
         valid?: true,
         advance_state: nil,
-        deduct_inventory: true,
+        deduct_inventory!: nil,
         set_totals!: nil,
         failed_payment?: false,
         store_transaction: nil,
@@ -561,7 +561,7 @@ describe OfferService, type: :services do
         allow_any_instance_of(OrderProcessor).to receive_messages(
           valid?: true,
           advance_state: nil,
-          deduct_inventory: true,
+          deduct_inventory!: nil,
           set_totals!: nil,
           failed_payment?: false,
           store_transaction: nil,

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -1,3 +1,7 @@
+def gravity_v1_api_root
+  (Rails.application.config_for(:gravity)['api_v1_root']).to_s
+end
+
 def gravity_v1_artwork(options = {})
   {
     artist: {

--- a/spec/support/offer_query_helper.rb
+++ b/spec/support/offer_query_helper.rb
@@ -20,6 +20,30 @@ module OfferQueryHelper
     }
   ).freeze
 
+  CREATE_INQUIRY_OFFER_ORDER = %(
+    mutation($input: CreateInquiryOfferOrderWithArtworkInput!) {
+      createInquiryOfferOrderWithArtwork(input: $input) {
+        orderOrError {
+          ... on OrderWithMutationSuccess {
+            order {
+              id
+              ... on OfferOrder {
+                impulseConversationId
+              }
+            }
+          }
+          ... on OrderWithMutationFailure {
+            error {
+              code
+              data
+              type
+            }
+          }
+        }
+      }
+    }
+  ).freeze
+
   ADD_OFFER_TO_ORDER = %(
     mutation($input: AddInitialOfferToOrderInput!) {
       addInitialOfferToOrder(input: $input) {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2471

(I did some refactoring and it might be easier to review by commits.)

Given that inquiry artworks don't have accurate inventory information (and we don't want partners to provide them upfront in Inquiry Checkout), we are going to relax the requirements on inventory for inquiry orders. That is,

- Do not check inventory
- Do not deduct/un-deduct inventory during the order lifecycle

I did an audit of how we currently handle inventory:

**Buy Now**
- Deduct inventory when a BN order is [submitted](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/order_service.rb#L54)
- Un-deduct inventory when [BN order submission failed](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/order_service.rb#L55) and inventory has been deducted

**Make Offer**
- Check inventory when [submitting an offer](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/offer_service.rb#L30) and [submitting an offer order](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/offer_service.rb#L41).
- Deduct inventory when [accepting an offer](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/offer_service.rb#L58)
- Un-deduct inventory when [accepting an offer failed](https://github.com/artsy/exchange/blob/b271a36d5bd44d506ecd4bde5d1799fce79a1e99/app/services/offer_service.rb#L75) and inventory has been deducted

Certain actions or events can also trigger inventory un-deduction, such as

- `OrderService.seller_lapse!`
- `OrderService.reject!`
- `OrderService.refund!`
- `StripeWebhookService.process_refund_event`