### PR TITLE
WIP: expand orders to accept a new states argument

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1275,6 +1275,7 @@ type Query {
     sellerType: String
     sort: OrderConnectionSortEnum
     state: OrderStateEnum
+    states: [OrderStateEnum!]
   ): OrderConnectionWithTotalCount
 }
 

--- a/app/controllers/errors/error_types.rb
+++ b/app/controllers/errors/error_types.rb
@@ -20,6 +20,7 @@ module Errors
       invalid_order
       invalid_seller_address
       invalid_state
+      invalid_states_params
       missing_artwork_location
       missing_commission_rate
       missing_country

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -15,6 +15,7 @@ class Types::QueryType < Types::BaseObject
     argument :seller_type, String, required: false
     argument :buyer_id, String, required: false
     argument :buyer_type, String, required: false
+    # state will soon be deprecated use states instead
     argument :state, Types::OrderStateEnum, required: false
     argument :states, [Types::OrderStateEnum], required: false
     argument :sort, Types::OrderConnectionSortEnum, required: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -16,6 +16,7 @@ class Types::QueryType < Types::BaseObject
     argument :buyer_id, String, required: false
     argument :buyer_type, String, required: false
     argument :state, Types::OrderStateEnum, required: false
+    argument :states, [Types::OrderStateEnum], required: false
     argument :sort, Types::OrderConnectionSortEnum, required: false
     argument :mode, Types::OrderModeEnum, required: false
   end
@@ -49,6 +50,13 @@ class Types::QueryType < Types::BaseObject
 
   def orders(params = {})
     validate_orders_request!(params)
+    states = params.delete(:states)
+    state = params[:state]
+
+    invalid_states_param = Errors::ValidationError.new(:invalid_states_params, message: 'params state and states cannot be passed together.')
+    raise invalid_states_param if state.present? && states.present?
+
+    params = params.merge(state: states) unless states.nil?
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }
     Order.where(params).order(order_clause)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -52,7 +52,7 @@ class Types::QueryType < Types::BaseObject
   def orders(params = {})
     validate_orders_request!(params)
     invalid_states_param = Errors::ValidationError.new(:invalid_states_params, message: 'params state and states cannot be passed together.')
-    raise invalid_states_param if params.has_key?(:state) && params.has_key?(:states)
+    raise invalid_states_param if params.key?(:state) && params.key?(:states)
 
     states = params.delete(:states)
     params = params.merge(state: states) unless states.nil?

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -50,12 +50,10 @@ class Types::QueryType < Types::BaseObject
 
   def orders(params = {})
     validate_orders_request!(params)
-    states = params.delete(:states)
-    state = params[:state]
-
     invalid_states_param = Errors::ValidationError.new(:invalid_states_params, message: 'params state and states cannot be passed together.')
-    raise invalid_states_param if state.present? && states.present?
+    raise invalid_states_param if params.has_key?(:state) && params.has_key?(:states)
 
+    states = params.delete(:states)
     params = params.merge(state: states) unless states.nil?
     sort = params.delete(:sort)
     order_clause = sort_to_order[sort] || { state_updated_at: :desc }

--- a/spec/controllers/api/requests/orders_query_request_spec.rb
+++ b/spec/controllers/api/requests/orders_query_request_spec.rb
@@ -356,7 +356,10 @@ describe Api::GraphqlController, type: :request do
 
       it 'returns an error when state and states argument is passed' do
         expect do
+          # rubocop:disable Style/WordArray
           client.execute(both_states_query, state: 'SUBMITTED', states: ['SUBMITTED', 'APPROVED'], sellerId: seller_id)
+
+          # rubocop:enable Style/WordArray
         end.to raise_error do |error|
           expect(error).to be_a(Graphlient::Errors::ServerError)
           expect(error.status_code).to eq 400


### PR DESCRIPTION
Addresses: [PURCHASE-2500](https://artsyproduct.atlassian.net/browse/PURCHASE-2500)

This is a work in progress for expanding the orders query to support filtering by multiple states.

**Filter by states argument:**
<img width="1122" alt="Screen Shot 2021-03-25 at 6 20 50 PM" src="https://user-images.githubusercontent.com/5201004/112551153-e74b1380-8d96-11eb-91e6-65c03a50b25e.png">

**Error when both `state` and `states` arguments are passed:**
<img width="1130" alt="Screen Shot 2021-03-25 at 6 20 22 PM" src="https://user-images.githubusercontent.com/5201004/112551211-ff229780-8d96-11eb-90a9-1dc56db0a60d.png">
