### PR TITLE
feat: return 0 for stripe fees on staging

### DIFF
--- a/lib/transaction_fee_calculator.rb
+++ b/lib/transaction_fee_calculator.rb
@@ -1,5 +1,7 @@
 module TransactionFeeCalculator
   def self.calculate(total_charge_amount, currency)
+    return 0 if ENV['NEW_TRANSACTION_FEE_ENABLED'] == 'true'
+
     0 unless total_charge_amount&.positive?
 
     # This is based on Stripe fee, we decided to charge unified 3.9% + 30 cents across all countries

--- a/spec/lib/transaction_fee_calculator.spec.rb
+++ b/spec/lib/transaction_fee_calculator.spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe TransactionFeeCalculator do
+  let(:currency) { 'USD' }
+  let(:total_charge_amount) { 15000 }
+
+  context 'with transaction fee flag set as true' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('NEW_TRANSACTION_FEE_ENABLED').and_return(true)
+    end
+    it 'calculates transaction fee' do
+      transaction_fee = TransactionFeeCalculator.calculate(total_charge_amount, currency)
+      expect(transaction_fee).to eq 0
+    end
+  end
+  context 'with transaction fee flag set as false' do
+    it 'calculates transaction fee' do
+      transaction_fee = TransactionFeeCalculator.calculate(total_charge_amount, currency)
+      expect(transaction_fee).to eq 615
+    end
+  end
+end


### PR DESCRIPTION
Update Exchange to not calculate Stripe fees on staging.

This PR introduces a new environment variable:  `NEW_TRANSACTION_FEE_ENABLED` that enables us to test not returning Stripe transaction fees in Staging only.

cc @artsy/purchase-devs 

https://artsyproduct.atlassian.net/browse/PURCHASE-2567