### PR TITLE
feat: allow sales_observers to execute order queries

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -95,13 +95,17 @@ class Types::QueryType < Types::BaseObject
     context[:current_user][:roles].include?('trusted')
   end
 
+  def sales_observer?
+    context[:current_user][:roles].include?('sales_observer')
+  end
+
   def trusted_admin?
     user_roles = context[:current_user][:roles].split(',')
     ArtsyAuthToken.trusted_admin?(user_roles)
   end
 
   def validate_order_request!(order)
-    return if trusted? || trusted_admin? ||
+    return if trusted? || trusted_admin? || sales_observer? ||
               (order.buyer_type == Order::USER && order.buyer_id == context[:current_user][:id]) ||
               (order.seller_type != Order::USER && context[:current_user][:partner_ids].include?(order.seller_id))
 
@@ -114,7 +118,7 @@ class Types::QueryType < Types::BaseObject
   end
 
   def validate_orders_request!(params)
-    return if trusted? || trusted_admin?
+    return if trusted? || trusted_admin? || sales_observer?
 
     if params[:buyer_id].present?
       raise ActiveRecord::RecordNotFound unless params[:buyer_id] == context[:current_user][:id]

--- a/spec/controllers/api/requests/order_query_request_spec.rb
+++ b/spec/controllers/api/requests/order_query_request_spec.rb
@@ -512,6 +512,25 @@ describe Api::GraphqlController, type: :request do
           expect(result.data.order.items_total_cents).to eq 0
         end
       end
+
+      context "sales_observer accessing another account's order" do
+        let(:jwt_roles) { 'sales_observer' }
+
+        it 'allows action' do
+          expect do
+            client.execute(query, id: user2_order1.id)
+          end.to_not raise_error
+        end
+
+        it 'returns expected payload' do
+          result = client.execute(query, id: user2_order1.id)
+          expect(result.data.order.buyer.id).to eq user2_order1.buyer_id
+          expect(result.data.order.seller.id).to eq user2_order1.seller_id
+          expect(result.data.order.currency_code).to eq 'USD'
+          expect(result.data.order.state).to eq 'PENDING'
+          expect(result.data.order.items_total_cents).to eq 0
+        end
+      end
     end
 
     context 'partner accessing order' do

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -268,6 +268,23 @@ describe Api::GraphqlController, type: :request do
       end
     end
 
+    context "sales_observer accessing another account's order" do
+      let(:jwt_roles) { 'sales_observer' }
+
+      it 'allows action' do
+        expect do
+          client.execute(query, buyerId: second_user)
+        end.to_not raise_error
+      end
+
+      it 'returns expected payload' do
+        result = client.execute(query, buyerId: second_user)
+        expect(result.data.orders.edges.count).to eq 1
+        ids = ids_from_result_data(result)
+        expect(ids).to match_array([user2_order1.id])
+      end
+    end
+
     describe 'total_count' do
       let(:query_with_total_count) do
         <<-GRAPHQL


### PR DESCRIPTION
Following up on https://github.com/artsy/volt/pull/4982. I originally missed that we were gatekeeping access to orders both in the Volt UI and in Exchange. This PR allows users with the `sales_observer` role to execute `order` and `orders` queries, but does _not_ allow them access to Exchange admin UI or to any mutations.

There are tests in place for the query permissions, and I confirmed the "no access to Exchange UI" via the following steps:
1. Started local Exchange server at localhost:3000
2. Opened Gravity staging console
3. `user = User.find_by_email 'matt.dole@artsymail.com'`
4. `user.update!(roles: ["admin", "customer_support", "billing_admin", "team", "sales_observer"])`
5. Opened incognito window, logged in and confirmed I was unable to access
6. `user.update!(roles: ["admin", "customer_support", "billing_admin", "team", "sales_admin", "partner_support"])`
7. Closed & reopened window for a fresh session, logged in, confirmed I was able to access (due to now having `sales_admin` and `partner_support` roles)

Original Jira ticket: https://artsyproduct.atlassian.net/browse/PX-3691