### PR TITLE
feat: do not un-deduct inventory for inquiry orders when receiving Stripe refund webhook (PURCHASE-2471)

### DIFF
--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -25,6 +25,6 @@ class StripeWebhookService
     order.refund! do
       order.transactions.create!(external_id: @event.id, destination_id: @event.data.object.destination_id, source_id: @event.data.object.source.id, amount_cents: @event.data.object.amount, status: Transaction::SUCCESS, transaction_type: Transaction::REFUND)
     end
-    order.line_items.each { |li| Gravity.undeduct_inventory(li) }
+    order.line_items.each { |li| Gravity.undeduct_inventory(li) } if order.require_inventory?
   end
 end

--- a/lib/line_item_helper.rb
+++ b/lib/line_item_helper.rb
@@ -14,6 +14,9 @@ module LineItemHelper
     else
       artwork[:inventory]
     end
+
+    return false if inventory.blank?
+
     inventory[:count].positive? || inventory[:unlimited]
   end
 

--- a/spec/services/inventory_service_spec.rb
+++ b/spec/services/inventory_service_spec.rb
@@ -43,7 +43,7 @@ describe InventoryService do
   end
 
   describe '#check_inventory' do
-    xcontext 'with null inventory' do
+    context 'with null inventory' do
       let(:artwork1_inventory) { nil }
 
       it 'raises an exception' do


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2471

Following https://github.com/artsy/exchange/pull/687, I missed one place where we un-deduct inventory when receiving a refund webhook from Stripe. This skips it for inquiry orders.

I also fixed the line item helper for determining if a line item has inventory when it's `nil` (currently it raises an error).